### PR TITLE
Autofix: Add ability to ignore phase data

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -302,7 +302,7 @@ def _build_parser(**kwargs):
         action="store",
         nargs="+",
         default=[],
-        choices=["fieldmaps", "sbref", "t2w", "flair", "fmap-jacobian"],
+        choices=["fieldmaps", "sbref", "t2w", "flair", "fmap-jacobian", "phase"],
         help="Ignore selected aspects of the input dataset to disable corresponding "
         "parts of the workflow (a space delimited list)",
     )


### PR DESCRIPTION
This change adds the 'phase' option to the --ignore parameter in the parser, allowing users to ignore phase data as mentioned in the GitHub issue. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    