### PR TITLE
[FIX] Add back fugue and prelude to the qsiprep image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennbbl/qsiprep_build:22.8.3
+    - image: pennbbl/qsiprep_build:22.9.0
   working_directory: /src/qsiprep
 
 runinstall: &runinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennbbl/qsiprep_build:22.8.3
+FROM pennbbl/qsiprep_build:22.9.0
 
 # WORKDIR /root/
 # # Installing qsiprep


### PR DESCRIPTION
Addresses

 * https://neurostars.org/t/cannot-run-qsiprep-missing-dependencies-fugue-prelude/22480
 * https://neurostars.org/t/qsiprep-dependencies-error-fugue-prelude/23432
 * #462 
