### PR TITLE
MISC: Remove outdated dsi_studio tracking parameters

### DIFF
--- a/qsiprep/data/pipelines/dsi_studio_gqi.json
+++ b/qsiprep/data/pipelines/dsi_studio_gqi.json
@@ -29,9 +29,6 @@
         "step_size": 1.0,
         "min_length": 30,
         "max_length": 250,
-        "seed_plan": 0,
-        "interpolation": 0,
-        "initial_dir": 2,
         "fiber_count": 5000000
       }
     },


### PR DESCRIPTION
Some parameters are no longer supported:

"seed_plan": used to control voxel or sub-voxel seeding

"interpolation": interpolation of data during tracking

"initial_dir": whether to seed tracts following the primary direction in a voxel, or a secondary one, or all of them. According to Frank, the tracking now always follows the primary direction
