### PR TITLE
[ENH] Stabilize autotrack performance

### DIFF
--- a/.circleci/AutoTrackTest.sh
+++ b/.circleci/AutoTrackTest.sh
@@ -25,7 +25,7 @@ CFG=${TESTDIR}/data/nipype.cfg
 EDDY_CFG=${TESTDIR}/data/eddy_config.json
 export FS_LICENSE=${TESTDIR}/data/license.txt
 
-# Test MRtrix3 multishell msmt with ACT
+# Test AutoTrack
 TESTNAME=autotrack
 setup_dir ${TESTDIR}/${TESTNAME}
 TEMPDIR=${TESTDIR}/${TESTNAME}/work
@@ -37,7 +37,7 @@ ${QSIPREP_CMD} \
 	 -w ${TEMPDIR} \
 	 --recon-input ${BIDS_INPUT_DIR} \
 	 --sloppy \
-     --stop-on-first-crash \
+         --stop-on-first-crash \
 	 --recon-spec dsi_studio_autotrack \
 	 --recon-only \
 	 -vv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennbbl/qsiprep_build:23.5.6
+    - image: pennbbl/qsiprep_build:23.7.2
   working_directory: /src/qsiprep
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
       - checkout
       - run: *runinstall
       - run:
-          name: Test the CSD recon workflows
+          name: Test the AutoTrack workflow
           no_output_timeout: 1h
           command: |
             cd .circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennbbl/qsiprep_build:23.5.6
+FROM pennbbl/qsiprep_build:23.7.2
 
 # WORKDIR /root/
 # # Installing qsiprep

--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -759,7 +759,6 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
                     copyfile=False,
                     argstr="--source=%s")
     map_file = File(exists=True,
-                    mandatory=True,
                     copyfile=False)
     track_id = traits.Str(
         "Fasciculus,Cingulum,Aslant,Corticos,Thalamic_R,Reticular,Optic,Fornix,Corpus",
@@ -812,9 +811,10 @@ class _AutoTrackInputSpec(DSIStudioCommandLineInputSpec):
     _boilerplate_traits = ["track_id", "track_voxel_ratio", "tolerance", "yield_rate"]
 
 
-class _AutoTrackOutputSpec(DSIStudioCommandLineInputSpec):
+class _AutoTrackOutputSpec(TraitedSpec):
     native_trk_files = OutputMultiObject(File(exists=True))
     stat_files = OutputMultiObject(File(exists=True))
+    map_file = File(exists=True)
 
 
 class AutoTrack(CommandLine):
@@ -834,26 +834,8 @@ class AutoTrack(CommandLine):
         stat_files = [str(fname.absolute()) for fname in cwd.rglob("*.stat.txt")]
         outputs["native_trk_files"] = trk_files
         outputs["stat_files"] = stat_files
-        return outputs
 
-
-class _AutoTrackInitInputSpec(_AutoTrackInputSpec):
-    num_threads = 1  # Force this so it doesn't use a ton of threads
-    map_file = File(mandatory=False)
-    track_id = "0"
-
-
-class _AutoTrackInitOutputSpec(_AutoTrackOutputSpec):
-    map_file = File(exists=True)
-
-
-class AutoTrackInit(AutoTrack):
-    input_spec = _AutoTrackInitInputSpec
-    output_spec = _AutoTrackInitOutputSpec
-
-    def _list_outputs(self):
-        outputs = self.output_spec().get()
-        cwd = Path(".")
+        # Find any mappings
         map_files = list(cwd.glob("*.map.gz"))
         if len(map_files) > 1:
             raise Exception("Too many map files generated")

--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -841,8 +841,6 @@ class _AutoTrackInitInputSpec(_AutoTrackInputSpec):
     num_threads = 1  # Force this so it doesn't use a ton of threads
     map_file = File(mandatory=False)
     track_id = "0"
-    num_retries = traits.Int(3, usedefault=True)
-    seconds_between_retries = traits.Int(500, usedefault=True)
 
 
 class _AutoTrackInitOutputSpec(_AutoTrackOutputSpec):
@@ -863,27 +861,6 @@ class AutoTrackInit(AutoTrack):
             raise Exception("No map files found in " + str(cwd.absolute()))
         outputs["map_file"] = str(map_files[0].absolute())
         return outputs
-
-    def _run_interface(self, runtime, correct_return_codes=(0,)):
-        if self.inputs.num_retries < 2:
-            return super(AutoTrackInit, self)._run_interface(
-                runtime, correct_return_codes)
-
-        for try_num in range(self.inputs.num_retries):
-            runtime = super(AutoTrackInit, self)._run_interface(
-                runtime, correct_return_codes)
-            succeeded = False
-            try:
-                self._list_outputs()
-                succeeded = True
-            except Exception:
-                LOGGER.info("Autotrack init has failed attempt {}".format(try_num + 1))
-                time.sleep(self.inputs.seconds_between_retries)
-
-            if succeeded:
-                return runtime
-
-        raise Exception("Autotrack was unable to run successfully.")
 
 
 class _AggregateAutoTrackResultsInputSpec(BaseInterfaceInputSpec):

--- a/qsiprep/utils/sloppy_recon.py
+++ b/qsiprep/utils/sloppy_recon.py
@@ -17,7 +17,7 @@ def make_sloppy(spec):
             "fiber_count": 5000},
         ("DSI Studio", "autotrack"): {
             "track_id": "Cortico_Spinal_Tract_L,Cortico_Spinal_Tract_R",
-            "tolerance": "30, 40",
+            "tolerance": "30,40",
             "track_voxel_ratio": 0.8},
 
         ("MRTrix3", "tractography"): {

--- a/qsiprep/utils/sloppy_recon.py
+++ b/qsiprep/utils/sloppy_recon.py
@@ -16,7 +16,7 @@ def make_sloppy(spec):
         ("DSI Studio", "tractography"): {
             "fiber_count": 5000},
         ("DSI Studio", "autotrack"): {
-            "track_id": "0,1,2"},
+            "track_id": "0,1"},
 
         ("MRTrix3", "tractography"): {
             "tckgen": {

--- a/qsiprep/utils/sloppy_recon.py
+++ b/qsiprep/utils/sloppy_recon.py
@@ -16,7 +16,7 @@ def make_sloppy(spec):
         ("DSI Studio", "tractography"): {
             "fiber_count": 5000},
         ("DSI Studio", "autotrack"): {
-            "track_id": "Cortico_Spinal_Tract_L,Cortico_Spinal_Tract_R",
+            "track_id": "Arcuate_Fasciculus_L,Arcuate_Fasciculus_R",
             "tolerance": "30,40",
             "track_voxel_ratio": 0.8},
 

--- a/qsiprep/utils/sloppy_recon.py
+++ b/qsiprep/utils/sloppy_recon.py
@@ -16,7 +16,9 @@ def make_sloppy(spec):
         ("DSI Studio", "tractography"): {
             "fiber_count": 5000},
         ("DSI Studio", "autotrack"): {
-            "track_id": "0,1"},
+            "track_id": "Cortico_Spinal_Tract_L,Cortico_Spinal_Tract_R",
+            "tolerance": "30, 40",
+            "track_voxel_ratio": 0.8},
 
         ("MRTrix3", "tractography"): {
             "tckgen": {


### PR DESCRIPTION
The AutoTrack workflow is constantly being killed on HPCs. This attempts to add some robustness to the run, which may or may not make a difference