### PR TITLE
[FIX] Update distortion_group_merge.py

### DIFF
--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -133,7 +133,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         ])
     elif merging_strategy.startswith('concat'):
         distortion_merger = pe.Node(MergeDWIs(), name='distortion_merger')
-    b0_ref_wf = init_dwi_reference_wf(name='merged_b0_ref', register_t1=False,
+    b0_ref_wf = init_dwi_reference_wf(omp_nthreads, name='merged_b0_ref', register_t1=False,
                                       gen_report=True, source_file=source_file)
     concat_cnr_images = pe.Node(Merge(), name='concat_cnr_images')
 


### PR DESCRIPTION
Addresses #554. add `omp_nthreads` argument to `init_dwi_reference_wf`. Seems like the argument might have got dropped at some point?

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Add `omp_nthreads` as first positional argument to `init_dwi_reference_wf`.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
N/A


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennbbl/qsiprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of qsiprep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/pennbbl/qsiprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
