### PR TITLE
ENH: Replace avscale with non-fsl tools

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,6 +31,11 @@
       "orcid": "0000-0003-2574-1705"
     },
     {
+      "name": "Humphries, Joseph",
+      "affiliation": "Turing Medical",
+      "orcid": "0000-0002-10257956"
+    },
+    {
       "name": "Krause, Michael",
       "affiliation": "Max Planck Institute for Human Development, Berlin, Germany",
       "orcid": "0000-0002-3878-6542"

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     scikit-image
     SimpleITK
     pyAFQ >= 1.0.1
+    transforms3d
 test_requires =
     coverage
     codecov


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in qsiprep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *qsiprep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

Related to Issue 482 (https://github.com/PennLINC/qsiprep/issues/482) but does not complete all changes required to close issue.

Changes almost entirely restricted to one file (interfaces/gradients.py), and mostly to the get_fsl_motion_params() function within that file. Previously the FSL tool avscale was used to extract motion parameters (rotation, translation, shear, and scale/zoom) from the affine transform produced by ANTs. This was replaced by a series of custom functions, an affine decompose from the transforms3d package, and a rotation vector conversion from scipy.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
No documentation changes necessary. No changes to usage, and the CombineMotions class interfaces that calls this motion extraction function can be treated exactly the same as it was prior to the change.


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennbbl/qsiprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of qsiprep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/pennbbl/qsiprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
