### PR TITLE
WIP: ENH: Make pyAFQ tests faster, add export all

### DIFF
--- a/.circleci/PyAFQReconExternalTrk.sh
+++ b/.circleci/PyAFQReconExternalTrk.sh
@@ -8,7 +8,7 @@ Reconstruction workflow tests
 All supported reconstruction workflows get tested
 
 This tests the following features:
- - Full pyAFQ pipeline
+ - pyAFQ pipeline with tractography done in mrtrix
 
 Inputs:
 -------
@@ -25,9 +25,8 @@ CFG=${TESTDIR}/data/nipype.cfg
 EDDY_CFG=${TESTDIR}/data/eddy_config.json
 export FS_LICENSE=${TESTDIR}/data/license.txt
 
-
-# Test pyafq_tractometry
-TESTNAME=pyafq_tractometry_test
+# Test mrtrix_multishell_msmt_pyafq_tractometry
+TESTNAME=mrtrix_multishell_msmt_pyafq_tractometry_test
 setup_dir ${TESTDIR}/${TESTNAME}
 TEMPDIR=${TESTDIR}/${TESTNAME}/work
 OUTPUT_DIR=${TESTDIR}/${TESTNAME}/derivatives
@@ -38,6 +37,6 @@ ${QSIPREP_CMD}  \
 	 -w ${TEMPDIR} \
 	 --recon-input ${BIDS_INPUT_DIR} \
 	 --sloppy \
-	 --recon-spec pyafq_tractometry \
+	 --recon-spec mrtrix_multishell_msmt_pyafq_tractometry \
 	 --recon-only \
 	 -vv

--- a/.circleci/PyAFQReconTests.sh
+++ b/.circleci/PyAFQReconTests.sh
@@ -27,20 +27,21 @@ export FS_LICENSE=${TESTDIR}/data/license.txt
 
 
 # Test pyafq_tractometry
-TESTNAME=pyafq_tractometry_test
-setup_dir ${TESTDIR}/${TESTNAME}
-TEMPDIR=${TESTDIR}/${TESTNAME}/work
-OUTPUT_DIR=${TESTDIR}/${TESTNAME}/derivatives
-BIDS_INPUT_DIR=${TESTDIR}/data/multishell_output/qsiprep
-QSIPREP_CMD=$(run_qsiprep_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR})
+# Using MSMT is likely prefered
+# TESTNAME=pyafq_tractometry_test
+# setup_dir ${TESTDIR}/${TESTNAME}
+# TEMPDIR=${TESTDIR}/${TESTNAME}/work
+# OUTPUT_DIR=${TESTDIR}/${TESTNAME}/derivatives
+# BIDS_INPUT_DIR=${TESTDIR}/data/multishell_output/qsiprep
+# QSIPREP_CMD=$(run_qsiprep_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR})
 
-${QSIPREP_CMD}  \
-	 -w ${TEMPDIR} \
-	 --recon-input ${BIDS_INPUT_DIR} \
-	 --sloppy \
-	 --recon-spec pyafq_tractometry \
-	 --recon-only \
-	 -vv
+# ${QSIPREP_CMD}  \
+# 	 -w ${TEMPDIR} \
+# 	 --recon-input ${BIDS_INPUT_DIR} \
+# 	 --sloppy \
+# 	 --recon-spec pyafq_tractometry \
+# 	 --recon-only \
+# 	 -vv
 
 
 # Test mrtrix_multishell_msmt_pyafq_tractometry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,11 +212,23 @@ jobs:
       - checkout
       - run: *runinstall
       - run:
-          name: Test the PYAFQ recon workflows
+          name: Test the PYAFQ standalone recon workflow
           no_output_timeout: 1h
           command: |
             cd .circleci
             bash PyAFQReconTests.sh
+
+  Recon_PYAFQExternalTrk:
+    <<: *dockersetup
+    steps:
+      - checkout
+      - run: *runinstall
+      - run:
+          name: Test the PYAFQ workflow with mrtrix tractography
+          no_output_timeout: 1h
+          command: |
+            cd .circleci
+            bash PyAFQReconExternalTrk.sh
 
   Recon_AMICO:
     <<: *dockersetup
@@ -541,6 +553,13 @@ workflows:
             tags:
               only: /.*/
 
+      - Recon_PYAFQ:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+
       - deployable:
           requires:
             - build_docs
@@ -558,6 +577,7 @@ workflows:
             - Recon_DIPY
             - Recon_AMICO
             - Recon_PYAFQ
+            - Recon_PYAFQExternalTrk
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ workflows:
             tags:
               only: /.*/
 
-      - Recon_PYAFQ:
+      - Recon_PYAFQExternalTrk:
           requires:
             - build
           filters:

--- a/qsiprep/interfaces/pyafq.py
+++ b/qsiprep/interfaces/pyafq.py
@@ -101,7 +101,11 @@ class PyAFQRecon(SimpleInterface):
             brain_mask_definition=brain_mask_definition,
             # mapping_definition=itk_map,
             **kwargs)
-        myafq.export("profiles")
+
+        if "export" not in kwargs or kwargs["export"] == "all":
+            myafq.export_all()
+        else:
+            myafq.export(kwargs["export"])
 
         self._results['afq_dir'] = output_dir
 

--- a/qsiprep/utils/sloppy_recon.py
+++ b/qsiprep/utils/sloppy_recon.py
@@ -30,7 +30,16 @@ def make_sloppy(spec):
                 "search_radius": "DELETE"}},
 
         ("MRTrix3", "global_tractography"): {
-            "niters": 10000}
+            "niters": 10000},
+
+        ("pyAFQ", "pyafq_tractometry"): {
+            "mapping_definition":
+                'AffMap(affine_kwargs={"level_iters": [10, 10, 10]})',
+            "bundle_info": '["SLF_L", "ARC_L", "CST_L", "CST_R"]',
+            "n_seeds": 10000,
+            "random_seeds": True,
+            "export": "all_bundles_figure",
+        }
     }
     sloppy_spec = deepcopy(spec)
     sloppy_nodes = []


### PR DESCRIPTION
Closes #422 and #434 by adding in the export all and choice of export functionality for pyAFQ.

I also want to reduce the runtime of the tests here. @mattcieslak , is there a way to change the parameters for one of the nodes in the json file for the test only? For example, I would like select here to be 1e4 instead of 1e6, but only when doing the circle CI tests: https://github.com/PennLINC/qsiprep/blob/80803117d8d2397b14b28668314f7e3258273447/qsiprep/data/pipelines/mrtrix_multishell_msmt_pyafq_tractometry.json#L35