### PR TITLE
[ENH] update mrtrix to 3.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN mkdir /opt/dsi-studio \
 
 
 # Install mrtrix3 from source
-ARG MRTRIX_SHA=5d6b3a6ffc6ee651151779539c8fd1e2e03fad81
+ARG MRTRIX_SHA=3498ff469b843d5b023c3675f1d955ba4105c5d1
 ENV PATH="/opt/mrtrix3-latest/bin:$PATH"
 RUN cd /opt \
     && curl -sSLO https://github.com/MRtrix3/mrtrix3/archive/${MRTRIX_SHA}.zip \

--- a/qsiprep/interfaces/mrtrix.py
+++ b/qsiprep/interfaces/mrtrix.py
@@ -907,16 +907,7 @@ class DWIBiasCorrectInputSpec(MRTrix3BaseInputSpec, SeriesPreprocReportInputSpec
     mask = File(
         argstr='-mask %s',
         desc='input mask image for bias field estimation')
-    use_ants = traits.Bool(
-        argstr='-ants',
-        mandatory=True,
-        desc='use ANTS N4 to estimate the inhomogeneity field',
-        xor=['use_fsl'])
-    use_fsl = traits.Bool(
-        argstr='-fsl',
-        mandatory=True,
-        desc='use FSL FAST to estimate the inhomogeneity field',
-        xor=['use_ants'])
+    method = traits.Enum('ants', 'fsl', argstr='%s', position=1, usedefault=True)
     bias_image = File(
         argstr='-bias %s',
         name_source='in_file',
@@ -960,9 +951,9 @@ class DWIBiasCorrect(SeriesPreprocReport, MRTrix3Base):
     >>> import nipype.interfaces.mrtrix3 as mrt
     >>> bias_correct = mrt.DWIBiasCorrect()
     >>> bias_correct.inputs.in_file = 'dwi.mif'
-    >>> bias_correct.inputs.use_ants = True
+    >>> bias_correct.inputs.method = 'ants'
     >>> bias_correct.cmdline
-    'dwibiascorrect -ants dwi.mif dwi_biascorr.mif'
+    'dwibiascorrect ants dwi.mif dwi_biascorr.mif'
     >>> bias_correct.run()                             # doctest: +SKIP
     """
     _cmd = 'dwibiascorrect'

--- a/qsiprep/interfaces/mrtrix.py
+++ b/qsiprep/interfaces/mrtrix.py
@@ -781,7 +781,8 @@ class BuildConnectome(MRTrix3Base):
 
         # get the connectivity matrix
         prefix = atlas_name + "_" + self.inputs.measure
-        connectivity_data[prefix + "_connectivity"] = np.loadtxt(self.inputs.out_file)
+        connectivity_data[prefix + "_connectivity"] = np.loadtxt(self.inputs.out_file,
+                                                                delimiter=',')
         merged_matfile = op.join(runtime.cwd, prefix + "_connectivity.mat")
         savemat(merged_matfile, connectivity_data, long_field_names=True)
         return runtime

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -349,7 +349,7 @@ def init_dwi_denoising_wf(dwi_denoise_window,
         step_num += 1
 
     if do_biascorr:
-        biascorr = pe.Node(DWIBiasCorrect(use_ants=True), name='biascorr')
+        biascorr = pe.Node(DWIBiasCorrect(method='ants'), name='biascorr')
         ds_report_biascorr = pe.Node(
             DerivativesDataSink(suffix=name + '_biascorr',
                                 source_file=source_file),


### PR DESCRIPTION
As pointed out in #269 the default FAST segmentation can be terrible. This PR will upgrade mrtrix so we can use HSV format