### PR TITLE
[FIX] specify DIPY_HOME in container

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,12 @@
 version: 2
+name: qsiprep
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python-spams<=2.6.1
+  - python=3.7
+  - pip>=20.1  # pip is needed as dependency
 
 python:
   install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -320,6 +320,7 @@ RUN python -c "from matplotlib import font_manager" && \
     sed -i 's/\(backend *: \).*$/\1Agg/g' $( python -c "import matplotlib; print(matplotlib.matplotlib_fname())" )
 
 RUN mkdir -p ${HOME}/.dipy
+
 RUN python -c "import amico; amico.core.setup()"
 
 RUN find $HOME -type d -exec chmod go=u {} + && \
@@ -335,7 +336,8 @@ ENV AFNI_INSTALLDIR=/usr/lib/afni \
     AFNI_IMSAVE_WARNINGS=NO \
     FSLOUTPUTTYPE=NIFTI_GZ \
     MRTRIX_NTHREADS=1 \
-    IS_DOCKER_8395080871=1
+    IS_DOCKER_8395080871=1 \
+    DIPY_HOME=/home/qsiprep/.dipy
 
 RUN ldconfig
 WORKDIR /tmp/


### PR DESCRIPTION
AMICO couldn't find DIPY_HOME when run in a singularity container