### PR TITLE
Update pyAFQ version to 1.1

### DIFF
--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -840,7 +840,7 @@ def build_qsiprep_workflow(opts, retval):
                     "stimuli",
                     "sourcedata",
                     "models",
-                    re.compile(r"^\.")))
+                    re.compile(r"\/\.\w+|^\.\w+")))
 
     subject_list = collect_participants(
         layout, participant_label=opts.participant_label)
@@ -1087,7 +1087,7 @@ def build_recon_workflow(opts, retval):
                     "stimuli",
                     "sourcedata",
                     "models",
-                    re.compile(r"^\.")))
+                    re.compile(r"\/\.\w+|^\.\w+")))
     subject_list = collect_participants(
         layout, participant_label=opts.participant_label)
     retval['subject_list'] = subject_list

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     scikit-learn >=0.20.2
     scikit-image
     SimpleITK
-    pyAFQ >= 1.0.1
+    pyAFQ >= 1.1
     transforms3d
 test_requires =
     coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     nilearn >= 0.10.1
     nipype >=1.3.1
     psutil >=5.4
-    pybids < 0.16.1
+    pybids == 0.16.2
     matplotlib
     svgutils <= 0.3.0
     numpy >= 1.18.5


### PR DESCRIPTION
Would this build a new qsiprep container with the new pyAFQ version? Would a user then have to use `latest` to access this version of pyAFQ, until a new RC of qsiprep is up? 