### PR TITLE
Crucial Fixes for Patch2Self

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,8 +255,8 @@ jobs:
       - run:
           name: Install graphviz
           command: |
-              sudo apt-get update
-              sudo apt-get install -y graphviz libblas-dev \
+              sudo apt update
+              sudo apt install -y graphviz libblas-dev \
                liblapack-dev gfortran
       - run:
           name: Install qsiprep.

--- a/qsiprep/interfaces/dipy.py
+++ b/qsiprep/interfaces/dipy.py
@@ -97,7 +97,7 @@ class Patch2SelfInputSpec(SeriesPreprocReportInputSpec):
                                  desc='patch radius in voxels.')
     bval_file = File(exists=True, mandatory=True,
                      desc="bval file containing b-values")
-    model = traits.Str('ridge', usedefault=True,
+    model = traits.Str('ols', usedefault=True,
                        desc='Regression model for Patch2Self')
     alpha = traits.Float(1., usedefault=True,
                          desc='Regularization parameter for Ridge and Lasso')

--- a/qsiprep/interfaces/patch2self.py
+++ b/qsiprep/interfaces/patch2self.py
@@ -163,10 +163,10 @@ def _extract_3d_patches(arr, patch_radius):
     return np.array(all_patches).T
 
 
-def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
+def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ols',
                b0_threshold=50, out_dtype=None, alpha=1.0, verbose=False,
-               b0_denoising=True, clip_negative_vals=True,
-               shift_intensity=False):
+               b0_denoising=True, clip_negative_vals=False,
+               shift_intensity=True):
     """ Patch2Self Denoiser
 
     Parameters
@@ -191,7 +191,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
             `sklearn.linear_model.LinearRegression`,
             `sklearn.linear_model.Lasso` or `sklearn.linear_model.Ridge`
             and other objects that inherit from `sklearn.base.RegressorMixin`.
-            Default: 'ridge'.
+            Default: 'ols'.
 
     b0_threshold : int, optional
         Threshold for considering volumes as b0.

--- a/qsiprep/viz/config.json
+++ b/qsiprep/viz/config.json
@@ -77,8 +77,8 @@
           {
               "name": "epi/denoising",
               "file_pattern": "dwi/.*_denoising\\.",
-              "title": "MP-PCA denoising",
-              "description": "Effect of MP-PCA denoising on a low and high-b image.",
+              "title": "DWI denoising",
+              "description": "Effect of denoising on a low and high-b image.",
               "imgtype": "svg+xml"
           },
           {


### PR DESCRIPTION
Fixes parameters upstream with `DIPY's Patch2Self`.

This is the reason why @SendyCaffarra was getting a bug. This issue was fixed in `Patch2Self` for DIPY in #2334 

[[PR Link]( https://github.com/dipy/dipy/issues/2334)]

Also setting default `'model='ols'`

I am also taking this opportunity to fix the naming [MP-PCA --> Generic "DWI Denoising"] in the reports. 