### PR TITLE
Add ability to ignore phase data

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -302,7 +302,7 @@ def _build_parser(**kwargs):
         action="store",
         nargs="+",
         default=[],
-        choices=["fieldmaps", "sbref", "t2w", "flair", "fmap-jacobian"],
+        choices=["fieldmaps", "sbref", "t2w", "flair", "fmap-jacobian", "phase"],
         help="Ignore selected aspects of the input dataset to disable corresponding "
         "parts of the workflow (a space delimited list)",
     )


### PR DESCRIPTION
The ability to ignore phase data was added in #679, but it looks like it was accidentally removed in #745. This PR adds it back in.

## Changes proposed in this pull request

- Add "phase" option to `--ignore` parameter.