### PR TITLE
[FIX] stop bizarre argsort behavior in best b=0

### DIFF
--- a/qsiprep/interfaces/epi_fmap.py
+++ b/qsiprep/interfaces/epi_fmap.py
@@ -258,7 +258,9 @@ def get_best_b0_topup_inputs_from(
 
     # Calculate the "quality" of each image:
     dwi_b0_df["qc_score"] = spec_groups["nii_3d_files"].transform(calculate_best_b0s)
-    dwi_b0_df["qc_rank"] = spec_groups["qc_score"].rank(ascending=True).astype(int) - 1
+    dwi_b0_df["qc_rank"] = (
+        np.nan_to_num(spec_groups["qc_score"].rank(ascending=True)).astype(int) - 1
+    )
 
     # Select only the top
     dwi_b0_df["selected_for_sdc"] = dwi_b0_df["qc_rank"] < max_per_spec

--- a/qsiprep/interfaces/epi_fmap.py
+++ b/qsiprep/interfaces/epi_fmap.py
@@ -259,7 +259,7 @@ def get_best_b0_topup_inputs_from(
     # Calculate the "quality" of each image:
     dwi_b0_df["qc_score"] = spec_groups["nii_3d_files"].transform(calculate_best_b0s)
     dwi_b0_df["qc_rank"] = (
-        np.nan_to_num(spec_groups["qc_score"].rank(ascending=True)).astype(int) - 1
+        np.nan_to_num(spec_groups["qc_score"].rank(ascending=True), nan=1.0).astype(int) - 1
     )
 
     # Select only the top


### PR DESCRIPTION
The argsort function when used on the averaged cross correlations was producing unpredictable ranks.

This PR may help pick topup reference images more robustly