### PR TITLE
[FIX] remove unneeded "method" from tracking

### DIFF
--- a/qsiprep/data/pipelines/csdsi_3dshore.json
+++ b/qsiprep/data/pipelines/csdsi_3dshore.json
@@ -26,10 +26,9 @@
       "input": "csdsi_3dshore",
       "parameters": {
         "turning_angle": 35,
-        "method": 0,
         "smoothing": 0.0,
         "step_size": 1.0,
-        "min_length": 10,
+        "min_length": 30,
         "max_length": 250,
         "seed_plan": 0,
         "interpolation": 0,

--- a/qsiprep/data/pipelines/dipy_3dshore.json
+++ b/qsiprep/data/pipelines/dipy_3dshore.json
@@ -27,7 +27,6 @@
       "input": "recon_3dshore",
       "parameters": {
         "turning_angle": 35,
-        "method": 0,
         "smoothing": 0.0,
         "step_size": 1.0,
         "min_length": 30,


### PR DESCRIPTION
The csdsi workflows were out of date with the current DSI Studio tractography interface