### PR TITLE
[ENH] Perform a sanity check on scans that are to be merged

### DIFF
--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -354,3 +354,28 @@ def init_dwi_pre_hmc_wf(
         ])  # fmt:skip
 
     return workflow
+
+
+def sanity_check_merge(layout, files_to_merge):
+    """Check that some basic features of the to-be-merged scans are compatible.
+
+    The features checked are:
+        * The acquisition grid is the same (slices, inplane-resolution, affine)
+        * The TR, TE
+        * The MultibandAccelerationFactor
+        * The slice timings
+
+    Parameters
+    ----------
+    layout: bids.layout.BIDSLayout
+        pybids layout object
+    files_to_merge: list
+        List of files that will be merged
+
+    Returns
+    -------
+    merge_ok: bool
+        Whether the group of scans is ok to merge
+
+    """
+    metadata_lookup = {scan: layout.get_metadata(scan) for scan in files_to_merge}


### PR DESCRIPTION
The merging done in QSIPrep was written before multipart IDs or b0 field identifiers were a part of BIDS. The strategy is based on the fields used in TOPUP/Eddy to define distortion groups, namely TotalReadoutTime and PhaseEncodingDirection. 

#710 makes slice-to-volume correction possible in Eddy but depends on concatenated scans having compatible slice timings, which is not currently checked for. A few other features of the to-be-concatenated images should also be checked.