### PR TITLE
Remove underscore versions of all parameters

### DIFF
--- a/.circleci/AllFieldmaps.sh
+++ b/.circleci/AllFieldmaps.sh
@@ -39,7 +39,7 @@ QSIPREP_CMD=$(run_qsiprep_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR})
 ${QSIPREP_CMD} \
 	 -w ${TEMPDIR} \
 	 --boilerplate \
-	 --sloppy --write-graph --mem_mb 4096 \
+	 --sloppy --write-graph --mem-mb 4096 \
 	 -vv --output-resolution 5
 
 # Test blip-up blip-down non-shelled series (SHORELine/sdcflows)
@@ -55,7 +55,7 @@ ${QSIPREP_CMD} \
 	 -w ${TEMPDIR} \
 	 --boilerplate \
      --hmc-model 3dSHORE \
-	 --sloppy --write-graph --mem_mb 4096 \
+	 --sloppy --write-graph --mem-mb 4096 \
 	 -vv --output-resolution 5
 
 

--- a/.circleci/CUDATest.sh
+++ b/.circleci/CUDATest.sh
@@ -34,9 +34,9 @@ ${QSIPREP_CMD} \
 	--sloppy \
 	--anat-modality none \
 	--denoise-method none \
-	--b1_biascorrect_stage none \
+	--b1-biascorrect-stage none \
 	--pepolar-method DRBUDDI \
-	--eddy_config ${EDDY_CFG} \
+	--eddy-config ${EDDY_CFG} \
 	--output-resolution 5 \
     -vv --stop-on-first-crash
 

--- a/.circleci/DRBUDDI_eddy_rpe_series.sh
+++ b/.circleci/DRBUDDI_eddy_rpe_series.sh
@@ -34,9 +34,9 @@ ${QSIPREP_CMD} \
 	--sloppy \
 	--anat-modality none \
 	--denoise-method none \
-	--b1_biascorrect_stage none \
+	--b1-biascorrect-stage none \
 	--pepolar-method DRBUDDI \
-	--eddy_config ${EDDY_CFG} \
+	--eddy-config ${EDDY_CFG} \
 	--output-resolution 5 \
     -vv --stop-on-first-crash
 

--- a/.circleci/DSCSDSI.sh
+++ b/.circleci/DSCSDSI.sh
@@ -41,10 +41,10 @@ ${QSIPREP_CMD} \
    -w ${TEMPDIR} \
    --sloppy --write-graph --use-syn-sdc \
    --force-syn \
-   --b1_biascorrect_stage none \
-   --hmc_model 3dSHORE \
+   --b1-biascorrect-stage none \
+   --hmc-model 3dSHORE \
    --hmc-transform Rigid \
-   --shoreline_iters 1 \
+   --shoreline-iters 1 \
    --output-resolution 5 \
    --stop-on-first-crash \
    -vv

--- a/.circleci/DSDTI_TOPUP.sh
+++ b/.circleci/DSDTI_TOPUP.sh
@@ -40,7 +40,7 @@ ${QSIPREP_CMD} \
 	--sloppy \
 	--unringing-method mrdegibbs \
 	--b1-biascorrect-stage legacy \
-	--eddy_config ${EDDY_CFG} \
+	--eddy-config ${EDDY_CFG} \
 	--output-resolution 5 \
     -vv
 

--- a/.circleci/HBCD_preproc.sh
+++ b/.circleci/HBCD_preproc.sh
@@ -35,9 +35,9 @@ ${QSIPREP_CMD} \
 	--anat-modality T2w \
 	--infant \
 	--denoise-method dwidenoise \
-	--b1_biascorrect_stage none \
+	--b1-biascorrect-stage none \
 	--pepolar-method DRBUDDI \
-	--eddy_config ${EDDY_CFG} \
+	--eddy-config ${EDDY_CFG} \
 	--output-resolution 5 \
     -vv --stop-on-first-crash
 

--- a/.circleci/IntramodalTemplate.sh
+++ b/.circleci/IntramodalTemplate.sh
@@ -40,8 +40,8 @@ QSIPREP_CMD=$(run_qsiprep_cmd ${BIDS_INPUT_DIR} ${OUTPUT_DIR})
 ${QSIPREP_CMD} \
 	 -w ${TEMPDIR} \
 	 --sloppy \
-	 --b1_biascorrect_stage none \
-	 --hmc_model none \
+	 --b1-biascorrect-stage none \
+	 --hmc-model none \
 	 --b0-motion-corr-to first \
 	 --output-resolution 5 \
 	 --intramodal-template-transform BSplineSyN \

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -34,7 +34,7 @@ a DWI scan (or scans) in the reverse phase encoding direction to use for
 susceptibility distortion correction (SDC).
 
 This creates a number of possible scenarios for preprocessing your DWIs. These
-scenarios can be controlled by the ``--separate_all_dwis`` argument. If your study
+scenarios can be controlled by the ``--separate-all-dwis`` argument. If your study
 has multiple sessions, DWI scans will *never* be combined across sessions.
 Merging only occurs within a session.
 

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -181,14 +181,12 @@ def _build_parser(**kwargs):
     g_bids = parser.add_argument_group("Options for filtering BIDS queries")
     g_bids.add_argument(
         "--skip-bids-validation",
-        "--skip_bids_validation",
         action="store_true",
         default=False,
         help="Assume the input dataset is BIDS compliant and skip the validation",
     )
     g_bids.add_argument(
         "--participant-label",
-        "--participant_label",
         action="store",
         nargs="+",
         type=_drop_sub,
@@ -197,7 +195,6 @@ def _build_parser(**kwargs):
     )
     g_bids.add_argument(
         "--session-id",
-        "--session_id",
         action="store",
         nargs="+",
         type=_drop_ses,
@@ -208,7 +205,6 @@ def _build_parser(**kwargs):
 
     g_bids.add_argument(
         "--bids-filter-file",
-        "--bids_filter_file",
         dest="bids_filters",
         action="store",
         type=BIDSFilter,
@@ -221,7 +217,6 @@ def _build_parser(**kwargs):
     )
     g_bids.add_argument(
         "--bids-database-dir",
-        "--bids_database_dir",
         metavar="PATH",
         type=Path,
         help="Path to a PyBIDS database folder, for faster indexing (especially "
@@ -232,7 +227,6 @@ def _build_parser(**kwargs):
     g_perfm.add_argument(
         "--nprocs",
         "--nthreads",
-        "--n_cpus",
         "--n-cpus",
         dest="nprocs",
         action="store",
@@ -241,14 +235,12 @@ def _build_parser(**kwargs):
     )
     g_perfm.add_argument(
         "--omp-nthreads",
-        "--omp_nthreads",
         action="store",
         type=PositiveInt,
         help="Maximum number of threads per-process",
     )
     g_perfm.add_argument(
         "--mem",
-        "--mem_mb",
         "--mem-mb",
         dest="memory_gb",
         action="store",
@@ -258,7 +250,6 @@ def _build_parser(**kwargs):
     )
     g_perfm.add_argument(
         "--low-mem",
-        "--low_mem",
         action="store_true",
         help="Attempt to reduce memory usage (will increase disk usage in working directory)",
     )
@@ -281,13 +272,11 @@ def _build_parser(**kwargs):
     g_subset.add_argument("--anat-only", action="store_true", help="Run anatomical workflows only")
     g_subset.add_argument(
         "--dwi-only",
-        "--dwi_only",
         action="store_true",
         help="ignore anatomical (T1w/T2w) data and process DWIs only",
     )
     g_subset.add_argument(
         "--boilerplate-only",
-        "--boilerplate_only",
         "--boilerplate",
         action="store_true",
         default=False,
@@ -295,7 +284,6 @@ def _build_parser(**kwargs):
     )
     g_subset.add_argument(
         "--reports-only",
-        "--reports_only",
         action="store_true",
         default=False,
         help="Only generate reports, don't run workflows. This will only rerun report "
@@ -327,7 +315,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--subject-anatomical-reference",
-        "--subject_anatomical_reference",
         choices=["first-alphabetically", "unbiased", "sessionwise"],
         default="first-alphabetically",
         help="How to define subject-specific anatomical space. "
@@ -337,7 +324,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--skip-anat-based-spatial-normalization",
-        "--skip_anat_based_spatial_normalization",
         action="store_true",
         default=False,
         help="skip running the anat-based normalization to template space. "
@@ -345,7 +331,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--anat-modality",
-        "--anat_modality",
         choices=["T1w", "T2w", "none"],
         default="T1w",
         help="Modality to use as the anatomical reference. Images of this "
@@ -354,7 +339,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--b0-threshold",
-        "--b0_threshold",
         action="store",
         type=int,
         default=100,
@@ -364,7 +348,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--dwi-denoise-window",
-        "--dwi_denoise_window",
         action="store",
         default="auto",
         help='window size in voxels for image-based denoising, integer or "auto".'
@@ -373,7 +356,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--denoise-method",
-        "--denoise_method",
         action="store",
         choices=["dwidenoise", "patch2self", "none"],
         default="dwidenoise",
@@ -382,7 +364,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--unringing-method",
-        "--unringing_method",
         action="store",
         choices=["none", "mrdegibbs", "rpg"],
         help="Method for Gibbs-ringing removal.\n - none: no action\n - mrdegibbs: "
@@ -391,13 +372,11 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--dwi-no-biascorr",
-        "--dwi_no_biascorr",
         action="store_true",
         help="DEPRECATED: see --b1-biascorrect-stage",
     )
     g_conf.add_argument(
         "--b1-biascorrect-stage",
-        "--b1_biascorrect_stage",
         action="store",
         choices=["final", "none", "legacy"],
         default="final",
@@ -408,26 +387,22 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--no-b0-harmonization",
-        "--no_b0_harmonization",
         action="store_true",
         help="skip re-scaling dwi scans to have matching b=0 intensities",
     )
     g_conf.add_argument(
         "--denoise-after-combining",
-        "--denoise_after_combining",
         action="store_true",
         help="run ``dwidenoise`` after combining dwis, but before motion correction",
     )
     g_conf.add_argument(
         "--separate-all-dwis",
-        "--separate_all_dwis",
         action="store_true",
         help="don't attempt to combine dwis from multiple runs. Each will be "
         "processed separately.",
     )
     g_conf.add_argument(
         "--distortion-group-merge",
-        "--distortion_group_merge",
         action="store",
         choices=["concat", "average", "none"],
         default="none",
@@ -440,7 +415,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--anatomical-template",
-        "--anatomical_template",
         required=False,
         action="store",
         choices=["MNI152NLin2009cAsym"],
@@ -449,7 +423,6 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--output-resolution",
-        "--output_resolution",
         action="store",
         required=True,
         type=float,
@@ -461,7 +434,6 @@ def _build_parser(**kwargs):
     g_coreg = parser.add_argument_group("Options for dwi-to-Anatomical coregistration")
     g_coreg.add_argument(
         "--b0-to-t1w-transform",
-        "--b0_to_t1w_transform",
         action="store",
         default="Rigid",
         choices=["Rigid", "Affine"],
@@ -470,7 +442,6 @@ def _build_parser(**kwargs):
     )
     g_coreg.add_argument(
         "--intramodal-template-iters",
-        "--intramodal_template_iters",
         action="store",
         default=0,
         type=int,
@@ -481,7 +452,6 @@ def _build_parser(**kwargs):
     )
     g_coreg.add_argument(
         "--intramodal-template-transform",
-        "--intramodal_template_transform",
         default="BSplineSyN",
         choices=["Rigid", "Affine", "BSplineSyN", "SyN"],
         action="store",
@@ -492,7 +462,6 @@ def _build_parser(**kwargs):
     g_fs = parser.add_argument_group("Specific options for FreeSurfer preprocessing")
     g_fs.add_argument(
         "--fs-license-file",
-        "--fs_license_file",
         metavar="PATH",
         type=Path,
         help="Path to FreeSurfer license key file. Get it (for free) by registering "
@@ -502,7 +471,6 @@ def _build_parser(**kwargs):
     g_moco = parser.add_argument_group("Specific options for motion correction and coregistration")
     g_moco.add_argument(
         "--b0-motion-corr-to",
-        "--bo_motion_corr_to",
         action="store",
         default="iterative",
         choices=["iterative", "first"],
@@ -511,7 +479,6 @@ def _build_parser(**kwargs):
     )
     g_moco.add_argument(
         "--hmc-transform",
-        "--hmc_transform",
         action="store",
         default="Affine",
         choices=["Affine", "Rigid"],
@@ -519,7 +486,6 @@ def _build_parser(**kwargs):
     )
     g_moco.add_argument(
         "--hmc-model",
-        "--hmc_model",
         action="store",
         default="eddy",
         choices=["none", "3dSHORE", "eddy", "tensor"],
@@ -530,7 +496,6 @@ def _build_parser(**kwargs):
     )
     g_moco.add_argument(
         "--eddy-config",
-        "--eddy_config",
         action="store",
         help="path to a json file with settings for the call to eddy. If no "
         "json is specified, a default one will be used. The current default "
@@ -539,7 +504,6 @@ def _build_parser(**kwargs):
     )
     g_moco.add_argument(
         "--shoreline-iters",
-        "--shoreline_iters",
         action="store",
         type=int,
         default=2,
@@ -550,7 +514,6 @@ def _build_parser(**kwargs):
     g_fmap = parser.add_argument_group("Specific options for handling fieldmaps")
     g_fmap.add_argument(
         "--pepolar-method",
-        "--pepolar_method",
         action="store",
         default="TOPUP",
         choices=["TOPUP", "DRBUDDI", "TOPUP+DRBUDDI"],
@@ -558,14 +521,12 @@ def _build_parser(**kwargs):
     )
     g_fmap.add_argument(
         "--fmap-bspline",
-        "--fmap_bspline",
         action="store_true",
         default=False,
         help="Fit a B-Spline field using least-squares (experimental)",
     )
     g_fmap.add_argument(
         "--fmap-no-demean",
-        "--fmap_no_demean",
         action="store_false",
         default=True,
         help="Do not remove median (within mask) from fieldmap",
@@ -575,7 +536,6 @@ def _build_parser(**kwargs):
     g_syn = parser.add_argument_group("Specific options for SyN distortion correction")
     g_syn.add_argument(
         "--use-syn-sdc",
-        "--use_syn_sdc",
         nargs="?",
         choices=["warn", "error"],
         action="store",
@@ -586,7 +546,6 @@ def _build_parser(**kwargs):
     )
     g_syn.add_argument(
         "--force-syn",
-        "--force_syn",
         action="store_true",
         default=False,
         help="EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to "
@@ -606,7 +565,6 @@ def _build_parser(**kwargs):
     g_other.add_argument(
         "-w",
         "--work-dir",
-        "--work_dir",
         action="store",
         type=Path,
         default=Path("work").absolute(),
@@ -614,14 +572,12 @@ def _build_parser(**kwargs):
     )
     g_other.add_argument(
         "--resource-monitor",
-        "--resource_monitor",
         action="store_true",
         default=False,
         help="Enable Nipype's resource monitoring to keep track of memory and CPU usage",
     )
     g_other.add_argument(
         "--config-file",
-        "--config_file",
         action="store",
         metavar="FILE",
         help="Use pre-generated configuration file. Values in file will be overridden "
@@ -629,14 +585,12 @@ def _build_parser(**kwargs):
     )
     g_other.add_argument(
         "--write-graph",
-        "--write_graph",
         action="store_true",
         default=False,
         help="Write workflow graph.",
     )
     g_other.add_argument(
         "--stop-on-first-crash",
-        "--stop_on_first_crash",
         action="store_true",
         default=False,
         help="Force stopping on first crash, even if a work directory was specified.",

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -180,8 +180,8 @@ def _build_parser(**kwargs):
 
     g_bids = parser.add_argument_group("Options for filtering BIDS queries")
     g_bids.add_argument(
-        "--skip_bids_validation",
         "--skip-bids-validation",
+        "--skip_bids_validation",
         action="store_true",
         default=False,
         help="Assume the input dataset is BIDS compliant and skip the validation",
@@ -197,6 +197,7 @@ def _build_parser(**kwargs):
     )
     g_bids.add_argument(
         "--session-id",
+        "--session_id",
         action="store",
         nargs="+",
         type=_drop_ses,
@@ -207,6 +208,7 @@ def _build_parser(**kwargs):
 
     g_bids.add_argument(
         "--bids-filter-file",
+        "--bids_filter_file",
         dest="bids_filters",
         action="store",
         type=BIDSFilter,
@@ -219,6 +221,7 @@ def _build_parser(**kwargs):
     )
     g_bids.add_argument(
         "--bids-database-dir",
+        "--bids_database_dir",
         metavar="PATH",
         type=Path,
         help="Path to a PyBIDS database folder, for faster indexing (especially "
@@ -238,6 +241,7 @@ def _build_parser(**kwargs):
     )
     g_perfm.add_argument(
         "--omp-nthreads",
+        "--omp_nthreads",
         action="store",
         type=PositiveInt,
         help="Maximum number of threads per-process",
@@ -254,6 +258,7 @@ def _build_parser(**kwargs):
     )
     g_perfm.add_argument(
         "--low-mem",
+        "--low_mem",
         action="store_true",
         help="Attempt to reduce memory usage (will increase disk usage in working directory)",
     )
@@ -276,6 +281,7 @@ def _build_parser(**kwargs):
     g_subset.add_argument("--anat-only", action="store_true", help="Run anatomical workflows only")
     g_subset.add_argument(
         "--dwi-only",
+        "--dwi_only",
         action="store_true",
         help="ignore anatomical (T1w/T2w) data and process DWIs only",
     )
@@ -289,6 +295,7 @@ def _build_parser(**kwargs):
     )
     g_subset.add_argument(
         "--reports-only",
+        "--reports_only",
         action="store_true",
         default=False,
         help="Only generate reports, don't run workflows. This will only rerun report "
@@ -320,6 +327,7 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--subject-anatomical-reference",
+        "--subject_anatomical_reference",
         choices=["first-alphabetically", "unbiased", "sessionwise"],
         default="first-alphabetically",
         help="How to define subject-specific anatomical space. "
@@ -329,6 +337,7 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--skip-anat-based-spatial-normalization",
+        "--skip_anat_based_spatial_normalization",
         action="store_true",
         default=False,
         help="skip running the anat-based normalization to template space. "
@@ -354,8 +363,8 @@ def _build_parser(**kwargs):
         "lowered or increased. Note, setting this too high can result in inaccurate results.",
     )
     g_conf.add_argument(
-        "--dwi_denoise_window",
         "--dwi-denoise-window",
+        "--dwi_denoise_window",
         action="store",
         default="auto",
         help='window size in voxels for image-based denoising, integer or "auto".'
@@ -410,8 +419,8 @@ def _build_parser(**kwargs):
         help="run ``dwidenoise`` after combining dwis, but before motion correction",
     )
     g_conf.add_argument(
-        "--separate_all_dwis",
         "--separate-all-dwis",
+        "--separate_all_dwis",
         action="store_true",
         help="don't attempt to combine dwis from multiple runs. Each will be "
         "processed separately.",
@@ -431,6 +440,7 @@ def _build_parser(**kwargs):
     )
     g_conf.add_argument(
         "--anatomical-template",
+        "--anatomical_template",
         required=False,
         action="store",
         choices=["MNI152NLin2009cAsym"],
@@ -508,8 +518,8 @@ def _build_parser(**kwargs):
         help="transformation to be optimized during head motion correction " "(default: affine)",
     )
     g_moco.add_argument(
-        "--hmc_model",
         "--hmc-model",
+        "--hmc_model",
         action="store",
         default="eddy",
         choices=["none", "3dSHORE", "eddy", "tensor"],
@@ -528,8 +538,8 @@ def _build_parser(**kwargs):
         "https://github.com/PennLINC/qsiprep/blob/master/qsiprep/data/eddy_params.json",
     )
     g_moco.add_argument(
-        "--shoreline_iters",
         "--shoreline-iters",
+        "--shoreline_iters",
         action="store",
         type=int,
         default=2,
@@ -548,12 +558,14 @@ def _build_parser(**kwargs):
     )
     g_fmap.add_argument(
         "--fmap-bspline",
+        "--fmap_bspline",
         action="store_true",
         default=False,
         help="Fit a B-Spline field using least-squares (experimental)",
     )
     g_fmap.add_argument(
         "--fmap-no-demean",
+        "--fmap_no_demean",
         action="store_false",
         default=True,
         help="Do not remove median (within mask) from fieldmap",
@@ -563,6 +575,7 @@ def _build_parser(**kwargs):
     g_syn = parser.add_argument_group("Specific options for SyN distortion correction")
     g_syn.add_argument(
         "--use-syn-sdc",
+        "--use_syn_sdc",
         nargs="?",
         choices=["warn", "error"],
         action="store",
@@ -573,6 +586,7 @@ def _build_parser(**kwargs):
     )
     g_syn.add_argument(
         "--force-syn",
+        "--force_syn",
         action="store_true",
         default=False,
         help="EXPERIMENTAL/TEMPORARY: Use SyN correction in addition to "
@@ -592,6 +606,7 @@ def _build_parser(**kwargs):
     g_other.add_argument(
         "-w",
         "--work-dir",
+        "--work_dir",
         action="store",
         type=Path,
         default=Path("work").absolute(),
@@ -599,12 +614,14 @@ def _build_parser(**kwargs):
     )
     g_other.add_argument(
         "--resource-monitor",
+        "--resource_monitor",
         action="store_true",
         default=False,
         help="Enable Nipype's resource monitoring to keep track of memory and CPU usage",
     )
     g_other.add_argument(
         "--config-file",
+        "--config_file",
         action="store",
         metavar="FILE",
         help="Use pre-generated configuration file. Values in file will be overridden "
@@ -612,12 +629,14 @@ def _build_parser(**kwargs):
     )
     g_other.add_argument(
         "--write-graph",
+        "--write_graph",
         action="store_true",
         default=False,
         help="Write workflow graph.",
     )
     g_other.add_argument(
         "--stop-on-first-crash",
+        "--stop_on_first_crash",
         action="store_true",
         default=False,
         help="Force stopping on first crash, even if a work directory was specified.",

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -687,7 +687,7 @@ def parse_args(args=None, namespace=None):
     if 1 < config.nipype.nprocs < config.nipype.omp_nthreads:
         build_log.warning(
             f"Per-process threads (--omp-nthreads={config.nipype.omp_nthreads}) exceed "
-            f"total threads (--nthreads/--n_cpus={config.nipype.nprocs})"
+            f"total threads (--nthreads/--n-cpus={config.nipype.nprocs})"
         )
 
     # Validate the tricky options here

--- a/qsiprep/tests/test_cli.py
+++ b/qsiprep/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from unittest.mock import DEFAULT, patch
+from unittest.mock import patch
 
 import pytest
 from nipype import config as nipype_config
@@ -99,7 +99,7 @@ def test_dscsdsi_fmap(data_dir, output_dir, working_dir):
         "--sloppy",
         "--b0-motion-corr-to=first",
         "--write-graph",
-        "--mem_mb=4096",
+        "--mem-mb=4096",
         "--output-resolution=5",
     ]
 
@@ -141,9 +141,9 @@ def test_cuda(data_dir, output_dir, working_dir):
         "--sloppy",
         "--anat-modality=none",
         "--denoise-method=none",
-        "--b1_biascorrect_stage=none",
+        "--b1-biascorrect-stage=none",
         "--pepolar-method=DRBUDDI",
-        f"--eddy_config={eddy_config}",
+        f"--eddy-config={eddy_config}",
         "--output-resolution=5",
     ]
 
@@ -187,9 +187,9 @@ def test_drbuddi_rpe(data_dir, output_dir, working_dir):
         "--anat-modality=none",
         "--denoise-method=none",
         "--b0-motion-corr-to=first",
-        "--b1_biascorrect_stage=none",
+        "--b1-biascorrect-stage=none",
         "--pepolar-method=DRBUDDI",
-        f"--eddy_config={eddy_config}",
+        f"--eddy-config={eddy_config}",
         "--output-resolution=5",
     ]
 
@@ -429,7 +429,7 @@ def test_intramodal_template(data_dir, output_dir, working_dir):
         "participant",
         f"-w={work_dir}",
         "--b1-biascorrect-stage=none",
-        "--hmc_model=none",
+        "--hmc-model=none",
         "--b0-motion-corr-to=first",
         "--output-resolution=5",
         "--intramodal-template-transform=BSplineSyN",
@@ -465,7 +465,7 @@ def test_multi_t1w(data_dir, output_dir, working_dir):
         "participant",
         f"-w={work_dir}",
         "--b1-biascorrect-stage=none",
-        "--hmc_model=none",
+        "--hmc-model=none",
         "--b0-motion-corr-to=first",
         "--output-resolution=5",
         "--intramodal-template-transform=BSplineSyN",

--- a/qsiprep/tests/test_cli.py
+++ b/qsiprep/tests/test_cli.py
@@ -57,7 +57,7 @@ def test_dsdti_fmap(data_dir, output_dir, working_dir):
         "--boilerplate",
         "--sloppy",
         "--write-graph",
-        "--mem_mb=4096",
+        "--mem-mb=4096",
         "--output-resolution=5",
     ]
 


### PR DESCRIPTION
Closes none. This is a breaking change because parameter names have effectively been changed.

## Changes proposed in this pull request

- Remove underscore versions of all parameters (e.g., `--anat_only` instead of `--anat-only`).
- Add dash versions where they were missing.