### PR TITLE
[ENH] add CNR to the imageqc.csv

### DIFF
--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -274,6 +274,7 @@ generating a *preprocessed DWI run in {tpl} space* with {vox}mm isotropic voxels
     return workflow
 
 
+
 def _first(inlist):
     return inlist[0]
 


### PR DESCRIPTION
Adds multiple columns to the imageqc.csv file. For each shell the in-brain CNR mean, median and standard deviation of Eddy's CNR values are recorded.