### PR TITLE
[FIX] remove pre bids-filter acq type argument

### DIFF
--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -116,8 +116,6 @@ def get_parser():
         nargs='+',
         help='a space delimited list of participant identifiers or a single '
         'identifier (the sub- prefix can be removed)')
-    g_bids.add_argument('--acquisition_type', '--acquisition_type', action='store',
-                        help='select a specific acquisition type to be processed')
     g_bids.add_argument('--bids-database-dir', '--bids_database_dir',
                         help="path to a saved BIDS database directory",
                         type=Path,


### PR DESCRIPTION
I'm debugging an issue and found that this option is present in the cli code, but never used anywhere. This was added in  d08a171c46555446e56bb9eb142f035ec37f8451  and I **assume** it was made obsolete with the `bids-filter-file` argument?

I was about to use this option when I figured out it would have made no difference anyway and I want to save others from falling into this little trap.