### PR TITLE
ENH: Rework the PR template and first time contributor message

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -6,28 +6,43 @@ newPRWelcomeComment: >
   We have detected this is the first time for you to contribute
   to *qsiprep*.
   Please check out our [contributing guidelines](https://github.com/pennbbl/qsiprep/blob/master/CONTRIBUTING.md).
-  
+
+  These are guidelines intended to make communication easier by describing a
+  consistent process, but don't worry if you don't get it everything exactly
+  "right" on the first try.
+
   We invite you to list yourself as a *qsiprep* contributor, so if your name
   is not already mentioned, please modify the
   [``.zenodo.json``](https://github.com/pennbbl/qsiprep/blob/master/.zenodo.json)
-  file with your data right above Russ' entry. Example:
+  file with your data. If you do so, your name will be listed as an author
+  at the next release. Please add yourself to the list in alphabetical order,
+  keeping Cieslak, Matthew as first and Satterthwaite, Theodore D. as last
+  authors, e.g.:
 
   ```
-
-  {
-     "name": "Contributor, New qsiprep",
-     "affiliation": "Department of fMRI prep'ing, Open Science Made-Up University",
-     "orcid": "<your id>"
-  },
-
-  {
-     "name": "Poldrack, Russell A.",
-     "affiliation": "Department of Psychology, Stanford University",
-     "orcid": "0000-0001-6755-0259"
-  },
-
+    {
+      (...)
+    },
+    {
+     {
+        "name": "<LastName>, <FirstName>",
+        "affiliation": "<Affiliation>",
+        "orcid": "<Id>"
+     },
+    {
+      (...)
+    }
+  ],
+  "keywords": [
+    "neuroimaging",
+    "workflow",
+    "pipeline",
+    "preprocessing",
+    "dMRI",
+    "BIDS"
+  ],
+  (...)
   ```
-
 
   Of course, if you want to opt-out this time there is no
   problem at all with adding your name later.

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,19 +6,14 @@
       "orcid": "0000-0002-1931-4734"
     },
     {
+      "name": "Camacho, Paul B.",
+      "affiliation": "Beckman Institute for Advanced Science & Technology, University of Illinois at Urbana-Champaign, IL, USA",
+      "orcid": "0000-0001-9048-7307"
+    },
+    {
       "name": "Covitz, Sydney",
-      "affiliation":"Department of Neuropsychiatry, University of Pennsylvania",
+      "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
       "orcid": "0000-0002-7430-4125"
-    },
-    {
-      "name": "Sydnor, Valerie Jill",
-      "affiliation": "Perelman School of Medicine, University of Pennsylvania",
-      "orcid": "0000-0002-8640-668X"
-    },
-    {
-      "name": "He, Xiaosong",
-      "affiliation": "Department of Bioengineering, University of Pennsylvania",
-      "orcid": "0000-0002-7941-2918"
     },
     {
       "name": "Foran, William",
@@ -26,9 +21,9 @@
       "orcid": "0000-0001-7491-9798"
     },
     {
-      "name": "Magnussen, Fredrik",
-      "affiliation": "Department of Psychology, University of Oslo",
-      "orcid": "0000-0003-2574-1705"
+      "name": "He, Xiaosong",
+      "affiliation": "Department of Bioengineering, University of Pennsylvania",
+      "orcid": "0000-0002-7941-2918"
     },
     {
       "name": "Humphries, Joseph",
@@ -36,24 +31,24 @@
       "orcid": "0000-0002-10257956"
     },
     {
+      "name": "Magnussen, Fredrik",
+      "affiliation": "Department of Psychology, University of Oslo",
+      "orcid": "0000-0003-2574-1705"
+    },
+    {
       "name": "Krause, Michael",
       "affiliation": "Max Planck Institute for Human Development, Berlin, Germany",
       "orcid": "0000-0002-3878-6542"
     },
     {
-      "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
+      "name": "Sydnor, Valerie Jill",
+      "affiliation": "Perelman School of Medicine, University of Pennsylvania",
+      "orcid": "0000-0002-8640-668X"
+    },
+    {
       "name": "Satterthwaite, Theodore D.",
-      "orcid": "0000-0001-7072-9399"
-    },
-    {
-      "affiliation": "Beckman Institute for Advanced Science & Technology, University of Illinois at Urbana-Champaign, IL, USA",
-      "name": "Camacho, Paul B.",
-      "orcid": "0000-0001-9048-7307"
-    },
-    {
       "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
-      "name": "Covitz, Sydney",
-      "orcid": "0000-0002-7430-4125"
+      "orcid": "0000-0001-7072-9399"
     }
   ],
   "keywords": [

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,25 @@
 <!--
 Text in these brackets are comments, and won't be visible when you submit your pull request.
-If this is your first contribution, please take the time to read these, in particular the comment
-beginning "Welcome, new contributors!".
+
+A pull request is a conversation. We may ask you to make some changes
+before accepting your PR, and likewise, you should feel free to ask us any
+questions you have.
+
+We ask you to read through the Contributing Guide:
+https://github.com/pennbbl/qsiprep/blob/master/CONTRIBUTING.md
+
+Please take the time to read these, especially if this is your first
+contribution.
+
+To boil it down, here are some highlights:
+
+1) Consider starting a conversation in the issues list before submitting a
+pull request. The discussion might save you a lot of time coding.
+2) Please use descriptive prefixes in your pull request title, such as
+"ENH:" for an enhancement or "FIX:" for a bug fix. (See the Contributing guide
+for the full set.) And consider adding a "WIP" tag for works-in-progress.
+3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as
+the rest of qsiprep.
 -->
 
 ## Changes proposed in this pull request
@@ -19,31 +37,4 @@ of ongoing development efforts and possible overlaps between contributions).
 ## Documentation that should be reviewed
 <!--
 Please summarize here the main changes to the documentation that the reviewers should be aware of.
--->
-
-
-
-<!--
-Welcome, new contributors!
-
-We ask you to read through the Contributing Guide:
-https://github.com/pennbbl/qsiprep/blob/master/CONTRIBUTING.md
-
-These are guidelines intended to make communication easier by describing a consistent process, but
-don't worry if you don't get it everything exactly "right" on the first try.
-
-To boil it down, here are some highlights:
-
-1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
-   lot of time coding.
-2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
-   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
-3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of qsiprep.
-4) We invite every contributor to add themselves to the `.zenodo.json` file
-   (https://github.com/pennbbl/qsiprep/blob/master/.zenodo.json), which will result in your being listed as an author
-   at the next release. Please add yourself as the next-to-last entry, just above Russ.
-
-A pull request is a conversation. We may ask you to make some changes before accepting your PR,
-and likewise, you should feel free to ask us any questions you have.
-
 -->


### PR DESCRIPTION
Rework the PR template and first time contributor message:
- Edit and reword as necessary the PR template and first time
  contributor message config files so that the first time contribution
  information is not duplicated.
- Instruct new contributors to add their names to the list in
  alphabetical order: reorder contributors alphabetically, keeping
  Cieslak, Matthew as first and and Satterthwaite, Theodore D. as last
  authors.
- Make the order of the contributor fields consistent: name,
  affiliation, orcid.
- Slightly reword the first time contributor placeholder tags in the
  first time contributor message config file.
- Remove the mention to Russell Poldrack as an author of the tool from
  the PR template: Russell is not actually listed as an author in the
  `.zenodo.json` file. Most likely this was transferred as-is from the
  `fmriprep` pipeline github config file:
  nipreps/fmriprep@2a25395
- Slightly reword the first time contributor placeholder tags in the
  first time contributor message config file.