### PR TITLE
[FIX] use a default working dir

### DIFF
--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -747,7 +747,7 @@ def build_qsiprep_workflow(opts, retval):
 
     bids_dir = opts.bids_dir.resolve()
     output_dir = opts.output_dir.resolve()
-    work_dir = opts.work_dir.resolve()
+    work_dir = Path(opts.work_dir or 'work')  # Set work/ as default
 
     retval['return_code'] = 1
     retval['workflow'] = None


### PR DESCRIPTION
Use a default working directory, to prevent an extremely user-unfriendly error message #222