### PR TITLE
Pin Nilearn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "matplotlib",
     "networkx ~= 2.8.8",
     "nibabel >= 3.0.0",
-    "nilearn >= 0.10.1",
+    "nilearn == 0.10.1",
     "nipype >= 1.3.1",
     "numpy >= 1.18.5",
     "pandas < 2.0.0",


### PR DESCRIPTION
Eventually we'll want to update the code to work with Nilearn 0.10.3, but in the meantime this will get QSIPrep working again.

## Changes proposed in this pull request

- Pin Nilearn to 0.10.1.