### PR TITLE
Fix bad phase connection when using `--denoise-after-combining`

### DIFF
--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -292,7 +292,6 @@ def init_merge_and_denoise_wf(
             ('out_bval', 'inputnode.bval_file'),
             ('out_dwi', 'inputnode.dwi_file'),
             ('out_bvec', 'inputnode.bvec_file'),
-            ('out_dwi_phase', 'inputnode.dwi_phase_file'),
         ]),
         (merge_dwis, merge_confounds, [('merged_denoising_confounds', 'in1')]),
         (denoising_wf, merge_confounds, [('outputnode.confounds', 'in2')]),


### PR DESCRIPTION
Closes #775. In #679, we added support for complex-valued denoising, but _only_ if `--denoise-after-combining` isn't used. This removes a connection from when I tried supporting complex-valued denoising when `--denoise-after-combining` is used.

It looks like this bug was found by running `--denoise-after-combining`. @mattcieslak any chance we could modify one of the tests to use `--denoise-after-combining`? Not sure if there are any test datasets with multiple runs.

## Changes proposed in this pull request

- Remove expected `out_dwi_phase` output from `merge_dwis` node.