### PR TITLE
DOC: How to avoid some pitfalls of using filters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN mkdir /opt/cmake \
     && cd ANTS-build \
     && make install \
     && rm -rf /tmp/ants \
-    && rm -rf /opt/cmake /usr/local/bin/cmake cmake-3.11.4-Linux-x86_64.sh
+    && rm -rf /opt/cmake /usr/local/bin/cmake
 
 ENV C3DPATH="/opt/convert3d-nightly" \
     PATH="/opt/convert3d-nightly/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN mkdir /opt/cmake \
     && cd ANTS-build \
     && make install \
     && rm -rf /tmp/ants \
-    && rm -rf /opt/cmake /usr/local/bin/cmake
+    && rm -rf /opt/cmake /usr/local/bin/cmake cmake-3.11.4-Linux-x86_64.sh
 
 ENV C3DPATH="/opt/convert3d-nightly" \
     PATH="/opt/convert3d-nightly/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN mkdir /opt/cmake \
     && cd ANTS-build \
     && make install \
     && rm -rf /tmp/ants \
-    && rm -rf /opt/cmake /usr/local/bin/cmake
+    && rm -rf /opt/cmake /usr/local/bin/cmake /cmake-3.11.4-Linux-x86_64.sh
 
 ENV C3DPATH="/opt/convert3d-nightly" \
     PATH="/opt/convert3d-nightly/bin:$PATH"

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -51,7 +51,7 @@ perform SDC. Further complicating this is the FSL workflow, which combines disto
 with eddy/motion correction and will merge scans with different PE directions.
 
 If you have some scans you want to combine and others you want to preprocess separately,
-you can call qsiprep more than once with BIDS filters to process the different scans.
+you can call qsiprep more than once with BIDS filters to process the different scans. Note that subject-level preprocessing (eg, of anatomical images) will be overwritten by subsequent calls to qsiprep for the same subject. This can be avoided by using an independent output directory for each call.
 
 .. _bids_filters:
 
@@ -75,11 +75,9 @@ of the file you will send to ``--bids-filter-file``. The queries in QSIPrep are:
       "dwi": {"datatype": "dwi", "suffix": "dwi"}
   }
 
-Each query has several "entities", which can be modified by filters. The list of
-supported entities is `here
-<https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json>`__.
-To filter data, modify the queries by changing one or more of the supported
-entities in the BIDS filter file. The general format of the filter file is::
+Each query has several "entities", which can be modified by filters. Here is a link to the `full list of supported entities in PyBids <https://github.com/bids-standard/pybids/blob/master/bids/layout/config/bids.json>`_, but note that not all of these entities are valid BIDS for MRI data. Refer to the `BIDS specification for MRI data <https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html>`_ to see which entities are valid BIDS for a particular data type. If filters are not working as expected, check that the file names are valid using a BIDS validator.
+
+To filter data, modify the queries by changing one or more valid entities in the BIDS filter file. The general format of the filter file is::
 
   {
     "query": { "entity": "value" }


### PR DESCRIPTION
## Changes proposed in this pull request

Updating the preprocessing documentation to note two things:

1. If you are using BIDS filters to process a subset of the data, be careful that your subsequent calls don't overwrite subject-level output. For example, if you have two time points and you want to process them separately, you might call with a filter to get session MR1 and again with a filter to get session MR2. But the T1w processing for MR2 will overwrite that for MR1, unless you send the output to different directories.

2. Clarify that not all entities known to PyBids can be used in filters. The link in the doc to the master list includes entities for all BIDS data, MRI or not. The filters will not work if you use an invalid entity (we found this in the FTDC by inadvertently using an entity "proc-", for MEG data, instead of "rec-", for MRI). 