### PR TITLE
BUG: Fix misalignment of columns added to confounds matrix

### DIFF
--- a/qsiprep/interfaces/confounds.py
+++ b/qsiprep/interfaces/confounds.py
@@ -131,6 +131,12 @@ def _gather_confounds(fdisp=None, motion=None, sliceqc_file=None, newpath=None,
         _adjust_indices(confounds_data, new)
         confounds_data = pd.concat((confounds_data, new), axis=1)
 
+    # Sort the confounds by index so that the remaining columns align properly.
+    # confounds_data['some_col'] = some_vector doesn't account for the index
+    # being out of sequence. pd.concat does respect indices, but eventually we
+    # want to write to csv in sequential order anyway
+    confounds_data.sort_index(axis=0, inplace=True)
+
     # Add in the sliceqc measures
     if isdefined(sliceqc_file) and sliceqc_file is not None:
         if sliceqc_file.endswith(".npz"):


### PR DESCRIPTION
The construction of the confounds matrix mixes pandas concat methods with direct addition of columns - the latter does not respect indices. Adding a call to sort_index reorganizes the FD / motion confounds data frame such that the indices are sequential. This means subsequent addition of columns with confounds['new_col'] = data work as expected, and the CSV file is written in the order most users would expect, with indices 0,1,...,N rather than 1,2,...N,0.

Fixes #397