### PR TITLE
[FIX] Use correct transform for t1w-space data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Build documentation
           command: |
-            apt-get update && apt-get install make
+            conda install -y make
             pip install ".[doc]"
             make SHPINXOPTS="-W" -C docs html  
   

--- a/qsiprep/interfaces/utils.py
+++ b/qsiprep/interfaces/utils.py
@@ -30,7 +30,7 @@ class GetConnectivityAtlasesInputSpec(BaseInterfaceInputSpec):
     atlas_names = traits.List(mandatory=True, desc='atlas names to be used')
     forward_transform = File(exists=True, desc='transform to get atlas into T1w space if desired')
     reference_image = File(exists=True, desc='')
-    space = traits.Str('T1w')
+    space = traits.Str('T1w', usedefault=True)
 
 
 class GetConnectivityAtlasesOutputSpec(TraitedSpec):


### PR DESCRIPTION
Issues #404, #415 and some Neurostars posts pointed out that the atlases from 0.15.x were not lining up with the T1w and dmri from qsiprep.

0.15.x had a refactored setup for anatomical data and some of the json files were changed to reflect this. This change interacted with the GetConnectivityAtlas class, which was missing the "T1w" space property and was just resampling the MNI atlas to the grid of the dmri data without any transforms.