### PR TITLE
[FIX] Add atlases back into derivatives

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,6 @@ dependencies:
 - mock
 - future
 - nibabel
-- statsmodels
 - xvfbwrapper
 - funcsigs
 - networkx>=2.0.0

--- a/qsiprep/viz/recon_config.json
+++ b/qsiprep/viz/recon_config.json
@@ -61,7 +61,14 @@
               "title": "DWI Bias correction",
               "description": "Effect of bias correction on a low and high-b image. Bias field contour lines are drawn as an overlay.",
               "imgtype": "svg+xml"
-          }
+          },
+          {
+            "name": "epi/mrtrixconmats",
+            "file_pattern": "dwi/.*desc-MRtrix3Connectivity.*_matrices\\.",
+            "title": "MRtrix3 Connectivity",
+            "description": "Connectivity estimated by tck2connectome",
+            "imgtype": "svg+xml"
+        }
         ]
     },
     {

--- a/qsiprep/workflows/recon/anatomical.py
+++ b/qsiprep/workflows/recon/anatomical.py
@@ -124,10 +124,18 @@ def init_recon_anatomical_wf(subject_id, recon_input_dir, extras_to_make,
             create_5tt_fast = pe.Node(
                 GenerateMasked5tt(algorithm='fsl'), 
                 name='create_5tt_fast')
+            ds_5tt_fast = pe.Node(
+                ReconDerivativesDataSink(
+                    desc="FAST",
+                    compress=True,
+                    suffix="5tt"),
+                name='ds_5tt_fast',
+                run_without_submitting=True)
             workflow.connect([
                 (anat_ingress, create_5tt_fast, [('t1_brain_mask', 'mask'),
                                                  ('t1_preproc', 'in_file')]),
-                (create_5tt_fast, outputnode, [('out_file', 'qsiprep_5tt_fast')])
+                (create_5tt_fast, outputnode, [('out_file', 'qsiprep_5tt_fast')]),
+                (create_5tt_fast, ds_5tt_fast, [('out_file', 'in_file')])
             ])
 
 

--- a/qsiprep/workflows/recon/build_workflow.py
+++ b/qsiprep/workflows/recon/build_workflow.py
@@ -143,12 +143,12 @@ def init_dwi_recon_workflow(dwi_file, workflow_spec, output_dir, prefer_dwi_mask
     # Fill-in datasinks and reportlet datasinks seen so far
     for node in workflow.list_node_names():
         node_suffix = node.split('.')[-1]
-        if node_suffix.startswith('ds_'):
-            workflow.connect(inputnode, 'dwi_file', workflow.get_node(node), 'source_file')
-            if "report" in node_suffix:
-                workflow.get_node(node).inputs.base_directory = reportlets_dir
-            else:
-                workflow.get_node(node).inputs.base_directory = output_dir
+        if node_suffix.startswith('ds'):
+            base_dir = reportlets_dir if "report" in node_suffix else output_dir
+            # LOGGER.info("setting %s base dir to %s", node_suffix, base_dir )
+            workflow.get_node(node).inputs.base_directory = base_dir
+            if node_suffix.startswith('ds_'):
+                workflow.connect(inputnode, 'dwi_file', workflow.get_node(node), 'source_file')
 
     return workflow
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ install_requires =
     xvfbwrapper
     scikit-learn >=0.20.2
     scikit-image
-    statsmodels <= 0.13.1
     SimpleITK
 test_requires =
     coverage


### PR DESCRIPTION
in version 0.15.x many of the recon derivatives stopped appearing in the outputs. This PR adds back the connectivity plot #378 and should fix the multi-run reconstruction bug #381 