### PR TITLE
[FIX]: CUDA threads for Eddy

### DIFF
--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -181,7 +181,7 @@ def init_fsl_hmc_wf(
     enhance_pre_sdc = pe.Node(EnhanceB0(), name="enhance_pre_sdc")
 
     # Run in parallel if possible
-    if eddy_args["use_cuda"] is True:
+    if eddy_args["use_cuda"]:
         eddy_args["num_threads"] = 1
         config.loggers.workflow.info("Using CUDA and %d threads in eddy", eddy_args["num_threads"])
     else:

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -181,8 +181,12 @@ def init_fsl_hmc_wf(
     enhance_pre_sdc = pe.Node(EnhanceB0(), name="enhance_pre_sdc")
 
     # Run in parallel if possible
-    config.loggers.workflow.info("Using %d threads in eddy", omp_nthreads)
-    eddy_args["num_threads"] = omp_nthreads
+    if eddy_args["use_cuda"] is True:
+        eddy_args["num_threads"] = 1
+        config.loggers.workflow.info("Using CUDA and %d threads in eddy", eddy_args["num_threads"])
+    else:
+        eddy_args["num_threads"] = omp_nthreads
+        config.loggers.workflow.info("Using %d threads in eddy", eddy_args["num_threads"])
     pre_eddy_b0_ref_wf = init_dwi_reference_wf(
         source_file=source_file,
         name="pre_eddy_b0_ref_wf",


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

Eddy is currently getting threads from `omp_nthreads`. However, eddy_cuda only works if `--nthr=1`. This will set the threads for eddy depending on the `use_cuda` key in eddy_config. Fixes #747.

Tested locally and it works. Will not catch the cases where `use_cuda` is True but no GPU is passed to container and then reverts to `eddy_cpu`


