### PR TITLE
[ENH] add n_procs to recon nodes

### DIFF
--- a/qsiprep/interfaces/amico.py
+++ b/qsiprep/interfaces/amico.py
@@ -163,7 +163,7 @@ class NODDI(AmicoReconInterface):
         LOGGER.info("Fitting NODDI Model.")
         aeval.set_model("NODDI")
         aeval.set_config('parallel_jobs', self.inputs.num_threads)
-        aeval.set_config('parallel_backend', 'multiprocessing')
+        aeval.set_config('parallel_backend', 'loky')
         # set the parameters
         aeval.model.dPar = self.inputs.dPar
         aeval.model.dIso = self.inputs.dIso

--- a/qsiprep/interfaces/amico.py
+++ b/qsiprep/interfaces/amico.py
@@ -163,6 +163,7 @@ class NODDI(AmicoReconInterface):
         LOGGER.info("Fitting NODDI Model.")
         aeval.set_model("NODDI")
         aeval.set_config('parallel_jobs', self.inputs.num_threads)
+        aeval.set_config('parallel_backend', 'multiprocessing')
         # set the parameters
         aeval.model.dPar = self.inputs.dPar
         aeval.model.dIso = self.inputs.dIso

--- a/qsiprep/interfaces/amico.py
+++ b/qsiprep/interfaces/amico.py
@@ -13,7 +13,6 @@ import os.path as op
 from pkg_resources import resource_filename as pkgr
 import nibabel as nb
 import numpy as np
-import amico
 from nipype import logging
 from nipype.utils.filemanip import fname_presuffix
 from nipype.interfaces.base import (
@@ -115,6 +114,7 @@ class NODDIInputSpec(AmicoInputSpec):
     dPar = traits.Float(mandatory=True)
     dIso =  traits.Float(mandatory=True)
     isExvivo = traits.Bool(False, usedefault=True)
+    num_threads = traits.Int(1, usedefault=True, nohash=True)
 
 
 class NODDIOutputSpec(AmicoOutputSpec):
@@ -149,6 +149,11 @@ class NODDI(AmicoReconInterface):
 
         # Prevent a ton of deprecation warnings
         os.environ['KMP_WARNINGS'] = '0'
+        os.environ["OMP_NUM_THREADS"] = str(self.inputs.num_threads)
+        os.environ["MKL_NUM_THREADS"] = str(self.inputs.num_threads)
+        import amico
+        if hasattr(amico, "set_verbose"):
+            amico.set_verbose(2)
         # Set up the AMICO evaluation
         aeval = amico.Evaluation("study", "subject")
         scheme_file = amico.util.fsl2scheme(bval_file, bvec_file,
@@ -157,6 +162,7 @@ class NODDI(AmicoReconInterface):
                         mask_filename=mask_file, b0_thr=self.inputs.b0_threshold)
         LOGGER.info("Fitting NODDI Model.")
         aeval.set_model("NODDI")
+        aeval.set_config('parallel_jobs', self.inputs.num_threads)
         # set the parameters
         aeval.model.dPar = self.inputs.dPar
         aeval.model.dIso = self.inputs.dIso

--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger('nipype.interface')
 
 
 class DSIStudioCommandLineInputSpec(CommandLineInputSpec):
-    nthreads = traits.Int(1, usedefault=True, argstr="--threads=%d")
+    num_threads = traits.Int(1, usedefault=True, argstr="--thread_count=%d")
 
 
 class DSIStudioCreateSrcInputSpec(DSIStudioCommandLineInputSpec):

--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -18,7 +18,11 @@ LOGGER = logging.getLogger('nipype.interface')
 
 
 class DSIStudioCommandLineInputSpec(CommandLineInputSpec):
-    num_threads = traits.Int(1, usedefault=True, argstr="--thread_count=%d")
+    num_threads = traits.Int(
+        1, 
+        usedefault=True, 
+        argstr="--thread_count=%d",
+        nohash=True)
 
 
 class DSIStudioCreateSrcInputSpec(DSIStudioCommandLineInputSpec):
@@ -389,7 +393,7 @@ class DSIStudioAtlasGraph(SimpleInterface):
         ifargs['thread_count'] = 1
 
         # Get number of parallel jobs
-        num_threads = ifargs.pop('nthreads')
+        num_threads = ifargs.pop('num_threads')
         atlas_configs = ifargs.pop('atlas_configs')
         workflow = pe.Workflow(name='dsistudio_atlasgraph')
         nodes = []

--- a/qsiprep/workflows/recon/amico.py
+++ b/qsiprep/workflows/recon/amico.py
@@ -69,14 +69,6 @@ diffusivity.""" % (params['dPar'], params['dIso'])
 
     convert_to_fibgz = pe.Node(NODDItoFIBGZ(), name='convert_to_fibgz')
 
-    plot_peaks = pe.Node(CLIReconPeaksReport(), name='plot_peaks')
-    ds_report_peaks = pe.Node(
-        ReconDerivativesDataSink(extension='.png',
-                                 desc="NODDI",
-                                 suffix='peaks'),
-        name='ds_report_peaks',
-        run_without_submitting=True)
-
     workflow.connect([
         (inputnode, noddi_fit, [('dwi_file', 'dwi_file'),
                                 ('bval_file', 'bval_file'),
@@ -98,6 +90,17 @@ diffusivity.""" % (params['dPar'], params['dIso'])
         (inputnode, convert_to_fibgz, [('dwi_mask', 'mask_file')]),
         (convert_to_fibgz, outputnode, [('fibgz_file', 'fibgz')])])
     if plot_reports:
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(), 
+            name='plot_peaks',
+            n_procs=omp_nthreads)
+        ds_report_peaks = pe.Node(
+            ReconDerivativesDataSink(extension='.png',
+                                    desc="NODDI",
+                                    suffix='peaks'),
+            name='ds_report_peaks',
+            run_without_submitting=True)
+
         workflow.connect([
             (inputnode, plot_peaks, [('dwi_mask', 'mask_file')]),
             (convert_to_fibgz, plot_peaks, [('fibgz_file', 'fib_file')]),

--- a/qsiprep/workflows/recon/amico.py
+++ b/qsiprep/workflows/recon/amico.py
@@ -56,7 +56,10 @@ def init_amico_noddi_fit_wf(omp_nthreads, available_anatomical_data,
     desc = """NODDI Reconstruction
 
 : """
-    noddi_fit = pe.Node(NODDI(**params), name="recon_noddi")
+    noddi_fit = pe.Node(
+        NODDI(**params), 
+        name="recon_noddi",
+        n_procs=omp_nthreads)
     desc += """\
 The NODDI model (@noddi) was fit using the AMICO implementation (@amico).
 A value of %.1E was used for parallel diffusivity and %.1E for isotropic

--- a/qsiprep/workflows/recon/dipy.py
+++ b/qsiprep/workflows/recon/dipy.py
@@ -111,14 +111,6 @@ def init_dipy_brainsuite_shore_recon_wf(omp_nthreads, available_anatomical_data,
     recon_shore = pe.Node(BrainSuiteShoreReconstruction(**params), name="recon_shore")
     doing_extrapolation = params.get("extrapolate_scheme") in ("HCP", "ABCD")
 
-    plot_peaks = pe.Node(CLIReconPeaksReport(), name='plot_peaks')
-    ds_report_peaks = pe.Node(
-        ReconDerivativesDataSink(extension='.png',
-                                 desc="3dSHOREODF",
-                                 suffix='peaks'),
-        name='ds_report_peaks',
-        run_without_submitting=True)
-
     workflow.connect([
         (inputnode, recon_shore, [('dwi_file', 'dwi_file'),
                                   ('bval_file', 'bval_file'),
@@ -138,6 +130,17 @@ def init_dipy_brainsuite_shore_recon_wf(omp_nthreads, available_anatomical_data,
                                    ('extrapolated_b', 'b_file')])
         ])
     if plot_reports:
+
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(),
+            name='plot_peaks',
+            n_procs=omp_nthreads)
+        ds_report_peaks = pe.Node(
+            ReconDerivativesDataSink(extension='.png',
+                                    desc="3dSHOREODF",
+                                    suffix='peaks'),
+            name='ds_report_peaks',
+            run_without_submitting=True)
         workflow.connect([
             (inputnode, plot_peaks, [('dwi_ref', 'background_image'),
                                      ('odf_rois', 'odf_rois')]),
@@ -335,14 +338,7 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
 
 : """
     plot_reports = params.pop("plot_reports", True)
-    plot_peaks = pe.Node(CLIReconPeaksReport(), name='plot_peaks')
     recon_map = pe.Node(MAPMRIReconstruction(**params), name="recon_map")
-    ds_report_peaks = pe.Node(
-        ReconDerivativesDataSink(extension='.png',
-                                 desc="MAPLMRIODF",
-                                 suffix='peaks'),
-        name='ds_report_peaks',
-        run_without_submitting=True)
 
     workflow.connect([
         (inputnode, recon_map, [('dwi_file', 'dwi_file'),
@@ -362,6 +358,16 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
                                  ('fibgz', 'fibgz'),
                                  ('fod_sh_mif', 'fod_sh_mif')])])
     if plot_reports:
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(), 
+            name='plot_peaks',
+            n_procs=omp_nthreads)
+        ds_report_peaks = pe.Node(
+            ReconDerivativesDataSink(extension='.png',
+                                    desc="MAPLMRIODF",
+                                    suffix='peaks'),
+            name='ds_report_peaks',
+            run_without_submitting=True)
         workflow.connect([
             (inputnode, plot_peaks, [('dwi_mask', 'mask_file'),
                                      ('dwi_ref', 'background_image'),
@@ -464,8 +470,11 @@ def init_dipy_dki_recon_wf(omp_nthreads, available_anatomical_data, name="dipy_d
                                  ('fibgz', 'fibgz')])
     ])
 
-    if plot_reports:
-        plot_peaks = pe.Node(CLIReconPeaksReport(peaks_only=True), name='plot_peaks')
+    if plot_reports and False:
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(peaks_only=True), 
+            name='plot_peaks',
+            n_procs=omp_nthreads)
         ds_report_peaks = pe.Node(
             ReconDerivativesDataSink(extension='.png',
                                      desc="DKI",

--- a/qsiprep/workflows/recon/dsi_studio.py
+++ b/qsiprep/workflows/recon/dsi_studio.py
@@ -70,16 +70,6 @@ Diffusion orientation distribution functions (ODFs) were reconstructed using
 generalized q-sampling imaging (GQI, @yeh2010gqi) with a ratio of mean diffusion
 distance of %02f.""" % romdd
 
-    # Plot targeted regions
-    if available_anatomical_data['has_qsiprep_t1w_transforms'] and plot_reports:
-        ds_report_odfs = pe.Node(
-            ReconDerivativesDataSink(extension='.png',
-                                     desc="GQIODF",
-                                     suffix='odfs'),
-            name='ds_report_odfs',
-            run_without_submitting=True)
-        workflow.connect(plot_peaks, 'odf_report', ds_report_odfs, 'in_file')
-
     workflow.connect([
         (inputnode, create_src, [('dwi_file', 'input_nifti_file'),
                                  ('bval_file', 'input_bvals_file'),
@@ -103,6 +93,16 @@ distance of %02f.""" % romdd
                                      ('odf_rois', 'odf_rois'),
                                      ('dwi_mask', 'mask_file')]),
             (plot_peaks, ds_report_peaks, [('peak_report', 'in_file')])])
+        # Plot targeted regions
+        if available_anatomical_data['has_qsiprep_t1w_transforms']:
+            ds_report_odfs = pe.Node(
+                ReconDerivativesDataSink(extension='.png',
+                                        desc="GQIODF",
+                                        suffix='odfs'),
+                name='ds_report_odfs',
+                run_without_submitting=True)
+            workflow.connect(plot_peaks, 'odf_report', ds_report_odfs, 'in_file')
+
 
     if output_suffix:
         # Save the output in the outputs directory

--- a/qsiprep/workflows/recon/dsi_studio.py
+++ b/qsiprep/workflows/recon/dsi_studio.py
@@ -79,7 +79,10 @@ distance of %02f.""" % romdd
         (gqi_recon, outputnode, [('output_fib', 'fibgz')])])
     if plot_reports:
         # Make a visual report of the model
-        plot_peaks = pe.Node(CLIReconPeaksReport(subtract_iso=True), name='plot_peaks')
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(subtract_iso=True), 
+            name='plot_peaks',
+            n_procs=omp_nthreads)
         ds_report_peaks = pe.Node(
             ReconDerivativesDataSink(extension='.png',
                                     desc="GQIODF",

--- a/qsiprep/workflows/recon/mrtrix.py
+++ b/qsiprep/workflows/recon/mrtrix.py
@@ -529,7 +529,6 @@ def init_mrtrix_connectivity_wf(omp_nthreads, available_anatomical_data, name="m
     plot_reports = params.pop("plot_reports", True)
     workflow = pe.Workflow(name=name)
     conmat_params = params.get("tck2connectome", {})
-    conmat_params['nthreads'] = omp_nthreads
     calc_connectivity = pe.Node(
         MRTrixAtlasGraph(tracking_params=conmat_params),
         name='calc_connectivity',

--- a/qsiprep/workflows/recon/mrtrix.py
+++ b/qsiprep/workflows/recon/mrtrix.py
@@ -209,7 +209,10 @@ A single-shell-optimized multi-tissue CSD was performed using MRtrix3Tissue
 
     if plot_reports:
         # Make a visual report of the model
-        plot_peaks = pe.Node(CLIReconPeaksReport(), name='plot_peaks')
+        plot_peaks = pe.Node(
+            CLIReconPeaksReport(), 
+            name='plot_peaks',
+            n_procs=omp_nthreads)
         ds_report_peaks = pe.Node(
             ReconDerivativesDataSink(extension='.png',
                                     desc="wmFOD",
@@ -542,7 +545,10 @@ def init_mrtrix_connectivity_wf(omp_nthreads, available_anatomical_data, name="m
     ])
 
     if plot_reports:
-        plot_connectivity = pe.Node(ConnectivityReport(), name='plot_connectivity')
+        plot_connectivity = pe.Node(
+            ConnectivityReport(), 
+            name='plot_connectivity',
+            n_procs=omp_nthreads)
         ds_report_connectivity = pe.Node(
             ReconDerivativesDataSink(extension='.svg',
                                     desc="MRtrix3Connectivity",

--- a/qsiprep/workflows/recon/mrtrix.py
+++ b/qsiprep/workflows/recon/mrtrix.py
@@ -2,6 +2,13 @@
 MRTrix workflows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Note that in nipype interfaces the threading-controlling attribute is 
+``nthreads``, not the typical ``num_threads`` expected by nipype. 
+To keep threading consistent between nipype and mrtrix, the 
+``nthreads`` attribute needs to be set in the interface and the 
+``n_procs`` attribute needs to be set on the Node.
+
+
 .. autofunction:: init_mrtrix_csd_recon_wf
 
 """
@@ -77,8 +84,9 @@ def init_mrtrix_csd_recon_wf(omp_nthreads, available_anatomical_data, name="mrtr
 
 
     """
-    inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields + ['odf_rois']),
-                        name="inputnode")
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=recon_workflow_input_fields),
+        name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=['fod_sh_mif', 'wm_odf', 'wm_txt', 'gm_odf', 'gm_txt', 'csf_odf',
@@ -117,6 +125,7 @@ FODs were estimated via constrained spherical deconvolution
     fod_algorithm = fod.get('algorithm', 'msmt_csd')
     fod['algorithm'] = fod_algorithm
     fod['nthreads'] = omp_nthreads
+    LOGGER.info("Using %d threads in MRtrix3", omp_nthreads)
     using_multitissue = fod_algorithm in ('ss3t', 'msmt_csd')
 
     # Intensity normalize?
@@ -125,7 +134,10 @@ FODs were estimated via constrained spherical deconvolution
     create_mif = pe.Node(MRTrixIngress(), name='create_mif')
     method_5tt = response.pop("method_5tt", "fast")
     # Use dwi2response from 3Tissue for updated dhollander
-    estimate_response = pe.Node(SS3TDwi2Response(**response), 'estimate_response')
+    estimate_response = pe.Node(
+        SS3TDwi2Response(**response), 
+        name='estimate_response',
+        n_procs=omp_nthreads)
 
     if response_algorithm == 'msmt_5tt':
         if method_5tt == "hsvs":
@@ -138,10 +150,16 @@ FODs were estimated via constrained spherical deconvolution
             raise Exception("Unrecognized 5tt method: " + method_5tt)
 
     if fod_algorithm in ('msmt_csd', 'csd'):
-        estimate_fod = pe.Node(EstimateFOD(**fod), 'estimate_fod')
+        estimate_fod = pe.Node(
+            EstimateFOD(**fod), 
+            name='estimate_fod',
+            n_procs=omp_nthreads)
         desc += ' Reconstruction was done using MRtrix3 (@mrtrix3).'
     elif fod_algorithm == 'ss3t':
-        estimate_fod = pe.Node(SS3TEstimateFOD(**fod), 'estimate_fod')
+        estimate_fod = pe.Node(
+            SS3TEstimateFOD(**fod), 
+            name='estimate_fod',
+            n_procs=omp_nthreads)
         desc += """ \
 A single-shell-optimized multi-tissue CSD was performed using MRtrix3Tissue
 (https://3Tissue.github.io), a fork of MRtrix3 (@mrtrix3)"""
@@ -172,8 +190,12 @@ A single-shell-optimized multi-tissue CSD was performed using MRtrix3Tissue
                                         ('csf_odf', 'csf_odf')])])
     else:
         intensity_norm = pe.Node(
-            MTNormalize(inlier_mask='inliers.nii.gz', norm_image='norm.nii.gz'),
-            name='intensity_norm')
+            MTNormalize(
+                nthreads=omp_nthreads,
+                inlier_mask='inliers.nii.gz', 
+                norm_image='norm.nii.gz'),
+            name='intensity_norm',
+            n_procs=omp_nthreads)
         workflow.connect([
             (inputnode, intensity_norm, [('dwi_mask', 'mask_file')]),
             (estimate_fod, intensity_norm, [('wm_odf', 'wm_odf'),
@@ -427,7 +449,10 @@ def init_mrtrix_tractography_wf(omp_nthreads, available_anatomical_data, name="m
     use_5tt = params.get("use_5tt", False)
     sift_params = params.get("sift2", {})
     sift_params['nthreads'] = omp_nthreads
-    tracking = pe.Node(TckGen(**tracking_params), name='tractography')
+    tracking = pe.Node(
+        TckGen(**tracking_params), 
+        name='tractography',
+        n_procs=omp_nthreads)
     workflow.connect([
         (inputnode, tracking, [
             ('fod_sh_mif', 'in_file'),
@@ -446,7 +471,10 @@ def init_mrtrix_tractography_wf(omp_nthreads, available_anatomical_data, name="m
         workflow.connect(inputnode, connect_5tt, tracking, 'act_file')
 
     if use_sift2:
-        tck_sift2 = pe.Node(SIFT2(**sift_params), name="tck_sift2")
+        tck_sift2 = pe.Node(
+            SIFT2(**sift_params), 
+            name="tck_sift2",
+            n_procs=omp_nthreads)
         workflow.connect([
             (inputnode, tck_sift2, [('fod_sh_mif', 'in_fod')]),
             (tracking, tck_sift2, [('out_file', 'in_tracks')]),
@@ -501,24 +529,31 @@ def init_mrtrix_connectivity_wf(omp_nthreads, available_anatomical_data, name="m
     plot_reports = params.pop("plot_reports", True)
     workflow = pe.Workflow(name=name)
     conmat_params = params.get("tck2connectome", {})
-    calc_connectivity = pe.Node(MRTrixAtlasGraph(tracking_params=conmat_params),
-                                name='calc_connectivity')
-    plot_connectivity = pe.Node(ConnectivityReport(), name='plot_connectivity')
-    ds_report_connectivity = pe.Node(
-        ReconDerivativesDataSink(extension='.svg',
-                                 desc="MRtrix3Connectivity",
-                                 suffix='matrices'),
-        name='ds_report_connectivity',
-        run_without_submitting=True)
+    conmat_params['nthreads'] = omp_nthreads
+    calc_connectivity = pe.Node(
+        MRTrixAtlasGraph(tracking_params=conmat_params),
+        name='calc_connectivity',
+        n_procs=omp_nthreads)
     workflow.connect([
         (inputnode, calc_connectivity, [('atlas_configs', 'atlas_configs'),
                                         ('tck_file', 'in_file'),
                                         ('sift_weights', 'in_weights')]),
-        (calc_connectivity, plot_connectivity, [
-            ('connectivity_matfile', 'connectivity_matfile')]),
-        (plot_connectivity, ds_report_connectivity, [('out_report', 'in_file')]),
+        
         (calc_connectivity, outputnode, [('connectivity_matfile', 'matfile')])
     ])
+
+    if plot_reports:
+        plot_connectivity = pe.Node(ConnectivityReport(), name='plot_connectivity')
+        ds_report_connectivity = pe.Node(
+            ReconDerivativesDataSink(extension='.svg',
+                                    desc="MRtrix3Connectivity",
+                                    suffix='matrices'),
+            name='ds_report_connectivity',
+            run_without_submitting=True)
+        workflow.connect([
+            (calc_connectivity, plot_connectivity, [
+                ('connectivity_matfile', 'connectivity_matfile')]),
+            (plot_connectivity, ds_report_connectivity, [('out_report', 'in_file')])])
 
     if output_suffix:
         # Save the output in the outputs directory
@@ -526,4 +561,5 @@ def init_mrtrix_connectivity_wf(omp_nthreads, available_anatomical_data, name="m
                                   name='ds_' + name,
                                   run_without_submitting=True)
         workflow.connect(calc_connectivity, 'connectivity_matfile', ds_connectivity, 'in_file')
+
     return workflow


### PR DESCRIPTION
I've seen some strange behavior with cpu usage in the recon interfaces. This explicitly limits the number of cpus in the nipype node constructor and in the interface definition