### PR TITLE
Move common metadata to top of JSON

### DIFF
--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -450,8 +450,10 @@ def scan_groups_to_sidecar(scan_groups):
     derivatives_metadata["SourceMetadata"] = scan_metadata
 
     # Copy common fields to the top level of the sidecar
-    common_metadata = scan_metadata[0]
-    for scan_metadata_dict in scan_metadata[1:]:
+
+    common_metadata = scan_metadata[concatenated_dwi_files[0]]
+    for dwi_file in concatenated_dwi_files[1:]:
+        scan_metadata_dict = scan_metadata[dwi_file]
         keys_to_remove = []
         for key in common_metadata:
             if key not in scan_metadata_dict:

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -468,7 +468,7 @@ def scan_groups_to_sidecar(scan_groups):
 
     derivatives_metadata["SourceMetadata"] = scan_metadata
     derivatives_metadata = {**common_metadata, **derivatives_metadata}
-derivatives_metadata["Sources"] = sorted(scan_metadata.keys())
+    derivatives_metadata["Sources"] = sorted(scan_metadata.keys())
     return derivatives_metadata
 
 

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -436,7 +436,6 @@ def scan_groups_to_sidecar(scan_groups):
 
     # Add the information about how the images were grouped and which fieldmaps were used
     derivatives_metadata = {"ScanGrouping": scan_groups}
-    derivatives_metadata["Sources"] = scan_groups["dwi_series"]
 
     # Get metadata from the individual scans that were combined to make this preprocessed image
     concatenated_dwi_files = scan_groups.get("dwi_series")
@@ -469,7 +468,7 @@ def scan_groups_to_sidecar(scan_groups):
 
     derivatives_metadata["SourceMetadata"] = scan_metadata
     derivatives_metadata = {**common_metadata, **derivatives_metadata}
-
+derivatives_metadata["Sources"] = sorted(scan_metadata.keys())
     return derivatives_metadata
 
 

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -436,7 +436,7 @@ def scan_groups_to_sidecar(scan_groups):
 
     # Add the information about how the images were grouped and which fieldmaps were used
     derivatives_metadata = {"ScanGrouping": scan_groups}
-    derivatives_metadata["Sources"] = scan_groups["dwi_files"]
+    derivatives_metadata["Sources"] = scan_groups["dwi_series"]
 
     # Get metadata from the individual scans that were combined to make this preprocessed image
     concatenated_dwi_files = scan_groups.get("dwi_series")


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Compare metadata dictionaries across runs in a merge group and compile the metadata fields that are consistent across runs. This then goes in the merged JSON file. QSIRecon can reference the metadata fields at the top level of the JSON.
    - In cases where the constituent runs don't have the same value for a given field, that field will be represented in the "SourceMetadata" field, but not in the top level of the JSON.
- Rename "scan_grouping" field to "ScanGrouping".  **THIS IS A BREAKING CHANGE**
- Rename "source_metadata" field to "SourceMetadata". **THIS IS A BREAKING CHANGE**
- Add "Sources" field to the JSON. I want to change all of the paths to BIDS-URIs in the future, but it's not a high priority item.