### PR TITLE
BUG: Prevent divide by zero if bvec is all zeros

### DIFF
--- a/qsiprep/interfaces/dwi_merge.py
+++ b/qsiprep/interfaces/dwi_merge.py
@@ -365,6 +365,11 @@ def average_carpetplots(carpet_list, image_pairs):
 
 
 def average_bvec(bvec1, bvec2):
+    # return straight away if the bvecs are identical
+    # This prevents comparison of zero vectors
+    if (bvec1 == bvec2).all():
+        return np.copy(bvec1), 0.0
+
     bvec_diff = angle_between(bvec1, bvec2)
 
     mean_bvec_plus = (bvec1 + bvec2) / 2.


### PR DESCRIPTION
Some older data has bvals / bvecs of exactly 0, because the don't account for the non-diffusion gradients that make the real diffusion weighting slightly non-zero.

average_bvec now checks if gradients are identical first, if they are it just returns the answer without doing any of the normalization that leads to division by zero.

Fixes #375. 