### PR TITLE
[FIX] pin pandas version to < 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     dmri-amico == 1.5.4
     seaborn
     SimpleITK
-    pandas
+    pandas < 2.0.0
     pyyaml
     jinja2 < 3.1
     xvfbwrapper


### PR DESCRIPTION
New pandas is causing an issue, pin it to < 2.0.0 for now