### PR TITLE
[ENH] Add ReconScalars node to recon workflows

### DIFF
--- a/.circleci/ScalarMapper.sh
+++ b/.circleci/ScalarMapper.sh
@@ -18,7 +18,7 @@ source ./get_data.sh
 TESTDIR=${PWD}
 TESTNAME=scalar_mapper_test
 get_config_data ${TESTDIR}
-#get_bids_data ${TESTDIR} multishell_output
+get_bids_data ${TESTDIR} multishell_output
 CFG=${TESTDIR}/data/nipype.cfg
 
 # Test MRtrix3 multishell msmt with ACT

--- a/.circleci/ScalarMapper.sh
+++ b/.circleci/ScalarMapper.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+cat << DOC
+
+Test the TORTOISE recon workflow
+=================================
+
+All supported reconstruction workflows get tested
+
+
+Inputs:
+-------
+ - qsiprep multi shell results (data/DSDTI_fmap)
+
+DOC
+set +e
+source ./get_data.sh
+TESTDIR=${PWD}
+TESTNAME=scalar_mapper_test
+get_config_data ${TESTDIR}
+#get_bids_data ${TESTDIR} multishell_output
+CFG=${TESTDIR}/data/nipype.cfg
+
+# Test MRtrix3 multishell msmt with ACT
+setup_dir ${TESTDIR}/${TESTNAME}
+TEMPDIR=${TESTDIR}/${TESTNAME}/work
+OUTPUT_DIR=${TESTDIR}/${TESTNAME}/derivatives
+BIDS_INPUT_DIR=${TESTDIR}/data/multishell_output/qsiprep
+export FS_LICENSE=${TESTDIR}/data/license.txt
+QSIPREP_CMD=$(run_qsiprep_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR})
+
+${QSIPREP_CMD} \
+   -w ${TEMPDIR} \
+	--recon-input ${BIDS_INPUT_DIR} \
+	--sloppy \
+    --stop-on-first-crash \
+	--recon-spec bundle_scalar_map \
+	--recon-only \
+	-vv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,18 @@ jobs:
             cd .circleci
             bash PyAFQReconExternalTrk.sh
 
+  Recon_ScalarMap:
+    <<: *dockersetup
+    steps:
+      - checkout
+      - run: *runinstall
+      - run:
+          name: Test scalar_mapping workflow
+          no_output_timeout: 1h
+          command: |
+            cd .circleci
+            bash ScalarMapper.sh
+
   Recon_AMICO:
     <<: *dockersetup
     resource_class: medium+
@@ -319,7 +331,7 @@ jobs:
               echo "the command ``git fetch --tags --verbose`` and push"
               echo "them to your fork with ``git push origin --tags``"
             fi
-            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" wrapper/qsiprep_docker.py
+            sed -i -E "s/(__version__ = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" wrapper/qsiprep-container/qsiprep_docker.py
             sed -i -E "s/(var version = )'[A-Za-z0-9.-]+'/\1'${CIRCLE_TAG:-$THISVERSION}'/" docs/citing.rst
             sed -i "s/title = {qsiprep}/title = {qsiprep ${CIRCLE_TAG:-$THISVERSION}}/" qsiprep/data/boilerplate.bib
             # Build docker image
@@ -609,6 +621,13 @@ workflows:
             tags:
               only: /.*/
 
+      - Recon_ScalarMap:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+
       - deployable:
           requires:
             - build_docs
@@ -630,6 +649,7 @@ workflows:
             - Recon_AMICO
             - Recon_PYAFQ
             - Recon_PYAFQExternalTrk
+            - Recon_ScalarMap
           filters:
             branches:
               only: master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "matplotlib",
     "networkx ~= 2.8.8",
     "nibabel >= 3.0.0",
-    "nilearn >= 0.10.1",
+    "nilearn == 0.10.1",
     "nipype >= 1.3.1",
     "numpy >= 1.18.5",
     "pandas < 2.0.0",

--- a/qsiprep/data/pipelines/bundle_scalar_map.json
+++ b/qsiprep/data/pipelines/bundle_scalar_map.json
@@ -1,0 +1,67 @@
+{
+  "name": "bundle_scalar_map",
+  "space" : "T1w",
+  "atlases": [ ],
+  "anatomical": [ ],
+  "nodes": [
+    {
+      "name": "DIPYdki",
+      "software": "Dipy",
+      "action": "DKI_reconstruction",
+      "input": "qsiprep",
+      "output_suffix": "DKI",
+      "parameters": {
+        "write_mif": false,
+        "write_fibgz": false
+      }
+    },
+    {
+      "name": "amiconoddi",
+      "action": "fit_noddi",
+      "software": "AMICO",
+      "input": "qsiprep",
+      "output_suffix": "wmNODDI",
+      "parameters": {
+        "isExvivo": false,
+        "dPar": 1.7E-3,
+        "dIso": 3.0E-3
+      }
+    },
+    {
+      "name": "dsistudio_gqi",
+      "software": "DSI Studio",
+      "action": "reconstruction",
+      "input": "qsiprep",
+      "output_suffix": "gqi",
+      "parameters": {"method": "gqi"}
+    },
+    {
+      "name": "autotrackgqi",
+      "software": "DSI Studio",
+      "action": "autotrack",
+      "input": "dsistudio_gqi",
+      "output_suffix": "AutoTrackGQI",
+      "parameters": {
+        "track_id": "Fasciculus,Cingulum,Aslant,Corticos,Thalamic_R,Reticular,Optic,Fornix,Corpus",
+        "tolerance": "22,26,30",
+        "track_voxel_ratio": 2.0,
+        "yield_rate": 0.000001
+      }
+    },
+    {
+      "name": "gqi_scalars",
+      "software": "DSI Studio",
+      "action": "export",
+      "input": "dsistudio_gqi",
+      "output_suffix": "gqiscalar"
+    },
+    {
+      "name": "bundle_means",
+      "software": "qsiprep",
+      "action": "bundle_map",
+      "input": "autotrackgqi",
+      "scalars_from": ["gqi_scalars", "amiconoddi", "DIPYdki"],
+      "output_suffix": "bundlemap"
+    }
+  ]
+}

--- a/qsiprep/data/pipelines/bundle_scalar_map.json
+++ b/qsiprep/data/pipelines/bundle_scalar_map.json
@@ -16,18 +16,6 @@
       }
     },
     {
-      "name": "amiconoddi",
-      "action": "fit_noddi",
-      "software": "AMICO",
-      "input": "qsiprep",
-      "output_suffix": "wmNODDI",
-      "parameters": {
-        "isExvivo": false,
-        "dPar": 1.7E-3,
-        "dIso": 3.0E-3
-      }
-    },
-    {
       "name": "dsistudio_gqi",
       "software": "DSI Studio",
       "action": "reconstruction",
@@ -60,7 +48,7 @@
       "software": "qsiprep",
       "action": "bundle_map",
       "input": "autotrackgqi",
-      "scalars_from": ["gqi_scalars", "amiconoddi", "DIPYdki"],
+      "scalars_from": ["gqi_scalars", "DIPYdki"],
       "output_suffix": "bundlemap"
     }
   ]

--- a/qsiprep/interfaces/interchange.py
+++ b/qsiprep/interfaces/interchange.py
@@ -48,6 +48,7 @@ class _ReconWorkflowInputsInputSpec(BaseInterfaceInputSpec):
 class _ReconWorkflowInputsOutputSpec(TraitedSpec):
     pass
 
+
 class ReconWorkflowInputs(SimpleInterface):
     input_spec = _ReconWorkflowInputsInputSpec
     output_spec = _ReconWorkflowInputsOutputSpec
@@ -84,3 +85,27 @@ class ReconAnatomicalData(SimpleInterface):
 for name in anatomical_workflow_outputs:
     _ReconAnatomicalDataInputSpec.add_class_trait(name, traits.Any)
     _ReconAnatomicalDataOutputSpec.add_class_trait(name, traits.Any)
+
+
+def get_scalar_data_gatherer(nodes):
+    class _ReconScalarDataInputSpec(BaseInterfaceInputSpec):
+        pass
+
+
+    class _ReconScalarDataOutputSpec(TraitedSpec):
+        recon_scalars = traits.List()
+
+
+    class ReconScalarData(SimpleInterface):
+        input_spec = _ReconScalarDataInputSpec
+        output_spec = _ReconScalarDataOutputSpec
+
+        def _run_interface(self, runtime):
+            inputs = self.inputs.get()
+            for name in anatomical_workflow_outputs:
+                self._results[name] = inputs.get(name)
+            return runtime
+    for node in nodes:
+        _ReconScalarDataInputSpec.add_class_trait(node["name"], traits.Any)
+
+    return ReconScalarData

--- a/qsiprep/interfaces/interchange.py
+++ b/qsiprep/interfaces/interchange.py
@@ -85,27 +85,3 @@ class ReconAnatomicalData(SimpleInterface):
 for name in anatomical_workflow_outputs:
     _ReconAnatomicalDataInputSpec.add_class_trait(name, traits.Any)
     _ReconAnatomicalDataOutputSpec.add_class_trait(name, traits.Any)
-
-
-def get_scalar_data_gatherer(nodes):
-    class _ReconScalarDataInputSpec(BaseInterfaceInputSpec):
-        pass
-
-
-    class _ReconScalarDataOutputSpec(TraitedSpec):
-        recon_scalars = traits.List()
-
-
-    class ReconScalarData(SimpleInterface):
-        input_spec = _ReconScalarDataInputSpec
-        output_spec = _ReconScalarDataOutputSpec
-
-        def _run_interface(self, runtime):
-            inputs = self.inputs.get()
-            for name in anatomical_workflow_outputs:
-                self._results[name] = inputs.get(name)
-            return runtime
-    for node in nodes:
-        _ReconScalarDataInputSpec.add_class_trait(node["name"], traits.Any)
-
-    return ReconScalarData

--- a/qsiprep/interfaces/recon_scalars.py
+++ b/qsiprep/interfaces/recon_scalars.py
@@ -110,3 +110,27 @@ for input_name in tortoise_scalars:
 class TORTOISEReconScalars(ReconScalars):
     input_spec = _TORTOISEReconScalarInputSpec
     scalar_metadata = tortoise_scalars
+
+
+# Scalars produced in the AMICO recon workflow
+amico_scalars = {
+    "icvf_image": {
+        "desc": "Intracellular volume fraction from NODDI"
+    },
+    "isovf_image": {
+        "desc": "Isotropic volume fraction from NODDI"
+    },
+    "od_image": {
+        "desc": "OD from NODDI"
+    }
+}
+
+class _AMICOReconScalarInputSpec(ReconScalarsInputSpec):
+    pass
+
+for input_name in tortoise_scalars:
+    _AMICOReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
+
+class AMICOReconScalars(ReconScalars):
+    input_spec = _AMICOReconScalarInputSpec
+    scalar_metadata = amico_scalars

--- a/qsiprep/interfaces/recon_scalars.py
+++ b/qsiprep/interfaces/recon_scalars.py
@@ -58,7 +58,7 @@ class ReconScalars(SimpleInterface):
             result = self.scalar_metadata[input_name].copy()
             result["path"] = op.abspath(inputs[input_name])
             result["workflow_name"] = self.inputs.workflow_name
-            result["variable_name"] = self.inputs.workflow_name + "_" + input_name
+            result["variable_name"] = input_name
             results.append(result)
         self._results["scalar_info"] = results
         return runtime

--- a/qsiprep/interfaces/recon_scalars.py
+++ b/qsiprep/interfaces/recon_scalars.py
@@ -211,5 +211,116 @@ class DSIStudioReconScalars(ReconScalars):
 
 
 dipy_dki_scalars = {
-
+    'fa': {
+        "desc": "DKI FA"
+    },
+    'md': {
+        "desc": "DKI MD"
+    },
+    'rd': {
+        "desc": "DKI RD"
+    },
+    'ad': {
+        "desc": "DKI AD"
+    },
+    'kfa': {
+        "desc": "DKI KFA"
+    },
+    'mk': {
+        "desc": "DKI MK"
+    },
+    'ak': {
+        "desc": "DKI AK"
+    },
+    'rk': {
+        "desc": "DKI RK"
+    },
+    'mkt': {
+        "desc": "DKI MKT"
+    }
 }
+class _DIPYDKIReconScalarInputSpec(ReconScalarsInputSpec):
+    pass
+
+for input_name in dipydki_scalars:
+    _DIPYDKIScalarInputSpec.add_class_trait(input_name, File(exists=True))
+
+class DIPYDKIReconScalars(ReconScalars):
+    input_spec = _DIPYDKIReconScalarInputSpec
+    scalar_metadata = dipy_dki_scalars
+
+
+# DIPY implementation of MAPMRI
+dipy_mapmri_scalars = {
+    "qiv_file": {
+        "desc": "q-space inverse variance from MAPMRI"
+    },
+    "msd_file": {
+        "desc": "mean square displacement from MAPMRI"
+    },
+    "lapnorm_file": {
+        "desc": "Laplacian norm from regularized MAPMRI (MAPL)"
+    },
+    "rtop_file": {
+        "desc": "Return to origin probability from MAPMRI"
+    },
+    "rtap_file": {
+        "desc": "Return to axis probability from MAPMRI"
+    },
+    "rtpp_file": {
+        "desc": "Return to plane probability from MAPMRI"
+    },
+    "ng_file": {
+        "desc": "Non-Gaussianity from MAPMRI"
+    },
+    "ngpar_file": {
+        "desc": "Non-Gaussianity parallel from MAPMRI"
+    },
+    "ngperp_file": {
+        "desc": "Non-Gaussianity perpendicular from MAPMRI"
+    },
+}
+
+
+class _DIPYMAPMRIReconScalarInputSpec(ReconScalarsInputSpec):
+    pass
+
+
+for input_name in dipy_mapmri_scalars:
+    _DIPYMAPMRIReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
+
+
+class DIPYMAPMRIReconScalars(ReconScalars):
+    input_spec = _DIPYMAPMRIReconScalarInputSpec
+    scalar_metadata = dipy_mapmri_scalars
+
+
+# Same as DIPY implementation of 3dSHORE, but with brainsuite bases
+brainsuite_3dshore_scalars = dipy_mapmri_scalars.copy()
+brainsuite_3dshore_scalars.update({
+    "cnr_image": {
+        "desc": "Contrast to noise ratio for 3dSHORE fit"
+    },
+    "alpha_image": {
+        "desc": "alpha used when fitting in each voxel"
+    },
+    "r2_image": {
+        "desc": "r^2 of the 3dSHORE fit"
+    },
+    "regularization_image": {
+        "desc": "regularization of the 3dSHORE fit"
+    },
+})
+
+
+class _BrainSuite3dSHOREReconScalarInputSpec(ReconScalarsInputSpec):
+    pass
+
+
+for input_name in brainsuite_3dshore_scalars:
+    _BrainSuite3dSHOREReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
+
+
+class BrainSuite3dSHOREReconScalars(ReconScalars):
+    input_spec = _BrainSuite3dSHOREReconScalarInputSpec
+    scalar_metadata = brainsuite_3dshore_scalars

--- a/qsiprep/interfaces/recon_scalars.py
+++ b/qsiprep/interfaces/recon_scalars.py
@@ -23,8 +23,7 @@ class ReconScalars(SimpleInterface):
     input_spec = ReconScalarsInputSpec
     output_spec = ReconScalarsOutputSpec
     scalar_metadata = {}
-    _ignore_traits = ("workflow_name")
-
+    _ignore_traits = ("workflow_name", "scalar_metadata")
     def __init__(self, from_file=None, resource_monitor=None, **inputs):
 
         # Get self._results defined
@@ -128,9 +127,89 @@ amico_scalars = {
 class _AMICOReconScalarInputSpec(ReconScalarsInputSpec):
     pass
 
-for input_name in tortoise_scalars:
+for input_name in amico_scalars:
     _AMICOReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
 
 class AMICOReconScalars(ReconScalars):
     input_spec = _AMICOReconScalarInputSpec
     scalar_metadata = amico_scalars
+
+
+# Scalars produced by DSI Studio
+dsistudio_scalars = {
+    "qa_file": {
+        "desc": "Fractional Anisotropy from a tensor fit"
+    },
+    "dti_fa_file": {
+        "desc": "Radial Diffusivity from a tensor fit"
+    },
+    "txx_file": {
+        "desc": "Tensor fit txx"
+    },
+    "txy_file": {
+        "desc": "Tensor fit txy"
+    },
+    "txz_file": {
+        "desc": "Tensor fit txz"
+    },
+    "tyy_file": {
+        "desc": "Tensor fit tyy"
+    },
+    "tyz_file": {
+        "desc": "Tensor fit tyz"
+    },
+    "tzz_file": {
+        "desc": "Tensor fit tzz"
+    },
+    "rd1_file": {
+        "desc": "RD1"
+    },
+    "rd2_file": {
+        "desc": "RD2"
+    },
+    "ha_file": {
+        "desc": "HA"
+    },
+    "md_file": {
+        "desc": "Mean Diffusivity"
+    },
+    "ad_file": {
+        "desc": "AD"
+    },
+    "rd_file": {
+        "desc": "Radial Diffusivity"
+    },
+    "gfa_file": {
+        "desc": "Generalized Fractional Anisotropy"
+    },
+    "iso_file": {
+        "desc": "Isotropic Diffusion"
+    },
+    "rdi_file": {
+        "desc": "RDI"
+    },
+    "nrdi02L_file": {
+        "desc": "NRDI at 02L"
+    },
+    "nrdi04L_file": {
+        "desc": "NRDI at 04L"
+    },
+    "nrdi06L_file": {
+        "desc": "NRDI at 06L"
+    },
+}
+
+class _DSIStudioReconScalarInputSpec(ReconScalarsInputSpec):
+    pass
+
+for input_name in dsistudio_scalars:
+    _DSIStudioReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
+
+class DSIStudioReconScalars(ReconScalars):
+    input_spec = _DSIStudioReconScalarInputSpec
+    scalar_metadata = dsistudio_scalars
+
+
+dipy_dki_scalars = {
+
+}

--- a/qsiprep/interfaces/recon_scalars.py
+++ b/qsiprep/interfaces/recon_scalars.py
@@ -2,6 +2,12 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Classes that collect scalar images and metadata from Recon Workflows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+"""
 import os
 import os.path as op
 from pkg_resources import resource_filename as pkgr
@@ -51,6 +57,7 @@ class ReconScalars(SimpleInterface):
                 continue
             result = self.scalar_metadata[input_name].copy()
             result["path"] = op.abspath(inputs[input_name])
+            result["workflow_name"] = self.inputs.workflow_name
             result["variable_name"] = self.inputs.workflow_name + "_" + input_name
             results.append(result)
         self._results["scalar_info"] = results
@@ -211,39 +218,39 @@ class DSIStudioReconScalars(ReconScalars):
 
 
 dipy_dki_scalars = {
-    'fa': {
+    'dki_fa': {
         "desc": "DKI FA"
     },
-    'md': {
+    'dki_md': {
         "desc": "DKI MD"
     },
-    'rd': {
+    'dki_rd': {
         "desc": "DKI RD"
     },
-    'ad': {
+    'dki_ad': {
         "desc": "DKI AD"
     },
-    'kfa': {
+    'dki_kfa': {
         "desc": "DKI KFA"
     },
-    'mk': {
+    'dki_mk': {
         "desc": "DKI MK"
     },
-    'ak': {
+    'dki_ak': {
         "desc": "DKI AK"
     },
-    'rk': {
+    'dki_rk': {
         "desc": "DKI RK"
     },
-    'mkt': {
+    'dki_mkt': {
         "desc": "DKI MKT"
     }
 }
 class _DIPYDKIReconScalarInputSpec(ReconScalarsInputSpec):
     pass
 
-for input_name in dipydki_scalars:
-    _DIPYDKIScalarInputSpec.add_class_trait(input_name, File(exists=True))
+for input_name in dipy_dki_scalars:
+    _DIPYDKIReconScalarInputSpec.add_class_trait(input_name, File(exists=True))
 
 class DIPYDKIReconScalars(ReconScalars):
     input_spec = _DIPYDKIReconScalarInputSpec

--- a/qsiprep/interfaces/scalar_mapping.py
+++ b/qsiprep/interfaces/scalar_mapping.py
@@ -2,12 +2,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-Workflows for AMICO
-~~~~~~~~~~~~~~~~~~~
-
-
-"""
 import os
 import os.path as op
 from pkg_resources import resource_filename as pkgr
@@ -16,13 +10,15 @@ import numpy as np
 from nipype import logging
 from nipype.utils.filemanip import fname_presuffix
 from nipype.interfaces.base import (
-    traits, TraitedSpec, BaseInterfaceInputSpec, File, SimpleInterface, isdefined
+    traits, TraitedSpec, BaseInterfaceInputSpec, File, SimpleInterface, isdefined,
+    InputMultiObject
 )
 
 
 class ScalarMapperInputSpec(BaseInterfaceInputSpec):
-    scalar_filter = traits.InputMultiObject(traits.Str())
-    recon_scalars = traits.InputMultiObject(traits.Any())
+    scalars_from = InputMultiObject(traits.Str())
+    recon_scalars = InputMultiObject(traits.Any())
+    dwiref_image = File(exists=True)
 
 
 class ScalarMapperOutputSpec(TraitedSpec):
@@ -34,14 +30,15 @@ class ScalarMapper(SimpleInterface):
     output_spec = ScalarMapperOutputSpec
 
 
+# For mapping to bundles
 class _BundleMapperInputSpec(ScalarMapperInputSpec):
-    bundles = traits.InputMultiObject(
+    tck_files = InputMultiObject(
         File(exists=True),
         desc="Paths to tck files")
-    bundle_names = traits.InputMultiObject(traits.Str())
+    bundle_names = InputMultiObject(traits.Str())
 
 
-class _BundleMapperOutputSpec(ScalarMapper):
+class _BundleMapperOutputSpec(ScalarMapperOutputSpec):
     bundle_summary = File(exists=True)
     bundle_profiles = File(exists=True)
 
@@ -50,3 +47,16 @@ class BundleMapper(ScalarMapper):
     input_spec = _BundleMapperInputSpec
     output_spec = _BundleMapperOutputSpec
 
+
+# For mapping to atlases
+class _AtlasMapperInputSpec(ScalarMapperInputSpec):
+    atlas_configs = traits.Any()
+
+
+class _AtlasMapperOutputSpec(ScalarMapperOutputSpec):
+    region_stats = File(exists=True, mandatory=True)
+
+
+class AtlasMapper(ScalarMapper):
+    input_spec = _AtlasMapperInputSpec
+    output_spec = _AtlasMapperOutputSpec

--- a/qsiprep/interfaces/scalar_mapping.py
+++ b/qsiprep/interfaces/scalar_mapping.py
@@ -112,7 +112,8 @@ class BundleMapper(ScalarMapper):
             # Then get the same stats for the scalars
             for recon_scalar in self.recon_scalars:
                 bundle_dfs.append(
-                    calculate_mask_stats(bundle_masker, tck_name, "bundle", recon_scalar))
+                    calculate_mask_stats(bundle_masker, tck_name, "bundle",
+                                         recon_scalar, tdi_weights))
         self._update_with_bids_info(bundle_dfs)
         summary_file = op.join(runtime.cwd, "bundle_stats.tsv")
         summary_df = pd.DataFrame(bundle_dfs)

--- a/qsiprep/interfaces/scalar_mapping.py
+++ b/qsiprep/interfaces/scalar_mapping.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Workflows for AMICO
+~~~~~~~~~~~~~~~~~~~
+
+
+"""
+import os
+import os.path as op
+from pkg_resources import resource_filename as pkgr
+import nibabel as nb
+import numpy as np
+from nipype import logging
+from nipype.utils.filemanip import fname_presuffix
+from nipype.interfaces.base import (
+    traits, TraitedSpec, BaseInterfaceInputSpec, File, SimpleInterface, isdefined
+)
+
+
+class ScalarMapperInputSpec(BaseInterfaceInputSpec):
+    scalar_filter = traits.InputMultiObject(traits.Str())
+    recon_scalars = traits.InputMultiObject(traits.Any())
+
+
+class ScalarMapperOutputSpec(TraitedSpec):
+    mapped_scalars = traits.List(File(exists=True))
+
+
+class ScalarMapper(SimpleInterface):
+    input_spec = ScalarMapperInputSpec
+    output_spec = ScalarMapperOutputSpec
+
+
+class _BundleMapperInputSpec(ScalarMapperInputSpec):
+    bundles = traits.InputMultiObject(
+        File(exists=True),
+        desc="Paths to tck files")
+    bundle_names = traits.InputMultiObject(traits.Str())
+
+
+class _BundleMapperOutputSpec(ScalarMapper):
+    bundle_summary = File(exists=True)
+    bundle_profiles = File(exists=True)
+
+
+class BundleMapper(ScalarMapper):
+    input_spec = _BundleMapperInputSpec
+    output_spec = _BundleMapperOutputSpec
+

--- a/qsiprep/interfaces/scalar_mapping.py
+++ b/qsiprep/interfaces/scalar_mapping.py
@@ -4,6 +4,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os
 import os.path as op
+import subprocess
 from pkg_resources import resource_filename as pkgr
 import nibabel as nb
 import numpy as np
@@ -13,7 +14,10 @@ from nipype.interfaces.base import (
     traits, TraitedSpec, BaseInterfaceInputSpec, File, SimpleInterface, isdefined,
     InputMultiObject
 )
-
+import nilearn.image as nim
+from nilearn.maskers import NiftiMasker
+import pandas as pd
+from .bids import get_bids_params
 
 class ScalarMapperInputSpec(BaseInterfaceInputSpec):
     scalars_from = InputMultiObject(traits.Str())
@@ -29,6 +33,22 @@ class ScalarMapper(SimpleInterface):
     input_spec = ScalarMapperInputSpec
     output_spec = ScalarMapperOutputSpec
 
+    def _load_scalars(self):
+        self.recon_scalars = self.inputs.recon_scalars
+        for scalar_obj in self.recon_scalars:
+            scalar_obj["image"] = nim.load_img(scalar_obj["path"])
+
+    def _update_with_bids_info(self, summary_row_list):
+        # Add BIDS info to the summarized scalars
+        bids_info = get_bids_params(self.inputs.dwiref_image)
+        for summary_row in summary_row_list:
+            summary_row.update(bids_info)
+
+    def _run_interface(self, runtime):
+        self._load_scalars()
+        self._do_mapping(runtime)
+        return runtime
+
 
 # For mapping to bundles
 class _BundleMapperInputSpec(ScalarMapperInputSpec):
@@ -43,9 +63,62 @@ class _BundleMapperOutputSpec(ScalarMapperOutputSpec):
     bundle_profiles = File(exists=True)
 
 
+def _get_tdi_img(dwiref_image, tck_file, output_tdi_file):
+    output = subprocess.run(
+        ["tckmap", "-template", dwiref_image, "-contrast", "tdi", "-force",
+         tck_file, output_tdi_file],
+        check=True)
+    return nim.load_img(output_tdi_file)
+
 class BundleMapper(ScalarMapper):
     input_spec = _BundleMapperInputSpec
     output_spec = _BundleMapperOutputSpec
+
+    def _do_mapping(self, runtime):
+        bundle_dfs = []
+        for tck_name, tck_file in zip(self.inputs.bundle_names, self.inputs.tck_files):
+            output_tdi_file = fname_presuffix(
+                tck_file,
+                suffix="_tdi.nii",
+                newpath=runtime.cwd,
+                use_ext=False)
+
+            # Create a TDI, where streamline count is mapped to voxels
+            tdi_img = _get_tdi_img(
+                self.inputs.dwiref_image,
+                tck_file,
+                output_tdi_file)
+
+            # Create a Masker from all voxels containing streamlines
+            msk_img = nim.math_img("a>0", a=tdi_img)
+            bundle_masker = NiftiMasker(msk_img)
+
+            # Get a weighting vector from the TDI
+            tdi_weights = bundle_masker.fit_transform(tdi_img).squeeze()
+            tdi_weights = tdi_weights / tdi_weights.sum()
+
+            # Start gathering stats with the TDI first
+            bundle_dfs.append(
+                calculate_mask_stats(
+                    bundle_masker,
+                    tck_name,
+                    "bundle",
+                    {"image": tdi_img,
+                     "variable_name": "tdi",
+                     "workflow_name": "scalar_to_bundle",
+                     "desc": "Streamline counts per voxel"})
+            )
+
+            # Then get the same stats for the scalars
+            for recon_scalar in self.recon_scalars:
+                bundle_dfs.append(
+                    calculate_mask_stats(bundle_masker, tck_name, "bundle", recon_scalar))
+        self._update_with_bids_info(bundle_dfs)
+        summary_file = op.join(runtime.cwd, "bundle_stats.tsv")
+        summary_df = pd.DataFrame(bundle_dfs)
+
+        summary_df.to_csv(summary_file, index=False, sep="\t")
+        self._results['bundle_summary'] = summary_file
 
 
 # For mapping to atlases
@@ -60,3 +133,38 @@ class _AtlasMapperOutputSpec(ScalarMapperOutputSpec):
 class AtlasMapper(ScalarMapper):
     input_spec = _AtlasMapperInputSpec
     output_spec = _AtlasMapperOutputSpec
+
+def calculate_mask_stats(masker, mask_name, mask_variable_name, recon_scalar, weighting_vector=None):
+
+    # Get the scalar data in the masked region
+    voxel_data = masker.fit_transform(recon_scalar["image"]).squeeze()
+    # Find out how much of this scalar is finite
+    nz_voxel_data = voxel_data.copy()
+    nz_voxel_data[nz_voxel_data == 0] = np.nan
+    nz_voxel_data[~np.isfinite(voxel_data)] = np.nan
+
+    # Make a prettier variable name
+    variable_name = recon_scalar["variable_name"].replace("_image", "").replace("_file", "")
+
+    results = {
+        mask_variable_name: mask_name,
+        "variable_name": variable_name,
+        "workflow": recon_scalar["workflow_name"],
+        "zero_proportion": np.sum(np.isnan(nz_voxel_data)) / voxel_data.shape[0],
+        "mean": np.mean(voxel_data),
+        "stdev": np.std(voxel_data),
+        "median": np.median(voxel_data),
+        "masked_mean": np.nanmean(nz_voxel_data),
+        "masked_median": np.nanmedian(nz_voxel_data),
+        "masked_stdev": np.nanstd(nz_voxel_data)
+    }
+
+    if weighting_vector is not None:
+        results["weighted_mean"] = np.sum(voxel_data * weighting_vector)
+        nz_weighting_vector = weighting_vector.copy()
+        nz_weighting_vector[np.isnan(nz_voxel_data)] = np.nan
+        nz_weighting_vector = nz_weighting_vector / np.nansum(nz_weighting_vector)
+        results["masked_weighted_mean"] = np.nansum(
+            nz_voxel_data * nz_weighting_vector )
+
+    return results

--- a/qsiprep/workflows/recon/build_workflow.py
+++ b/qsiprep/workflows/recon/build_workflow.py
@@ -18,9 +18,10 @@ from .converters import init_mif_to_fibgz_wf, init_qsiprep_to_fsl_wf
 from .dynamics import init_controllability_wf
 from .utils import init_conform_dwi_wf, init_discard_repeated_samples_wf
 from .steinhardt import init_steinhardt_order_param_wf
+from .scalar_mapping import init_scalar_to_bundle_wf
 from ...engine import Workflow
 from ...interfaces.interchange import (
-    default_input_set, recon_workflow_input_fields, get_scalar_data_gatherer
+    default_input_set, recon_workflow_input_fields
 )
 
 LOGGER = logging.getLogger('nipype.interface')
@@ -60,21 +61,20 @@ def init_dwi_recon_workflow(workflow_spec, output_dir,
     _check_repeats(workflow.list_node_names())
 
     # Create a node that gathers scalar outputs from those that produce them
-    ReconScalarData = get_scalar_data_gatherer(workflow_spec["nodes"])
-    scalar_gatherer = pe.Node(ReconScalarData(), name="scalar_gatherer")
+    scalar_gatherer = pe.Node(niu.Merge(len(nodes_to_add)), name="scalar_gatherer")
 
     # Now that all nodes are in the workflow, connect them
-    for node_spec in workflow_spec['nodes']:
+    for node_num, node_spec in enumerate(workflow_spec['nodes'], start=1):
 
         # get the nipype node object
         node_name = node_spec['name']
         node = workflow.get_node(node_name)
 
         consuming_scalars = node_spec.get("scalars_from", [])
-        if not consuming_scalars:
-            workflow.connect(scalar_gatherer, "scalars", node, "scalar_images")
+        if consuming_scalars:
+            workflow.connect(scalar_gatherer, "out", node, "inputnode.collected_scalars")
         else:
-            workflow.connect(node, "outputnode.recon_scalars", scalar_gatherer, node_spec["name"])
+            workflow.connect(node, "outputnode.recon_scalars", scalar_gatherer, "in%d"%node_num)
 
         if node_spec.get('input', 'qsiprep') == 'qsiprep':
             # directly connect all the qsiprep outputs to every node
@@ -138,6 +138,15 @@ def workflow_from_spec(omp_nthreads, available_anatomical_data, node_spec,
     output_suffix = node_spec.get("output_suffix", "")
     node_name = node_spec.get("name", None)
     parameters = node_spec.get("parameters", {})
+
+    # It makes more sense intuitively to have scalars_from in the
+    # root of a recon spec "node". But to pass it to the workflow
+    # it needs to go in parameters
+    if "scalars_from" in node_spec and node_spec["scalars_from"]:
+        if parameters.get("scalars_from"):
+            LOGGER.warning("overwriting scalars_from in parameters")
+        parameters["scalars_from"] = node_spec["scalars_from"]
+
     if skip_odf_plots:
         LOGGER.info("skipping ODF plots for %s", node_name)
         parameters['plot_reports'] = False
@@ -215,7 +224,7 @@ def workflow_from_spec(omp_nthreads, available_anatomical_data, node_spec,
         if node_spec['action'] == 'steinhardt_order_parameters':
             return init_steinhardt_order_param_wf(**kwargs)
         if node_spec['action'] == 'bundle_map':
-            return init_bundle_map_wf(**kwargs)
+            return init_scalar_to_bundle_wf(**kwargs)
 
     raise Exception("Unknown node %s" % node_spec)
 

--- a/qsiprep/workflows/recon/converters.py
+++ b/qsiprep/workflows/recon/converters.py
@@ -69,12 +69,13 @@ def init_qsiprep_to_fsl_wf(omp_nthreads, available_anatomical_data,
     """Converts QSIPrep outputs (images, bval, bvec) to fsl standard orientation"""
     inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields),
                         name="inputnode")
-    to_reorient = ["mask_file", "dwi_file", "bval_file", "bvec_file"]
+    to_reorient = ["mask_file", "dwi_file", "bval_file", "bvec_file", "recon_scalars"]
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=to_reorient),
             name="outputnode")
     workflow = Workflow(name=name)
+    outputnode.inputs.recon_scalars = []
 
     convert_dwi_to_fsl = pe.Node(
         ConformDwi(orientation="LAS"), name="convert_to_fsl")

--- a/qsiprep/workflows/recon/dipy.py
+++ b/qsiprep/workflows/recon/dipy.py
@@ -13,6 +13,9 @@ from ...interfaces.dipy import BrainSuiteShoreReconstruction, KurtosisReconstruc
 from ...interfaces.interchange import recon_workflow_input_fields
 from ...engine import Workflow
 from ...interfaces.reports import CLIReconPeaksReport
+from ...interfaces.recon_scalars import (
+    DIPYDKIReconScalars, DIPYMAPMRIReconScalars, BrainSuite3dSHOREReconScalars)
+
 
 LOGGER = logging.getLogger('nipype.interface')
 
@@ -100,7 +103,7 @@ def init_dipy_brainsuite_shore_recon_wf(omp_nthreads, available_anatomical_data,
         niu.IdentityInterface(
             fields=['shore_coeffs_image', 'rtop_image', 'alpha_image', 'r2_image',
                     'cnr_image', 'regularization_image', 'fibgz', 'fod_sh_mif',
-                    'dwi_file', 'bval_file', 'bvec_file', 'b_file']),
+                    'dwi_file', 'bval_file', 'bvec_file', 'b_file', 'recon_scalars']),
         name="outputnode")
 
     workflow = Workflow(name=name)
@@ -108,7 +111,12 @@ def init_dipy_brainsuite_shore_recon_wf(omp_nthreads, available_anatomical_data,
 
 : """
     plot_reports = params.pop("plot_reports", True)
-    recon_shore = pe.Node(BrainSuiteShoreReconstruction(**params), name="recon_shore")
+    recon_shore = pe.Node(
+        BrainSuiteShoreReconstruction(**params), name="recon_shore")
+    recon_scalars = pe.Node(
+        BrainSuite3dSHOREReconScalars(workflow_name="name"),
+        name="recon_scalars",
+        run_without_submitting=True)
     doing_extrapolation = params.get("extrapolate_scheme") in ("HCP", "ABCD")
 
     workflow.connect([
@@ -127,8 +135,16 @@ def init_dipy_brainsuite_shore_recon_wf(omp_nthreads, available_anatomical_data,
                                    ('extrapolated_dwi', 'dwi_file'),
                                    ('extrapolated_bvals', 'bval_file'),
                                    ('extrapolated_bvecs', 'bvec_file'),
-                                   ('extrapolated_b', 'b_file')])
-        ])
+                                   ('extrapolated_b', 'b_file')]),
+        (recon_shore, recon_scalars, [
+            ('rtop_image', 'rtop_file'),
+            ('alpha_image', 'alpha_image'),
+            ('r2_image', 'r2_image'),
+            ('cnr_image', 'cnr_image'),
+            ('regularization_image', 'regularization_image')]),
+        (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])
+    ])
+
     if plot_reports:
 
         plot_peaks = pe.Node(
@@ -330,7 +346,7 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=['mapmri_coeffs', 'rtop', 'rtap', 'rtpp', 'fibgz', 'fod_sh_mif',
-                    'parng', 'perng', 'ng', 'qiv', 'lapnorm', 'msd']),
+                    'parng', 'perng', 'ng', 'qiv', 'lapnorm', 'msd', 'recon_scalars']),
         name="outputnode")
 
     workflow = Workflow(name=name)
@@ -339,7 +355,10 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
 : """
     plot_reports = params.pop("plot_reports", True)
     recon_map = pe.Node(MAPMRIReconstruction(**params), name="recon_map")
-
+    recon_scalars = pe.Node(
+        DIPYMAPMRIReconScalars(workflow_name=name),
+        name="recon_scalars",
+        run_without_submitting=True)
     workflow.connect([
         (inputnode, recon_map, [('dwi_file', 'dwi_file'),
                                 ('bval_file', 'bval_file'),
@@ -356,7 +375,18 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
                                  ('qiv', 'qiv'),
                                  ('lapnorm', 'lapnorm'),
                                  ('fibgz', 'fibgz'),
-                                 ('fod_sh_mif', 'fod_sh_mif')])])
+                                 ('fod_sh_mif', 'fod_sh_mif')]),
+        (recon_map, recon_scalars, [
+            ('rtop', 'rtop_file'),
+            ('rtap', 'rtap_file'),
+            ('rtpp', 'rtpp_file'),
+            ('ng', 'ng_file'),
+            ('parng', 'ngpar_file'),
+            ('perng', 'ngper_file'),
+            ('msd', 'msd_file'),
+            ('qiv', 'qiv_file'),
+            ('lapnorm', 'lapnorm_file')]),
+        (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])])
     if plot_reports:
         plot_peaks = pe.Node(
             CLIReconPeaksReport(),
@@ -440,9 +470,11 @@ def init_dipy_dki_recon_wf(omp_nthreads, available_anatomical_data, name="dipy_d
         niu.IdentityInterface(
             fields=['tensor', 'fa', 'md', 'rd', 'ad',
                     'colorFA', 'kfa', 'mk', 'ak', 'rk',
-                    'mkt']),
+                    'mkt', 'recon_scalars']),
         name="outputnode")
-
+    recon_scalars = pe.Node(DIPYDKIReconScalars(workflow_name=name),
+                            run_without_submitting=True,
+                            name="recon_scalars")
     workflow = Workflow(name=name)
     desc = """Dipy Reconstruction
 
@@ -450,24 +482,36 @@ def init_dipy_dki_recon_wf(omp_nthreads, available_anatomical_data, name="dipy_d
     plot_reports = params.pop("plot_reports", True)
     recon_dki = pe.Node(KurtosisReconstruction(**params), name="recon_dki")
 
-
     workflow.connect([
-        (inputnode, recon_dki, [('dwi_file', 'dwi_file'),
-                                ('bval_file', 'bval_file'),
-                                ('bvec_file', 'bvec_file'),
-                                ('dwi_mask', 'mask_file')]),
-        (recon_dki, outputnode, [('tensor', 'tensor'),
-                                 ('fa', 'fa'),
-                                 ('md', 'md'),
-                                 ('rd', 'rd'),
-                                 ('ad', 'ad'),
-                                 ('colorFA', 'colorFA'),
-                                 ('kfa', 'kfa'),
-                                 ('mk', 'mk'),
-                                 ('ak', 'ak'),
-                                 ('rk', 'rk'),
-                                 ('mkt', 'mkt'),
-                                 ('fibgz', 'fibgz')])
+        (inputnode, recon_dki, [
+            ('dwi_file', 'dwi_file'),
+            ('bval_file', 'bval_file'),
+            ('bvec_file', 'bvec_file'),
+            ('dwi_mask', 'mask_file')]),
+        (recon_dki, outputnode, [
+            ('tensor', 'tensor'),
+            ('fa', 'fa'),
+            ('md', 'md'),
+            ('rd', 'rd'),
+            ('ad', 'ad'),
+            ('colorFA', 'colorFA'),
+            ('kfa', 'kfa'),
+            ('mk', 'mk'),
+            ('ak', 'ak'),
+            ('rk', 'rk'),
+            ('mkt', 'mkt'),
+            ('fibgz', 'fibgz')]),
+        (recon_dki, recon_scalars, [
+            ('fa', 'dki_fa'),
+            ('md', 'dki_md'),
+            ('rd', 'dki_rd'),
+            ('ad', 'dki_ad'),
+            ('kfa', 'dki_kfa'),
+            ('mk', 'dki_mk'),
+            ('ak', 'dki_ak'),
+            ('rk', 'dki_rk'),
+            ('mkt', 'dki_mkt')]),
+        (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])
     ])
 
     if plot_reports and False:

--- a/qsiprep/workflows/recon/dipy.py
+++ b/qsiprep/workflows/recon/dipy.py
@@ -382,7 +382,7 @@ def init_dipy_mapmri_recon_wf(omp_nthreads, available_anatomical_data, name="dip
             ('rtpp', 'rtpp_file'),
             ('ng', 'ng_file'),
             ('parng', 'ngpar_file'),
-            ('perng', 'ngper_file'),
+            ('perng', 'ngperp_file'),
             ('msd', 'msd_file'),
             ('qiv', 'qiv_file'),
             ('lapnorm', 'lapnorm_file')]),

--- a/qsiprep/workflows/recon/dsi_studio.py
+++ b/qsiprep/workflows/recon/dsi_studio.py
@@ -17,6 +17,7 @@ from qsiprep.interfaces.dsi_studio import (DSIStudioCreateSrc, DSIStudioGQIRecon
 
 import logging
 from ...interfaces.bids import ReconDerivativesDataSink
+from ...interfaces.recon_scalars import DSIStudioReconScalars
 from ...interfaces.converters import DSIStudioTrkToTck
 from ...interfaces.interchange import recon_workflow_input_fields
 from ...engine import Workflow
@@ -479,6 +480,7 @@ def init_dsi_studio_export_wf(omp_nthreads, available_anatomical_data, name="dsi
         name="outputnode")
     workflow = pe.Workflow(name=name)
     export = pe.Node(DSIStudioExport(to_export=",".join(scalar_names)), name='export')
+    recon_scalars = pe.Node(DSIStudioReconScalars(workflow_name=name), n_procs=1)
     fixhdr_nodes = {}
     for scalar_name in scalar_names:
         output_name = scalar_name + '_file'

--- a/qsiprep/workflows/recon/dsi_studio.py
+++ b/qsiprep/workflows/recon/dsi_studio.py
@@ -480,7 +480,10 @@ def init_dsi_studio_export_wf(omp_nthreads, available_anatomical_data, name="dsi
         name="outputnode")
     workflow = pe.Workflow(name=name)
     export = pe.Node(DSIStudioExport(to_export=",".join(scalar_names)), name='export')
-    recon_scalars = pe.Node(DSIStudioReconScalars(workflow_name=name), n_procs=1)
+    recon_scalars = pe.Node(
+        DSIStudioReconScalars(workflow_name=name),
+        name="recon_scalars",
+        n_procs=1)
     fixhdr_nodes = {}
     for scalar_name in scalar_names:
         output_name = scalar_name + '_file'
@@ -488,7 +491,7 @@ def init_dsi_studio_export_wf(omp_nthreads, available_anatomical_data, name="dsi
         connections = [(export, fixhdr_nodes[scalar_name], [(output_name, 'dsi_studio_nifti')]),
                        (inputnode, fixhdr_nodes[scalar_name], [('dwi_file',
                                                                 'correct_header_nifti')]),
-                       (fixhdr_nodes[scalar_name], outputnode, [('out_file', output_name)])
+                       (fixhdr_nodes[scalar_name], outputnode, [('out_file', output_name)]),
                        (fixhdr_nodes[scalar_name], recon_scalars, [("out_file", output_name)])]
         if output_suffix:
             connections += [(fixhdr_nodes[scalar_name],
@@ -501,6 +504,6 @@ def init_dsi_studio_export_wf(omp_nthreads, available_anatomical_data, name="dsi
 
     workflow.connect([
         (inputnode, export, [('fibgz', 'input_file')]),
-        (recon_scalars, outputnode, ("scalar_info", "recon_scalars"))])
+        (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])])
 
     return workflow

--- a/qsiprep/workflows/recon/mrtrix.py
+++ b/qsiprep/workflows/recon/mrtrix.py
@@ -88,9 +88,10 @@ def init_mrtrix_csd_recon_wf(omp_nthreads, available_anatomical_data, name="mrtr
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=['fod_sh_mif', 'wm_odf', 'wm_txt', 'gm_odf', 'gm_txt', 'csf_odf',
-                    'csf_txt']),
+                    'csf_txt', 'recon_scalars']),
         name="outputnode")
     workflow = Workflow(name=name)
+    outputnode.inputs.recon_scalars = []
     plot_reports = params.pop("plot_reports", True)
     desc = """MRtrix3 Reconstruction
 
@@ -346,10 +347,11 @@ def init_global_tractography_wf(omp_nthreads, available_anatomical_data, name="m
         name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['fod_sh_mif', 'wm_odf', 'iso_fraction', 'tck_file']),
+            fields=['fod_sh_mif', 'wm_odf', 'iso_fraction', 'tck_file', 'recon_scalars']),
         name="outputnode")
 
     workflow = pe.Workflow(name=name)
+    outputnode.inputs.recon_scalars = []
     plot_reports = params.pop("plot_reports", True)
 
     create_mif = pe.Node(MRTrixIngress(), name='create_mif')
@@ -439,10 +441,11 @@ def init_mrtrix_tractography_wf(omp_nthreads, available_anatomical_data, name="m
         niu.IdentityInterface(fields=recon_workflow_input_fields + ['fod_sh_mif']),
         name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['tck_file', 'sift_weights']),
+        niu.IdentityInterface(fields=['tck_file', 'sift_weights', 'recon_scalars']),
         name="outputnode")
 
     workflow = pe.Workflow(name=name)
+    outputnode.inputs.recon_scalars = []
     plot_reports = params.pop("plot_reports", True)
     # Resample anat mask
     tracking_params = params.get("tckgen", {})
@@ -527,8 +530,9 @@ def init_mrtrix_connectivity_wf(omp_nthreads, available_anatomical_data, name="m
         niu.IdentityInterface(
             fields=recon_workflow_input_fields + ['tck_file', 'sift_weights', 'atlas_configs']),
         name="inputnode")
-    outputnode = pe.Node(niu.IdentityInterface(fields=['matfile']),
+    outputnode = pe.Node(niu.IdentityInterface(fields=['matfile', 'recon_scalars']),
                          name="outputnode")
+    outputnode.inputs.recon_scalars = []
     plot_reports = params.pop("plot_reports", True)
     workflow = pe.Workflow(name=name)
     conmat_params = params.get("tck2connectome", {})

--- a/qsiprep/workflows/recon/pyafq.py
+++ b/qsiprep/workflows/recon/pyafq.py
@@ -62,8 +62,9 @@ def init_pyafq_wf(omp_nthreads, available_anatomical_data,
         fields=recon_workflow_input_fields + ['tck_file']),
         name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['afq_dir']),
+        niu.IdentityInterface(fields=['afq_dir', 'recon_scalars']),
         name="outputnode")
+    outputnode.inputs.recon_scalars=[]
 
     kwargs = _parse_qsiprep_params_dict(params)
     kwargs["omp_nthreads"] = omp_nthreads

--- a/qsiprep/workflows/recon/scalar_mapping.py
+++ b/qsiprep/workflows/recon/scalar_mapping.py
@@ -1,0 +1,127 @@
+"""
+Converting between file formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: init_mif_to_fibgz_wf
+.. autofunction:: init_fibgz_to_mif_wf
+
+"""
+import nipype.pipeline.engine as pe
+import nipype.interfaces.utility as niu
+import logging
+from ...interfaces.bids import ReconDerivativesDataSink
+from ...interfaces.interchange import recon_workflow_input_fields
+from ...engine import Workflow
+from ...interfaces.scalar_mapping import FilterScalars
+LOGGER = logging.getLogger('nipype.workflow')
+
+
+def init_scalar_to_bundle_wf(omp_nthreads, available_anatomical_data,
+                         name="scalar_to_bundle", output_suffix="", params={}):
+    """Map scalar images to bundles
+
+
+
+    Inputs
+        tck_files
+            MRtrix3 format tck files for each bundle
+        bundle_names
+            Names that describe which bundles are present in `tck_files`at mif file containing sh coefficients representing FODs.
+        recon_scalars
+            List of dictionaries containing scalar info
+
+    Outputs
+
+        bundle_summaries
+            summary statistics in tsv formar
+
+    """
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=recon_workflow_input_fields +
+            ["tck_files", "bundle_names", "recon_scalars"]),
+        name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['bundle_summaries']), name="outputnode")
+    workflow = Workflow(name=name)
+    convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
+    workflow.connect([
+        (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
+        (convert_to_fib, outputnode, [('fib_file', 'fib_file')])
+    ])
+    return workflow
+
+
+def init_fibgz_to_mif_wf(name="fibgz_to_mif", output_suffix="", params={}):
+    """Needs Documentation"""
+    inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields + ["mif_file"]),
+                        name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['fib_file']), name="outputnode")
+    workflow = Workflow(name=name)
+    convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
+    workflow.connect([
+        (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
+        (convert_to_fib, outputnode, [('fib_file', 'fib_file')])
+    ])
+    return workflow
+
+
+def init_qsiprep_to_fsl_wf(omp_nthreads, available_anatomical_data,
+                           name="qsiprep_to_fsl", output_suffix="", params={}):
+    """Converts QSIPrep outputs (images, bval, bvec) to fsl standard orientation"""
+    inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields),
+                        name="inputnode")
+    to_reorient = ["mask_file", "dwi_file", "bval_file", "bvec_file", "recon_scalars"]
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=to_reorient),
+            name="outputnode")
+    workflow = Workflow(name=name)
+    outputnode.inputs.recon_scalars = []
+
+    convert_dwi_to_fsl = pe.Node(
+        ConformDwi(orientation="LAS"), name="convert_to_fsl")
+    convert_mask_to_fsl = pe.Node(
+        ConformDwi(orientation="LAS"),name="convert_mask_to_fsl")
+    workflow.connect([
+        (inputnode, convert_dwi_to_fsl, [
+            ('dwi_file', 'dwi_file'),
+            ('bval_file', 'bval_file'),
+            ('bvec_file', 'bvec_file')]),
+        (convert_dwi_to_fsl, outputnode, [
+            ('dwi_file', 'dwi_file'),
+            ('bval_file', 'bval_file'),
+            ('bvec_file', 'bvec_file')]),
+        (inputnode, convert_mask_to_fsl, [('mask_file', 'dwi_file')]),
+        (convert_mask_to_fsl, outputnode, [('dwi_file', 'mask_file')])
+    ])
+
+    if output_suffix:
+        # Save the output in the outputs directory
+        ds_dwi_file = pe.Node(
+            ReconDerivativesDataSink(
+                suffix=output_suffix + "_dwi"),
+                name='ds_dwi_' + name,
+                run_without_submitting=True)
+        ds_bval_file = pe.Node(
+            ReconDerivativesDataSink(
+                suffix=output_suffix + "_dwi"),
+                name='ds_bval_' + name,
+                run_without_submitting=True)
+        ds_bvec_file = pe.Node(
+            ReconDerivativesDataSink(
+                suffix=output_suffix + "_dwi"),
+                name='ds_bvec_' + name,
+                run_without_submitting=True)
+        ds_mask_file = pe.Node(
+            ReconDerivativesDataSink(
+                suffix=output_suffix + "_mask"),
+                name='ds_mask_' + name,
+                run_without_submitting=True)
+        workflow.connect([
+            (convert_dwi_to_fsl, ds_bval_file, [('bval_file', 'in_file')]),
+            (convert_dwi_to_fsl, ds_bvec_file, [('bvec_file', 'in_file')]),
+            (convert_dwi_to_fsl, ds_dwi_file, [('dwi_file', 'in_file')]),
+            (convert_mask_to_fsl, ds_mask_file, [('dwi_file', 'in_file')])
+    return workflow

--- a/qsiprep/workflows/recon/scalar_mapping.py
+++ b/qsiprep/workflows/recon/scalar_mapping.py
@@ -69,11 +69,10 @@ def init_scalar_to_bundle_wf(omp_nthreads, available_anatomical_data,
 
     return workflow
 
+
 def init_scalar_to_atlas_wf(omp_nthreads, available_anatomical_data,
                             name="scalar_to_template", output_suffix="", params={}):
-    """Map scalar images to bundles
-
-
+    """Map scalar images to atlas regions
 
     Inputs
         tck_files
@@ -84,7 +83,6 @@ def init_scalar_to_atlas_wf(omp_nthreads, available_anatomical_data,
             List of dictionaries containing scalar info
 
     Outputs
-
         bundle_summaries
             summary statistics in tsv format
 
@@ -116,6 +114,7 @@ def init_scalar_to_atlas_wf(omp_nthreads, available_anatomical_data,
         workflow.connect([
             (bundle_mapper, ds_bundle_summaries, [("bundle_summaries", "in_file")])
         ])
+    return workflow
 
 
 def init_scalar_to_template_wf(omp_nthreads, available_anatomical_data,

--- a/qsiprep/workflows/recon/scalar_mapping.py
+++ b/qsiprep/workflows/recon/scalar_mapping.py
@@ -12,12 +12,12 @@ import logging
 from ...interfaces.bids import ReconDerivativesDataSink
 from ...interfaces.interchange import recon_workflow_input_fields
 from ...engine import Workflow
-from ...interfaces.scalar_mapping import FilterScalars
+from ...interfaces.scalar_mapping import BundleMapper
 LOGGER = logging.getLogger('nipype.workflow')
 
 
 def init_scalar_to_bundle_wf(omp_nthreads, available_anatomical_data,
-                         name="scalar_to_bundle", output_suffix="", params={}):
+                             name="scalar_to_bundle", output_suffix="", params={}):
     """Map scalar images to bundles
 
 
@@ -26,7 +26,7 @@ def init_scalar_to_bundle_wf(omp_nthreads, available_anatomical_data,
         tck_files
             MRtrix3 format tck files for each bundle
         bundle_names
-            Names that describe which bundles are present in `tck_files`at mif file containing sh coefficients representing FODs.
+            Names that describe which bundles are present in `tck_files`
         recon_scalars
             List of dictionaries containing scalar info
 
@@ -39,89 +39,94 @@ def init_scalar_to_bundle_wf(omp_nthreads, available_anatomical_data,
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=recon_workflow_input_fields +
+            ["tck_files", "bundle_names", "recon_scalars", "collected_scalars"]),
+        name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['bundle_summary']), name="outputnode")
+    workflow = Workflow(name=name)
+    bundle_mapper = pe.Node(
+        BundleMapper(**params),
+        name="bundle_mapper")
+    workflow.connect([
+        (inputnode, bundle_mapper, [
+            ("collected_scalars", "recon_scalars"),
+            ("tck_files", "tck_files"),
+            ("dwi_ref", "dwiref_image"),
+            ("bundle_names", "bundle_names")]),
+        (bundle_mapper, outputnode, [
+            ("bundle_summary", "bundle_summary")])
+    ])
+    if output_suffix:
+
+        ds_bundle_summaries = pe.Node(
+            ReconDerivativesDataSink(desc="bundlemap",
+                                     suffix=output_suffix),
+            name='ds_bundle_summaries',
+            run_without_submitting=True)
+        workflow.connect([
+            (bundle_mapper, ds_bundle_summaries, [("bundle_summary", "in_file")])
+        ])
+
+    return workflow
+
+def init_scalar_to_atlas_wf(omp_nthreads, available_anatomical_data,
+                            name="scalar_to_template", output_suffix="", params={}):
+    """Map scalar images to bundles
+
+
+
+    Inputs
+        tck_files
+            MRtrix3 format tck files for each bundle
+        bundle_names
+            Names that describe which bundles are present in `tck_files`
+        recon_scalars
+            List of dictionaries containing scalar info
+
+    Outputs
+
+        bundle_summaries
+            summary statistics in tsv format
+
+    """
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=recon_workflow_input_fields +
             ["tck_files", "bundle_names", "recon_scalars"]),
         name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['bundle_summaries']), name="outputnode")
     workflow = Workflow(name=name)
-    convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
+    bundle_mapper = pe.Node(
+        BundleMapper(**params),
+        name="bundle_mapper")
     workflow.connect([
-        (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
-        (convert_to_fib, outputnode, [('fib_file', 'fib_file')])
+        (inputnode, bundle_mapper, [
+            ("recon_scalars", "recon_scalars"),
+            ("tck_files", "tck_files"),
+            ("dwi_ref", "dwiref_image")])
     ])
-    return workflow
-
-
-def init_fibgz_to_mif_wf(name="fibgz_to_mif", output_suffix="", params={}):
-    """Needs Documentation"""
-    inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields + ["mif_file"]),
-                        name="inputnode")
-    outputnode = pe.Node(
-        niu.IdentityInterface(fields=['fib_file']), name="outputnode")
-    workflow = Workflow(name=name)
-    convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
-    workflow.connect([
-        (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
-        (convert_to_fib, outputnode, [('fib_file', 'fib_file')])
-    ])
-    return workflow
-
-
-def init_qsiprep_to_fsl_wf(omp_nthreads, available_anatomical_data,
-                           name="qsiprep_to_fsl", output_suffix="", params={}):
-    """Converts QSIPrep outputs (images, bval, bvec) to fsl standard orientation"""
-    inputnode = pe.Node(niu.IdentityInterface(fields=recon_workflow_input_fields),
-                        name="inputnode")
-    to_reorient = ["mask_file", "dwi_file", "bval_file", "bvec_file", "recon_scalars"]
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=to_reorient),
-            name="outputnode")
-    workflow = Workflow(name=name)
-    outputnode.inputs.recon_scalars = []
-
-    convert_dwi_to_fsl = pe.Node(
-        ConformDwi(orientation="LAS"), name="convert_to_fsl")
-    convert_mask_to_fsl = pe.Node(
-        ConformDwi(orientation="LAS"),name="convert_mask_to_fsl")
-    workflow.connect([
-        (inputnode, convert_dwi_to_fsl, [
-            ('dwi_file', 'dwi_file'),
-            ('bval_file', 'bval_file'),
-            ('bvec_file', 'bvec_file')]),
-        (convert_dwi_to_fsl, outputnode, [
-            ('dwi_file', 'dwi_file'),
-            ('bval_file', 'bval_file'),
-            ('bvec_file', 'bvec_file')]),
-        (inputnode, convert_mask_to_fsl, [('mask_file', 'dwi_file')]),
-        (convert_mask_to_fsl, outputnode, [('dwi_file', 'mask_file')])
-    ])
-
     if output_suffix:
-        # Save the output in the outputs directory
-        ds_dwi_file = pe.Node(
-            ReconDerivativesDataSink(
-                suffix=output_suffix + "_dwi"),
-                name='ds_dwi_' + name,
-                run_without_submitting=True)
-        ds_bval_file = pe.Node(
-            ReconDerivativesDataSink(
-                suffix=output_suffix + "_dwi"),
-                name='ds_bval_' + name,
-                run_without_submitting=True)
-        ds_bvec_file = pe.Node(
-            ReconDerivativesDataSink(
-                suffix=output_suffix + "_dwi"),
-                name='ds_bvec_' + name,
-                run_without_submitting=True)
-        ds_mask_file = pe.Node(
-            ReconDerivativesDataSink(
-                suffix=output_suffix + "_mask"),
-                name='ds_mask_' + name,
-                run_without_submitting=True)
+
+        ds_bundle_summaries = pe.Node(
+            ReconDerivativesDataSink(desc="bundlemap",
+                                     suffix=output_suffix),
+            name='ds_bundle_summaries',
+            run_without_submitting=True)
         workflow.connect([
-            (convert_dwi_to_fsl, ds_bval_file, [('bval_file', 'in_file')]),
-            (convert_dwi_to_fsl, ds_bvec_file, [('bvec_file', 'in_file')]),
-            (convert_dwi_to_fsl, ds_dwi_file, [('dwi_file', 'in_file')]),
-            (convert_mask_to_fsl, ds_mask_file, [('dwi_file', 'in_file')])
+            (bundle_mapper, ds_bundle_summaries, [("bundle_summaries", "in_file")])
+        ])
+
+
+def init_scalar_to_template_wf(omp_nthreads, available_anatomical_data,
+                               name="scalar_to_template", output_suffix="", params={}):
+    """Maps scalar data to a volumetric template"""
+
+    return workflow
+
+
+def init_scalar_to_surface_wf(omp_nthreads, available_anatomical_data,
+                              name="scalar_to_surface", output_suffix="", params={}):
+    """Maps scalar data to a surface."""
+    raise NotImplementedError()
     return workflow

--- a/qsiprep/workflows/recon/tortoise.py
+++ b/qsiprep/workflows/recon/tortoise.py
@@ -100,7 +100,8 @@ Methods implemented in TORTOISE (@tortoisev3) were used for reconstruction. """
             ('dwi_file', 'dwi_file'),
             ('bval_file', 'bval_file'),
             ('bvec_file', 'bvec_file'),
-            ('dwi_mask', 'mask_file')])])
+            ('dwi_mask', 'mask_file')]),
+        (recon_scalars, outputnode, [("scalar_info", "recon_scalars")])])
 
     # EstimateTensor
     if tensor_opts:


### PR DESCRIPTION
These nodes will collect scalar images produced by the recon workflows and make them available to a "mapper" that can summarize them by atlases or bundles.

Interfaces to add:

 - [X] amico_noddi
 - [X] TORTOISE
 - [x] csdsi_3dshore
 - [x] dipy_3dshore
 - [x] dipy_mapmri
 - [x] dipy_dki
 - [x] dsi_studio_gqi
 - [x] multishell_scalarfest
 - [x] mrtrix_multishell_msmt_ACT-fast
 - [x] mrtrix_multishell_msmt_ACT-noACT
 - [x] mrtrix_multishell_msmt_ACT-hsvs
 - [x] mrtrix_singleshell_msmt_ACT-fast
 - [x] mrtrix_singleshell_msmt_ACT-noACT
 - [x] mrtrix_singleshell_msmt_ACT-hsvs
 - [x] mrtrix_tckglobal
 - [x] reorient_fslstd
 - [x] mrtrix_multishell_msmt_pyafq_tractometry
 - [x] pyafq_tractometry
 - [x] dsi_studio_autotrack