### PR TITLE
[ENH] add option for "native template"

### DIFF
--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -329,6 +329,13 @@ def get_parser():
         default='MNI152NLin2009cAsym',
         help='volume template space (default: MNI152NLin2009cAsym)')
     g_conf.add_argument(
+        "--native-template",
+        required=False,
+        action='store',
+        type=Path,
+        help="A preprocessed native space image from fmriprep or previous qsiprep"
+        "that will be used instead of AC-PC to define subject native space.")
+    g_conf.add_argument(
         '--output-resolution', '--output_resolution',
         action='store',
         # required when not recon-only (which can be specified in sysargs 2 ways)
@@ -411,17 +418,6 @@ def get_parser():
     # ANTs options
     g_ants = parser.add_argument_group(
         'Specific options for ANTs registrations')
-    g_ants.add_argument(
-        '--skull-strip-template', '--skull_strip_template',
-        action='store',
-        default='OASIS',
-        choices=['OASIS', 'NKI'],
-        help='select ANTs skull-stripping template (default: OASIS)')
-    g_ants.add_argument(
-        '--skull-strip-fixed-seed', '--skull_strip_fixed_seed',
-        action='store_true',
-        help='do not use a random seed for skull-stripping - will ensure '
-        'run-to-run replicability when used with --omp-nthreads 1')
     g_ants.add_argument(
         '--skip-anat-based-spatial-normalization', '--skip_anat_based_spatial_normalization',
         action='store_true',
@@ -980,6 +976,7 @@ def build_qsiprep_workflow(opts, retval):
         force_spatial_normalization=force_spatial_normalization,
         output_resolution=opts.output_resolution,
         template=opts.anatomical_template,
+        native_template=opts.native_template,
         bids_dir=bids_dir,
         motion_corr_to=opts.b0_motion_corr_to,
         hmc_transform=opts.hmc_transform,

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -51,7 +51,7 @@ def init_qsiprep_wf(
         force_spatial_normalization, skull_strip_template,
         skull_strip_fixed_seed, freesurfer, hmc_model, impute_slice_threshold,
         hmc_transform, shoreline_iters, eddy_config, write_local_bvecs,
-        template, motion_corr_to, b0_to_t1w_transform,
+        template, native_template, motion_corr_to, b0_to_t1w_transform,
         intramodal_template_iters, intramodal_template_transform,
         prefer_dedicated_fmaps, fmap_bspline, fmap_demean, use_syn, force_syn,
         raw_image_sdc):
@@ -97,6 +97,7 @@ def init_qsiprep_wf(
                               skull_strip_template='OASIS',
                               skull_strip_fixed_seed=False,
                               template='MNI152NLin2009cAsym',
+                              native_template=None,
                               motion_corr_to='iterative',
                               b0_to_t1w_transform='Rigid',
                               intramodal_template_iters=0,
@@ -258,6 +259,7 @@ def init_qsiprep_wf(
             skull_strip_template=skull_strip_template,
             skull_strip_fixed_seed=skull_strip_fixed_seed,
             template=template,
+            native_template=native_template,
             prefer_dedicated_fmaps=prefer_dedicated_fmaps,
             motion_corr_to=motion_corr_to,
             b0_to_t1w_transform=b0_to_t1w_transform,
@@ -292,7 +294,7 @@ def init_single_subject_wf(
         no_b0_harmonization, infant_mode, combine_all_dwis, raw_image_sdc,
         distortion_group_merge, pepolar_method, omp_nthreads, skull_strip_template,
         force_spatial_normalization, skull_strip_fixed_seed, freesurfer, hires,
-        template, output_resolution, prefer_dedicated_fmaps,
+        template, native_template, output_resolution, prefer_dedicated_fmaps,
         motion_corr_to, b0_to_t1w_transform, intramodal_template_iters,
         intramodal_template_transform, hmc_model, hmc_transform,
         shoreline_iters, eddy_config, impute_slice_threshold, fmap_bspline,
@@ -345,6 +347,7 @@ def init_single_subject_wf(
             skull_strip_template='OASIS',
             skull_strip_fixed_seed=False,
             template='MNI152NLin2009cAsym',
+            native_template=None,
             prefer_dedicated_fmaps=False,
             motion_corr_to='iterative',
             b0_to_t1w_transform='Rigid',
@@ -424,6 +427,8 @@ def init_single_subject_wf(
             Root directory of BIDS dataset
         template : str
             Name of template targeted by ``template`` output space
+        native_template : str or None
+            Either a path to an existing image or None
         hmc_model : 'none', '3dSHORE' or 'eddy'
             Model used to generate target images for head motion correction. If 'none'
             the transform from the nearest b0 will be used.
@@ -575,6 +580,7 @@ to workflows in *QSIPrep*'s documentation]\
     info_modality = "dwi" if dwi_only else anatomical_contrast.lower()
     anat_preproc_wf = init_anat_preproc_wf(
         template=template,
+        native_template=native_template,
         debug=debug,
         dwi_only=dwi_only,
         infant_mode=infant_mode,


### PR DESCRIPTION
Issue: Sometimes there is a specific image that you want the dmri results aligned to, and not necessarily to AC-PC. This PR introduces the `--native-template` where  an external image will be used to define the `space-T1w`. 

The main use case is to take a T1w from a previous fMRIPrep run or QSIPrep run and have the QSIPrep runs from this QSIPrep run be aligned to them. 