### PR TITLE
Use correct base name with `--distortion-group-merge average`

### DIFF
--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -342,6 +342,7 @@ to workflows in *QSIPrep*'s documentation]\
                 merging_strategy=config.workflow.distortion_group_merge,
                 source_file=merged_group + "_dwi.nii.gz",
                 inputs_list=merged_to_subgroups[merged_group],
+                output_prefix=merged_group,
                 name=merged_group.replace("-", "_") + "_final_merge_wf",
             )
 

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -189,9 +189,7 @@ def init_distortion_group_merge_wf(
         name="processed_qc_wf",
     )
     # Combine all the QC measures for a series QC
-    series_qc = pe.Node(
-        SeriesQC(output_file_name=config.execution.output_prefix), name="series_qc"
-    )
+    series_qc = pe.Node(SeriesQC(output_file_name=source_file), name="series_qc")
     ds_series_qc = pe.Node(
         DerivativesDataSink(
             desc="ImageQC",

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -32,6 +32,7 @@ def init_distortion_group_merge_wf(
     merging_strategy,
     inputs_list,
     source_file,
+    output_prefix,
     name,
 ) -> Workflow:
     """Create an unbiased intramodal template for a subject. This aligns the b=0 references
@@ -189,7 +190,7 @@ def init_distortion_group_merge_wf(
         name="processed_qc_wf",
     )
     # Combine all the QC measures for a series QC
-    series_qc = pe.Node(SeriesQC(output_file_name=source_file), name="series_qc")
+    series_qc = pe.Node(SeriesQC(output_file_name=output_prefix), name="series_qc")
     ds_series_qc = pe.Node(
         DerivativesDataSink(
             desc="ImageQC",


### PR DESCRIPTION
Closes #838.

## Changes proposed in this pull request

- Replace nonexistent config value with merged source filename in `init_distortion_group_merge_wf`.