### PR TITLE
[ENH] improve dsi_studio qc interfaces and remove hard link dependency

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -29,6 +29,11 @@
       "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
       "name": "Satterthwaite, Theodore D.",
       "orcid": "0000-0001-7072-9399"
+    },
+    {
+      "name": "Krause, Michael",
+      "affiliation": "Max Planck Institute for Human Development, Berlin, Germany",
+      "orcid": "0000-0002-3878-6542"
     }
   ],
   "keywords": [

--- a/qsiprep/workflows/dwi/qc.py
+++ b/qsiprep/workflows/dwi/qc.py
@@ -69,7 +69,7 @@ def init_modelfree_qc_wf(dwi_files=None, name='dwi_qc_wf'):
             ('bvec_file', 'input_bvecs_file')]),
         (raw_src, raw_src_qc, [('output_src', 'src_file')]),
         (raw_src, raw_gqi, [('output_src', 'input_src_file')]),
-        (raw_gqi, raw_fib_qc, [('output_fib', 'fib_file')]),
+        (raw_gqi, raw_fib_qc, [('output_fib', 'src_file')]),
         (raw_fib_qc, merged_qc, [('qc_txt', 'fib_qc')]),
         (raw_src_qc, merged_qc, [('qc_txt', 'src_qc')]),
         (merged_qc, outputnode, [('qc_file', 'qc_summary')]),


### PR DESCRIPTION
## Changes proposed in this pull request

Two days ago we tripped over the fact that the use of [`os.link()` in dsi_studio.py](https://github.com/PennBBL/qsiprep/blob/master/qsiprep/interfaces/dsi_studio.py#L135) fails for file systems without or with limited hard link support ([BeeGFS](https://www.beegfs.io/wiki/FAQ#hardlinks) in our case). A quick fix would have been to just wrap it into a try-except block and use `shutil.copyfile()` on failure. However, I was curious what was going on in the interfaces and I found that the reason a tmp directory was created (at least for [DSIStudioSrcQC](https://github.com/PennBBL/qsiprep/blob/master/qsiprep/interfaces/dsi_studio.py#L106) was probably caused by some decision in the [DSI-Studio src](https://github.com/frankyeh/DSI-Studio/blob/ea38389afb12877211ad5bf9f2eb1630d0b33cc1/main.cpp#L74) to not support symbolic links when searching for input source files in a directory.

It turns out that we probably don't need to create the tmp directory if we only run the qc action on single files with `dsi_studio --action=qc --src...`. The symbolic link check does not fire then. This allowed for some minor code deduplication and simplification. Specifically, I merged `DSIStudioSrcQC` and `DSIStudioFibQC` into a single `DSIStudioQC` interface as they both just run the same dsi_studio command on different (single) input files.

Note that this is my first time playing around with traited specs and nipype interfaces, so I probably did something wrong :smile:  Still, I think this is a non-invasive improvement and at least a bug fix for file systems without hard link support.