### PR TITLE
[FIX] recon workflows when --anat-modality T2w was used 

### DIFF
--- a/qsiprep/interfaces/anatomical.py
+++ b/qsiprep/interfaces/anatomical.py
@@ -111,7 +111,7 @@ class QsiprepAnatomicalIngress(SimpleInterface):
         )
         self._get_if_exists(
             "t1_preproc",
-            "%s/sub-%s_desc-preproc_T1w.nii*" % (anat_root, sub),
+            "%s/sub-%s_desc-preproc_T*w.nii*" % (anat_root, sub),
             excludes=["space-MNI"],
         )
         if "t1_preproc" not in self._results:
@@ -133,15 +133,15 @@ class QsiprepAnatomicalIngress(SimpleInterface):
         )
         self._get_if_exists(
             "orig_to_t1_mode_forward_transform",
-            "%s/sub-%s*_from-orig_to-T1w_mode-image_xfm.txt" % (anat_root, sub),
+            "%s/sub-%s*_from-orig_to-T*w_mode-image_xfm.txt" % (anat_root, sub),
         )
         self._get_if_exists(
             "t1_2_mni_reverse_transform",
-            "%s/sub-%s*_from-MNI152NLin2009cAsym_to-T1w*_xfm.h5" % (anat_root, sub),
+            "%s/sub-%s*_from-MNI152NLin2009cAsym_to-T*w*_xfm.h5" % (anat_root, sub),
         )
         self._get_if_exists(
             "t1_2_mni_forward_transform",
-            "%s/sub-%s*_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5" % (anat_root, sub),
+            "%s/sub-%s*_from-T*w_to-MNI152NLin2009cAsym_mode-image_xfm.h5" % (anat_root, sub),
         )
         if not self.inputs.infant_mode:
             self._results["template_image"] = pkgrf("qsiprep", "data/mni_1mm_t1w_lps_brain.nii.gz")

--- a/qsiprep/workflows/recon/anatomical.py
+++ b/qsiprep/workflows/recon/anatomical.py
@@ -300,6 +300,23 @@ def check_hsv_inputs(subj_fs_path):
     return missing
 
 
+def _check_zipped_unzipped(path_to_check):
+    """Check to see if a path exists and warn if it's gzipped."""
+
+    exists = False
+    if path_to_check.exists():
+        exists = True
+    if path_to_check.name.endswith(".gz"):
+        nonzipped = str(path_to_check)[:-3]
+        if Path(nonzipped).exists():
+            LOGGER.warn(
+                "A Non-gzipped input nifti file was found. Consider gzipping %s", nonzipped
+            )
+            exists = True
+    LOGGER.info(f"CHECKING {path_to_check}: {exists}")
+    return exists
+
+
 def check_qsiprep_anatomical_outputs(recon_input_dir, subject_id, anat_type):
     """Determines whether an aligned T1w exists in a qsiprep derivatives directory.
 
@@ -313,18 +330,19 @@ def check_qsiprep_anatomical_outputs(recon_input_dir, subject_id, anat_type):
     to_check = (
         QSIPREP_ANAT_REQUIREMENTS if anat_type == "T1w" else QSIPREP_NORMALIZED_ANAT_REQUIREMENTS
     )
+
     for requirement in to_check:
-        requirement = recon_input_path / requirement.format(subject_id=subject_id)
-        if not requirement.exists():
-            # Is the non-gzipped version is there
-            if requirement.name.endswith(".gz"):
-                nonzipped = str(requirement)[:-3]
-                if Path(nonzipped).exists():
-                    LOGGER.warn(
-                        "A Non-gzipped input nifti file was found. Consider gzipping %s", nonzipped
-                    )
-                    continue
-            missing.append(str(requirement))
+        requirement = requirement.format(subject_id=subject_id)
+        t1_version = recon_input_path / requirement
+        if _check_zipped_unzipped(t1_version):
+            continue
+
+        # Try to see if a T2w version is present
+        t2w_version = recon_input_path / requirement.replace("_T1w", "_T2w")
+        if _check_zipped_unzipped(t2w_version):
+            continue
+        missing.append(str(t1_version))
+
     return missing
 
 


### PR DESCRIPTION
Recon workflows were missing the processed anatomical data when `--anat-modality T2w` was used for preprocessing. This fixes that