### PR TITLE
Apply stylistic changes to `workflows/base.py`

### DIFF
--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -429,12 +429,17 @@ def get_parser():
         action='store',
         default='OASIS',
         choices=['OASIS', 'NKI'],
-        help='select ANTs skull-stripping template (default: OASIS)')
+        help='select ANTs skull-stripping template (default: OASIS). (IGNORED)',
+    )
     g_ants.add_argument(
         '--skull-strip-fixed-seed', '--skull_strip_fixed_seed',
         action='store_true',
-        help='do not use a random seed for skull-stripping - will ensure '
-        'run-to-run replicability when used with --omp-nthreads 1')
+        help=(
+            'do not use a random seed for skull-stripping - will ensure '
+            'run-to-run replicability when used with --omp-nthreads 1. '
+            '(IGNORED)'
+        ),
+    )
     g_ants.add_argument(
         '--skip-anat-based-spatial-normalization', '--skip_anat_based_spatial_normalization',
         action='store_true',
@@ -471,8 +476,11 @@ def get_parser():
         '--prefer_dedicated_fmaps', '--prefer-dedicated-fmaps',
         action='store_true',
         default=False,
-        help='forces unwarping to use files from the fmap directory instead '
-        'of using an RPEdir scan from the same session.')
+        help=(
+            'forces unwarping to use files from the fmap directory instead '
+            'of using an RPEdir scan from the same session. (IGNORED)'
+        ),
+    )
     g_fmap.add_argument(
         '--fmap-bspline', '--fmap_bspline',
         action='store_true',
@@ -492,7 +500,7 @@ def get_parser():
         action='store_true',
         default=False,
         help='EXPERIMENTAL: Use fieldmap-free distortion correction. To use '
-        'this option, "template" must be passed to --output-space')
+        'this option, "template" must be passed to --output-space. (IGNORED)')
     g_syn.add_argument(
         '--force-syn', '--force_syn',
         action='store_true',
@@ -966,9 +974,7 @@ def build_qsiprep_workflow(opts, retval):
         work_dir=work_dir,
         output_dir=str(output_dir),
         ignore=opts.ignore,
-        hires=False,
         anatomical_contrast=opts.anat_modality,
-        freesurfer=opts.do_reconall,
         bids_filters=opts.bids_filters,
         debug=opts.sloppy,
         low_mem=opts.low_mem,
@@ -988,8 +994,6 @@ def build_qsiprep_workflow(opts, retval):
         denoise_before_combining=not opts.denoise_after_combining,
         write_local_bvecs=opts.write_local_bvecs,
         omp_nthreads=omp_nthreads,
-        skull_strip_template=opts.skull_strip_template,
-        skull_strip_fixed_seed=opts.skull_strip_fixed_seed,
         force_spatial_normalization=force_spatial_normalization,
         output_resolution=opts.output_resolution,
         template=opts.anatomical_template,
@@ -1004,10 +1008,8 @@ def build_qsiprep_workflow(opts, retval):
         b0_to_t1w_transform=opts.b0_to_t1w_transform,
         intramodal_template_iters=opts.intramodal_template_iters,
         intramodal_template_transform=opts.intramodal_template_transform,
-        prefer_dedicated_fmaps=opts.prefer_dedicated_fmaps,
         fmap_bspline=opts.fmap_bspline,
         fmap_demean=opts.fmap_no_demean,
-        use_syn=opts.use_syn_sdc,
         force_syn=opts.force_syn
     )
     retval['return_code'] = 0

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -56,7 +56,6 @@ def init_qsiprep_wf(
     dwi_only,
     longitudinal,
     b0_threshold,
-    hires,
     anatomical_contrast,
     denoise_before_combining,
     dwi_denoise_window,
@@ -72,9 +71,6 @@ def init_qsiprep_wf(
     omp_nthreads,
     bids_filters,
     force_spatial_normalization,
-    skull_strip_template,
-    skull_strip_fixed_seed,
-    freesurfer,
     hmc_model,
     impute_slice_threshold,
     hmc_transform,
@@ -86,10 +82,8 @@ def init_qsiprep_wf(
     b0_to_t1w_transform,
     intramodal_template_iters,
     intramodal_template_transform,
-    prefer_dedicated_fmaps,
     fmap_bspline,
     fmap_demean,
-    use_syn,
     force_syn,
     raw_image_sdc,
 ):
@@ -118,8 +112,6 @@ def init_qsiprep_wf(
             anat_only=False,
             longitudinal=False,
             b0_threshold=100,
-            freesurfer=False,
-            hires=False,
             denoise_before_combining=True,
             dwi_denoise_window=7,
             denoise_method='patch2self',
@@ -132,8 +124,6 @@ def init_qsiprep_wf(
             omp_nthreads=1,
             output_resolution=2.0,
             hmc_model='3dSHORE',
-            skull_strip_template='OASIS',
-            skull_strip_fixed_seed=False,
             template='MNI152NLin2009cAsym',
             motion_corr_to='iterative',
             b0_to_t1w_transform='Rigid',
@@ -146,10 +136,8 @@ def init_qsiprep_wf(
             shoreline_iters=2,
             impute_slice_threshold=0,
             write_local_bvecs=False,
-            prefer_dedicated_fmaps=False,
             fmap_bspline=False,
             fmap_demean=True,
-            use_syn=True,
             force_spatial_normalization=True,
             force_syn=True,
         )
@@ -208,15 +196,6 @@ def init_qsiprep_wf(
         The method for SDC when EPI fieldmaps are used.
     omp_nthreads : int
         Maximum number of threads an individual process may use
-    skull_strip_template : str
-        Name of ANTs skull-stripping template ('OASIS' or 'NKI')
-    skull_strip_fixed_seed : bool
-        Do not use a random seed for skull-stripping - will ensure
-        run-to-run replicability when used with --omp-nthreads 1
-    freesurfer : bool
-        Enable FreeSurfer surface reconstruction (may increase runtime)
-    hires : bool
-        Enable sub-millimeter preprocessing in FreeSurfer
     template : str
         Name of template targeted by ``template`` output space
     motion_corr_to : str
@@ -242,19 +221,12 @@ def init_qsiprep_wf(
         Path to a JSON file containing config options for eddy
     raw_image_sdc: bool
         Use raw (direct from BIDS) images for distortion
-    prefer_dedicated_fmaps: bool
-        If a reverse PE fieldmap is available in fmap, use that even if a reverse PE
-        DWI series is available
     write_local_bvecs : bool
         Write out a series of voxelwise bvecs
     fmap_bspline : bool
         **Experimental**: Fit B-Spline field using least-squares
     fmap_demean : bool
         Demean voxel-shift map during unwarp
-    use_syn : bool
-        **Experimental**: Enable ANTs SyN-based susceptibility distortion
-        correction (SDC). If fieldmaps are present and enabled, this is not
-        run, by default.
     force_syn : bool
         **Temporary**: Always run SyN-based SDC
     """
@@ -287,16 +259,11 @@ def init_qsiprep_wf(
             longitudinal=longitudinal,
             infant_mode=infant_mode,
             b0_threshold=b0_threshold,
-            freesurfer=freesurfer,
-            hires=hires,
             combine_all_dwis=combine_all_dwis,
             distortion_group_merge=distortion_group_merge,
             pepolar_method=pepolar_method,
             omp_nthreads=omp_nthreads,
-            skull_strip_template=skull_strip_template,
-            skull_strip_fixed_seed=skull_strip_fixed_seed,
             template=template,
-            prefer_dedicated_fmaps=prefer_dedicated_fmaps,
             motion_corr_to=motion_corr_to,
             b0_to_t1w_transform=b0_to_t1w_transform,
             intramodal_template_iters=intramodal_template_iters,
@@ -310,7 +277,6 @@ def init_qsiprep_wf(
             write_local_bvecs=write_local_bvecs,
             fmap_bspline=fmap_bspline,
             fmap_demean=fmap_demean,
-            use_syn=use_syn,
             force_syn=force_syn,
         )
 
@@ -352,14 +318,9 @@ def init_single_subject_wf(
     distortion_group_merge,
     pepolar_method,
     omp_nthreads,
-    skull_strip_template,
     force_spatial_normalization,
-    skull_strip_fixed_seed,
-    freesurfer,
-    hires,
     template,
     output_resolution,
-    prefer_dedicated_fmaps,
     motion_corr_to,
     b0_to_t1w_transform,
     intramodal_template_iters,
@@ -371,7 +332,6 @@ def init_single_subject_wf(
     impute_slice_threshold,
     fmap_bspline,
     fmap_demean,
-    use_syn,
     force_syn,
 ):
     """Organize the preprocessing pipeline for a single subject.
@@ -412,17 +372,12 @@ def init_single_subject_wf(
             anat_only=False,
             longitudinal=False,
             b0_threshold=100,
-            freesurfer=False,
-            hires=False,
             force_spatial_normalization=True,
             combine_all_dwis=True,
             distortion_group_merge='none',
             pepolar_method='TOPUP',
             omp_nthreads=1,
-            skull_strip_template='OASIS',
-            skull_strip_fixed_seed=False,
             template='MNI152NLin2009cAsym',
-            prefer_dedicated_fmaps=False,
             motion_corr_to='iterative',
             b0_to_t1w_transform='Rigid',
             intramodal_template_iters=0,
@@ -436,7 +391,6 @@ def init_single_subject_wf(
             write_local_bvecs=False,
             fmap_bspline=False,
             fmap_demean=True,
-            use_syn=False,
             force_syn=False,
         )
 
@@ -485,15 +439,6 @@ def init_single_subject_wf(
         Either 'DRBUDDI' or 'TOPUP'. The method for SDC when EPI fieldmaps are used.
     omp_nthreads : int
         Maximum number of threads an individual process may use
-    skull_strip_template : str
-        Name of ANTs skull-stripping template ('OASIS' or 'NKI')
-    skull_strip_fixed_seed : bool
-        Do not use a random seed for skull-stripping - will ensure
-        run-to-run replicability when used with --omp-nthreads 1
-    freesurfer : bool
-        Enable FreeSurfer surface reconstruction (may increase runtime)
-    hires : bool
-        Enable sub-millimeter preprocessing in FreeSurfer
     reportlets_dir : str
         Directory in which to save reportlets
     output_dir : str
@@ -521,10 +466,6 @@ def init_single_subject_wf(
         **Experimental**: Fit B-Spline field using least-squares
     fmap_demean : bool
         Demean voxel-shift map during unwarp
-    use_syn : bool
-        **Experimental**: Enable ANTs SyN-based susceptibility distortion
-        correction (SDC). If fieldmaps are present and enabled, this is not
-        run, by default.
     force_syn : bool
         **Temporary**: Always run SyN-based SDC
     eddy_config: str

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -479,9 +479,9 @@ def init_single_subject_wf(
         LOGGER.warning("Building a test workflow")
     else:
         subject_data, layout = collect_data(
-            bids_dir, 
-            subject_id, 
-            filters=bids_filters, 
+            bids_dir,
+            subject_id,
+            filters=bids_filters,
             bids_validate=False
         )
 
@@ -596,28 +596,29 @@ to workflows in *QSIPrep*'s documentation]\
         name="anat_preproc_wf")
 
     workflow.connect([
-        (inputnode, anat_preproc_wf, [('subjects_dir',
-                                       'inputnode.subjects_dir')]),
-        (bidssrc, bids_info, [((info_modality, fix_multi_source_name,
-                                dwi_only, anatomical_contrast),
-                               'in_file')]),
+        (inputnode, anat_preproc_wf, [('subjects_dir', 'inputnode.subjects_dir')]),
+        (bidssrc, bids_info, [
+            ((info_modality, fix_multi_source_name, dwi_only, anatomical_contrast), 'in_file'),
+        ]),
         (inputnode, summary, [('subjects_dir', 'subjects_dir')]),
         (bidssrc, summary, [('t1w', 't1w'), ('t2w', 't2w')]),
         (bids_info, summary, [('subject_id', 'subject_id')]),
-        (bidssrc, anat_preproc_wf, [('t1w', 'inputnode.t1w'),
-                                    ('t2w', 'inputnode.t2w'),
-                                    ('roi', 'inputnode.roi'),
-                                    ('flair', 'inputnode.flair')]),
+        (bidssrc, anat_preproc_wf, [
+            ('t1w', 'inputnode.t1w'),
+            ('t2w', 'inputnode.t2w'),
+            ('roi', 'inputnode.roi'),
+            ('flair', 'inputnode.flair'),
+        ]),
         (summary, anat_preproc_wf, [('subject_id', 'inputnode.subject_id')]),
-        (bidssrc, ds_report_summary, [((info_modality, fix_multi_source_name,
-                                        dwi_only, anatomical_contrast),
-                                       'source_file')]),
+        (bidssrc, ds_report_summary, [
+            ((info_modality, fix_multi_source_name, dwi_only, anatomical_contrast), 'source_file'),
+        ]),
         (summary, ds_report_summary, [('out_report', 'in_file')]),
-        (bidssrc, ds_report_about, [((info_modality, fix_multi_source_name,
-                                      dwi_only, anatomical_contrast),
-                                     'source_file')]),
+        (bidssrc, ds_report_about, [
+            ((info_modality, fix_multi_source_name, dwi_only, anatomical_contrast), 'source_file'),
+        ]),
         (about, ds_report_about, [('out_report', 'in_file')])
-    ])
+    ])  # fmt:skip
 
     if anat_only:
         return workflow
@@ -661,12 +662,14 @@ to workflows in *QSIPrep*'s documentation]\
                 omp_nthreads=omp_nthreads,
                 reportlets_dir=reportlets_dir,
                 name=merged_group.replace('-', '_') + "_final_merge_wf")
+
             workflow.connect([
                 (anat_preproc_wf, merging_group_workflows[merged_group], [
                     ('outputnode.t1_brain', 'inputnode.t1_brain'),
                     ('outputnode.t1_seg', 'inputnode.t1_seg'),
-                    ('outputnode.t1_mask', 'inputnode.t1_mask')])
-            ])
+                    ('outputnode.t1_mask', 'inputnode.t1_mask'),
+                ]),
+            ])  # fmt:skip
 
     outputs_to_files = {dwi_group['concatenated_bids_name']: dwi_group
                         for dwi_group in dwi_fmap_groups}
@@ -699,13 +702,11 @@ to workflows in *QSIPrep*'s documentation]\
                 ('outputnode.t1_seg', 'inputnode.t1_seg'),
                 ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
                 ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
-                ('outputnode.t1_2_mni_forward_transform',
-                 'inputnode.t1_2_mni_forward_transform'),
-                ('outputnode.t1_2_mni_reverse_transform',
-                 'inputnode.t1_2_mni_reverse_transform'),
-                ('outputnode.dwi_sampling_grid',
-                 'inputnode.dwi_sampling_grid')])
-        ])
+                ('outputnode.t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform'),
+                ('outputnode.t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
+                ('outputnode.dwi_sampling_grid', 'inputnode.dwi_sampling_grid'),
+            ]),
+        ])  # fmt:skip
 
     # create a processing pipeline for the dwis in each session
     for output_fname, dwi_info in outputs_to_files.items():
@@ -764,79 +765,69 @@ to workflows in *QSIPrep*'s documentation]\
             write_derivatives=not merging_distortion_groups)
 
         workflow.connect([
-            (
-                anat_preproc_wf,
-                dwi_preproc_wf,
-                [
-                    ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
-                    ('outputnode.t1_brain', 'inputnode.t1_brain'),
-                    ('outputnode.t1_mask', 'inputnode.t1_mask'),
-                    ('outputnode.t1_seg', 'inputnode.t1_seg'),
-                    ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
-                    ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
-                    ('outputnode.t1_2_mni_forward_transform',
-                     'inputnode.t1_2_mni_forward_transform'),
-                    ('outputnode.t1_2_mni_reverse_transform',
-                     'inputnode.t1_2_mni_reverse_transform'),
-                    ('outputnode.dwi_sampling_grid',
-                     'inputnode.dwi_sampling_grid'),
-                    ('outputnode.t2w_unfatsat', 'inputnode.t2w_unfatsat'),
-                ]),
-            (
-                anat_preproc_wf,
-                dwi_finalize_wf,
-                [
-                    ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
-                    ('outputnode.t1_brain', 'inputnode.t1_brain'),
-                    ('outputnode.t1_mask', 'inputnode.t1_mask'),
-                    ('outputnode.t1_seg', 'inputnode.t1_seg'),
-                    ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
-                    ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
-                    ('outputnode.t1_2_mni_forward_transform',
-                     'inputnode.t1_2_mni_forward_transform'),
-                    ('outputnode.t1_2_mni_reverse_transform',
-                     'inputnode.t1_2_mni_reverse_transform'),
-                    ('outputnode.dwi_sampling_grid',
-                     'inputnode.dwi_sampling_grid'),
-                ]),
-            (
-                dwi_preproc_wf,
-                dwi_finalize_wf,
-                [
-                    ('outputnode.dwi_files', 'inputnode.dwi_files'),
-                    ('outputnode.cnr_map', 'inputnode.cnr_map'),
-                    ('outputnode.bval_files', 'inputnode.bval_files'),
-                    ('outputnode.bvec_files', 'inputnode.bvec_files'),
-                    ('outputnode.b0_ref_image', 'inputnode.b0_ref_image'),
-                    ('outputnode.b0_indices', 'inputnode.b0_indices'),
-                    ('outputnode.hmc_xforms', 'inputnode.hmc_xforms'),
-                    ('outputnode.fieldwarps', 'inputnode.fieldwarps'),
-                    ('outputnode.itk_b0_to_t1', 'inputnode.itk_b0_to_t1'),
-                    ('outputnode.hmc_optimization_data', 'inputnode.hmc_optimization_data'),
-                    ('outputnode.raw_qc_file', 'inputnode.raw_qc_file'),
-                    ('outputnode.coreg_score', 'inputnode.coreg_score'),
-                    ('outputnode.raw_concatenated', 'inputnode.raw_concatenated'),
-                    ('outputnode.confounds', 'inputnode.confounds'),
-                    ('outputnode.carpetplot_data', 'inputnode.carpetplot_data'),
-                    ('outputnode.sdc_scaling_images', 'inputnode.sdc_scaling_images')
-                    ])
-        ])
+            (anat_preproc_wf, dwi_preproc_wf, [
+                ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
+                ('outputnode.t1_brain', 'inputnode.t1_brain'),
+                ('outputnode.t1_mask', 'inputnode.t1_mask'),
+                ('outputnode.t1_seg', 'inputnode.t1_seg'),
+                ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
+                ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
+                ('outputnode.t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform'),
+                ('outputnode.t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
+                ('outputnode.dwi_sampling_grid', 'inputnode.dwi_sampling_grid'),
+                ('outputnode.t2w_unfatsat', 'inputnode.t2w_unfatsat'),
+            ]),
+            (anat_preproc_wf, dwi_finalize_wf, [
+                ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
+                ('outputnode.t1_brain', 'inputnode.t1_brain'),
+                ('outputnode.t1_mask', 'inputnode.t1_mask'),
+                ('outputnode.t1_seg', 'inputnode.t1_seg'),
+                ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
+                ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
+                ('outputnode.t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform'),
+                ('outputnode.t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
+                ('outputnode.dwi_sampling_grid', 'inputnode.dwi_sampling_grid'),
+            ]),
+            (dwi_preproc_wf, dwi_finalize_wf, [
+                ('outputnode.dwi_files', 'inputnode.dwi_files'),
+                ('outputnode.cnr_map', 'inputnode.cnr_map'),
+                ('outputnode.bval_files', 'inputnode.bval_files'),
+                ('outputnode.bvec_files', 'inputnode.bvec_files'),
+                ('outputnode.b0_ref_image', 'inputnode.b0_ref_image'),
+                ('outputnode.b0_indices', 'inputnode.b0_indices'),
+                ('outputnode.hmc_xforms', 'inputnode.hmc_xforms'),
+                ('outputnode.fieldwarps', 'inputnode.fieldwarps'),
+                ('outputnode.itk_b0_to_t1', 'inputnode.itk_b0_to_t1'),
+                ('outputnode.hmc_optimization_data', 'inputnode.hmc_optimization_data'),
+                ('outputnode.raw_qc_file', 'inputnode.raw_qc_file'),
+                ('outputnode.coreg_score', 'inputnode.coreg_score'),
+                ('outputnode.raw_concatenated', 'inputnode.raw_concatenated'),
+                ('outputnode.confounds', 'inputnode.confounds'),
+                ('outputnode.carpetplot_data', 'inputnode.carpetplot_data'),
+                ('outputnode.sdc_scaling_images', 'inputnode.sdc_scaling_images'),
+            ]),
+        ])  # fmt:skip
 
         if make_intramodal_template:
             input_name = 'inputnode.{name}_b0_template'.format(name=output_wfname)
             output_name = 'outputnode.{name}_transform'.format(name=output_wfname)
             workflow.connect([
                 (dwi_preproc_wf, intramodal_template_wf, [
-                    ('outputnode.b0_ref_image', input_name)]),
+                    ('outputnode.b0_ref_image', input_name),
+                ]),
                 (intramodal_template_wf, dwi_finalize_wf, [
                     (output_name, 'inputnode.b0_to_intramodal_template_transforms'),
-                    ('outputnode.intramodal_template_to_t1_affine',
-                     'inputnode.intramodal_template_to_t1_affine'),
-                    ('outputnode.intramodal_template_to_t1_warp',
-                     'inputnode.intramodal_template_to_t1_warp'),
-                    ('outputnode.intramodal_template',
-                     'inputnode.intramodal_template')])
-            ])
+                    (
+                        'outputnode.intramodal_template_to_t1_affine',
+                        'inputnode.intramodal_template_to_t1_affine',
+                    ),
+                    (
+                        'outputnode.intramodal_template_to_t1_warp',
+                        'inputnode.intramodal_template_to_t1_warp',
+                    ),
+                    ('outputnode.intramodal_template', 'inputnode.intramodal_template'),
+                ]),
+            ])  # fmt:skip
 
         if merging_distortion_groups:
             image_name = 'inputnode.{name}_image'.format(name=output_wfname)
@@ -859,15 +850,16 @@ to workflows in *QSIPrep*'s documentation]\
                     ('outputnode.bvecs_t1', bvec_name),
                     ('outputnode.dwi_t1', image_name),
                     ('outputnode.t1_b0_ref', b0_ref_name),
-                    ('outputnode.cnr_map_t1', cnr_name)
-                    ]),
+                    ('outputnode.cnr_map_t1', cnr_name),
+                ]),
                 (dwi_preproc_wf, final_merge_wf, [
                     ('outputnode.raw_concatenated', raw_concatenated_image_name),
                     ('outputnode.original_bvecs', original_bvec_name),
                     ('outputnode.original_files', original_bids_name),
                     ('outputnode.carpetplot_data', carpetplot_name),
-                    ('outputnode.confounds', confounds_name)])
-            ])
+                    ('outputnode.confounds', confounds_name),
+                ])
+            ])  # fmt:skip
 
     return workflow
 

--- a/tests/smoke_tests.py
+++ b/tests/smoke_tests.py
@@ -6,173 +6,160 @@ from qsiprep.workflows.base import init_qsiprep_wf
 @pytest.mark.smoke
 def test_preproc_pepolar_sdc(tmp_path):
     # Get the empty bids data
-    bids_root = pkgrf('qsiprep', 'data/abcd')
+    bids_root = pkgrf("qsiprep", "data/abcd")
     work_dir = str(tmp_path.absolute() / "preproc_pepolar_sdc_work")
     output_dir = str(tmp_path.absolute() / "preproc_pepolar_sdc_output")
     bids_dir = bids_root
-    subject_list = ['abcd']
-    wf = init_qsiprep_wf(subject_list=subject_list,
-                         run_uuid="test",
-                         work_dir=work_dir,
-                         output_dir=output_dir,
-                         bids_dir=bids_dir,
-                         ignore=[],
-                         debug=False,
-                         low_mem=False,
-                         anat_only=False,
-                         longitudinal=False,
-                         freesurfer=False,
-                         hires=False,
-                         force_spatial_normalization=False,
-                         denoise_before_combining=True,
-                         dwi_denoise_window=7,
-                         combine_all_dwis=True,
-                         omp_nthreads=1,
-                         skull_strip_template='OASIS',
-                         skull_strip_fixed_seed=False,
-                         output_spaces=['T1w', 'template'],
-                         template='MNI152NLin2009cAsym',
-                         output_resolution=1.25,
-                         motion_corr_to='iterative',
-                         b0_to_t1w_transform='Rigid',
-                         hmc_transform='Affine',
-                         hmc_model='3dSHORE',
-                         impute_slice_threshold=0,
-                         write_local_bvecs=False,
-                         fmap_bspline=False,
-                         fmap_demean=True,
-                         use_syn=False,
-                         prefer_dedicated_fmaps=True,
-                         force_syn=False)
+    subject_list = ["abcd"]
+    wf = init_qsiprep_wf(
+        subject_list=subject_list,
+        run_uuid="test",
+        work_dir=work_dir,
+        output_dir=output_dir,
+        bids_dir=bids_dir,
+        ignore=[],
+        debug=False,
+        low_mem=False,
+        anat_only=False,
+        longitudinal=False,
+        force_spatial_normalization=False,
+        denoise_before_combining=True,
+        dwi_denoise_window=7,
+        combine_all_dwis=True,
+        omp_nthreads=1,
+        output_spaces=["T1w", "template"],
+        template="MNI152NLin2009cAsym",
+        output_resolution=1.25,
+        motion_corr_to="iterative",
+        b0_to_t1w_transform="Rigid",
+        hmc_transform="Affine",
+        hmc_model="3dSHORE",
+        impute_slice_threshold=0,
+        write_local_bvecs=False,
+        fmap_bspline=False,
+        fmap_demean=True,
+        force_syn=False,
+    )
 
     assert len(wf.list_node_names())
+
 
 @pytest.mark.smoke
 def test_preproc_syn_sdc(tmp_path):
     # Get the empty bids data
-    bids_root = pkgrf('qsiprep', 'data/abcd')
+    bids_root = pkgrf("qsiprep", "data/abcd")
     work_dir = str(tmp_path.absolute() / "preproc_syn_sdc_work")
     output_dir = str(tmp_path.absolute() / "preproc_syn_sdc_output")
     bids_dir = bids_root
-    subject_list = ['abcd']
-    wf = init_qsiprep_wf(subject_list=subject_list,
-                         run_uuid="test",
-                         work_dir=work_dir,
-                         output_dir=output_dir,
-                         bids_dir=bids_dir,
-                         ignore=[],
-                         debug=False,
-                         low_mem=False,
-                         anat_only=False,
-                         longitudinal=False,
-                         freesurfer=False,
-                         hires=False,
-                         denoise_before_combining=True,
-                         dwi_denoise_window=7,
-                         combine_all_dwis=True,
-                         omp_nthreads=1,
-                         skull_strip_template='OASIS',
-                         force_spatial_normalization=False,
-                         skull_strip_fixed_seed=False,
-                         output_spaces=['T1w', 'template'],
-                         template='MNI152NLin2009cAsym',
-                         output_resolution=1.25,
-                         motion_corr_to='iterative',
-                         b0_to_t1w_transform='Rigid',
-                         hmc_transform='Affine',
-                         hmc_model='3dSHORE',
-                         impute_slice_threshold=0,
-                         write_local_bvecs=False,
-                         fmap_bspline=False,
-                         fmap_demean=True,
-                         use_syn=True,
-                         prefer_dedicated_fmaps=False,
-                         force_syn=True)
+    subject_list = ["abcd"]
+    wf = init_qsiprep_wf(
+        subject_list=subject_list,
+        run_uuid="test",
+        work_dir=work_dir,
+        output_dir=output_dir,
+        bids_dir=bids_dir,
+        ignore=[],
+        debug=False,
+        low_mem=False,
+        anat_only=False,
+        longitudinal=False,
+        denoise_before_combining=True,
+        dwi_denoise_window=7,
+        combine_all_dwis=True,
+        omp_nthreads=1,
+        force_spatial_normalization=False,
+        output_spaces=["T1w", "template"],
+        template="MNI152NLin2009cAsym",
+        output_resolution=1.25,
+        motion_corr_to="iterative",
+        b0_to_t1w_transform="Rigid",
+        hmc_transform="Affine",
+        hmc_model="3dSHORE",
+        impute_slice_threshold=0,
+        write_local_bvecs=False,
+        fmap_bspline=False,
+        fmap_demean=True,
+        force_syn=True,
+    )
     assert len(wf.list_node_names())
+
 
 @pytest.mark.smoke
 def test_preproc_nonehmc_sdc(tmp_path):
     # Get the empty bids data
-    bids_root = pkgrf('qsiprep', 'data/abcd')
+    bids_root = pkgrf("qsiprep", "data/abcd")
     work_dir = str(tmp_path.absolute() / "preproc_nonehmc_work")
     output_dir = str(tmp_path.absolute() / "preproc_nonehmc_output")
     bids_dir = bids_root
-    subject_list = ['abcd']
-    wf = init_qsiprep_wf(subject_list=subject_list,
-                         run_uuid="test",
-                         work_dir=work_dir,
-                         output_dir=output_dir,
-                         bids_dir=bids_dir,
-                         ignore=[],
-                         debug=False,
-                         low_mem=False,
-                         anat_only=False,
-                         longitudinal=False,
-                         freesurfer=False,
-                         hires=False,
-                         denoise_before_combining=True,
-                         dwi_denoise_window=7,
-                         combine_all_dwis=True,
-                         omp_nthreads=1,
-                         skull_strip_template='OASIS',
-                         skull_strip_fixed_seed=False,
-                         output_spaces=['T1w', 'template'],
-                         force_spatial_normalization=False,
-                         template='MNI152NLin2009cAsym',
-                         output_resolution=1.25,
-                         motion_corr_to='iterative',
-                         b0_to_t1w_transform='Rigid',
-                         hmc_transform='Affine',
-                         hmc_model='none',
-                         impute_slice_threshold=0,
-                         write_local_bvecs=False,
-                         fmap_bspline=False,
-                         fmap_demean=True,
-                         use_syn=False,
-                         prefer_dedicated_fmaps=False,
-                         force_syn=False)
+    subject_list = ["abcd"]
+    wf = init_qsiprep_wf(
+        subject_list=subject_list,
+        run_uuid="test",
+        work_dir=work_dir,
+        output_dir=output_dir,
+        bids_dir=bids_dir,
+        ignore=[],
+        debug=False,
+        low_mem=False,
+        anat_only=False,
+        longitudinal=False,
+        denoise_before_combining=True,
+        dwi_denoise_window=7,
+        combine_all_dwis=True,
+        omp_nthreads=1,
+        output_spaces=["T1w", "template"],
+        force_spatial_normalization=False,
+        template="MNI152NLin2009cAsym",
+        output_resolution=1.25,
+        motion_corr_to="iterative",
+        b0_to_t1w_transform="Rigid",
+        hmc_transform="Affine",
+        hmc_model="none",
+        impute_slice_threshold=0,
+        write_local_bvecs=False,
+        fmap_bspline=False,
+        fmap_demean=True,
+        force_syn=False,
+    )
     assert len(wf.list_node_names())
+
 
 @pytest.mark.smoke
 def test_preproc_buds(tmp_path):
     # Get the empty bids data
-    bids_root = pkgrf('qsiprep', 'data/buds')
+    bids_root = pkgrf("qsiprep", "data/buds")
     work_dir = str(tmp_path.absolute() / "preproc_buds_work")
     output_dir = str(tmp_path.absolute() / "preproc_buds_output")
     bids_dir = bids_root
-    subject_list = ['1']
+    subject_list = ["1"]
 
-    wf = init_qsiprep_wf(subject_list=subject_list,
-                         run_uuid="test",
-                         work_dir=work_dir,
-                         output_dir=output_dir,
-                         bids_dir=bids_dir,
-                         ignore=[],
-                         debug=False,
-                         low_mem=False,
-                         anat_only=False,
-                         longitudinal=False,
-                         freesurfer=False,
-                         hires=False,
-                         denoise_before_combining=True,
-                         force_spatial_normalization=False,
-                         dwi_denoise_window=7,
-                         combine_all_dwis=True,
-                         omp_nthreads=1,
-                         skull_strip_template='OASIS',
-                         skull_strip_fixed_seed=False,
-                         output_spaces=['T1w', 'template'],
-                         template='MNI152NLin2009cAsym',
-                         output_resolution=1.25,
-                         motion_corr_to='iterative',
-                         b0_to_t1w_transform='Rigid',
-                         hmc_transform='Affine',
-                         hmc_model='none',
-                         impute_slice_threshold=0,
-                         write_local_bvecs=False,
-                         fmap_bspline=False,
-                         fmap_demean=True,
-                         use_syn=False,
-                         prefer_dedicated_fmaps=False,
-                         force_syn=False)
+    wf = init_qsiprep_wf(
+        subject_list=subject_list,
+        run_uuid="test",
+        work_dir=work_dir,
+        output_dir=output_dir,
+        bids_dir=bids_dir,
+        ignore=[],
+        debug=False,
+        low_mem=False,
+        anat_only=False,
+        longitudinal=False,
+        denoise_before_combining=True,
+        force_spatial_normalization=False,
+        dwi_denoise_window=7,
+        combine_all_dwis=True,
+        omp_nthreads=1,
+        output_spaces=["T1w", "template"],
+        template="MNI152NLin2009cAsym",
+        output_resolution=1.25,
+        motion_corr_to="iterative",
+        b0_to_t1w_transform="Rigid",
+        hmc_transform="Affine",
+        hmc_model="none",
+        impute_slice_threshold=0,
+        write_local_bvecs=False,
+        fmap_bspline=False,
+        fmap_demean=True,
+        force_syn=False,
+    )
     assert len(wf.list_node_names())


### PR DESCRIPTION
Closes none, but relates to the hackathon we're planning.

## Changes proposed in this pull request

- Add `# fmt:skip` comments to the ends of `workflow.connect` calls, which will make any autoformatters and linters skip those calls. This will keep black (or whatever autoformatter we want) from messing up workflow connections, which are typically pretty ugly post-auto-formatting.
- Run black and isort on the file.
- Make minor changes to the docstrings.
- Remove an unused import.
- Remove unused parameters from `init_single_subject_wf`: skull_strip_template, skull_strip_fixed_seed, freesurfer, hires, prefer_dedicated_fmaps, and use_syn.
    - I also removed the parameters from `init_qsiprep_wf` and added `(IGNORED)` to the descriptions of the related command line arguments.

