### PR TITLE
[FIX] PyAFQ was not being written to derivatives

### DIFF
--- a/qsiprep/workflows/recon/pyafq.py
+++ b/qsiprep/workflows/recon/pyafq.py
@@ -93,7 +93,9 @@ def init_pyafq_wf(
     if qsirecon_suffix:
         # Save the output in the outputs directory
         ds_afq = pe.Node(
-            ReconDerivativesDataSink(), name="ds_" + name, run_without_submitting=True
+            ReconDerivativesDataSink(qsirecon_suffix=qsirecon_suffix),
+            name="ds_" + name,
+            run_without_submitting=True,
         )
         workflow.connect(run_afq, "afq_dir", ds_afq, "in_file")
 


### PR DESCRIPTION
Issue is described [here](https://neurostars.org/t/qsi-reconstruction-writes-to-work-dir-but-not-derivatives/29209/1).

The PyAFQ workflows needed a `"qsirecon_suffix"` in their datasink.