### PR TITLE
Hardcode extensions for GIF figures

### DIFF
--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -109,7 +109,7 @@ sections:
   reportlets:
   - bids: {datatype: figures, desc: summary, suffix: dwi}
   - bids: {datatype: figures, desc: validation, suffix: dwi}
-  - bids: {datatype: figures, desc: samplingscheme, suffix: dwi}
+  - bids: {datatype: figures, desc: samplingscheme, suffix: dwi, extension: [.png]}
     caption: |
       Animation of the DWI sampling scheme. Each separate scan is its own color
     static: false
@@ -235,7 +235,7 @@ sections:
     static: false
     subtitle: Reorientation of DWI reference image to AC-PC
 
-  - bids: {datatype: figures, desc: shorelineiters, suffix: dwi}
+  - bids: {datatype: figures, desc: shorelineiters, suffix: dwi, extension: [.png]}
     caption: |
       Difference in motion estimates over SHORELine iterations. Values close to zero
       indicate good convergence.


### PR DESCRIPTION
This is just until the next nireports release is made, since GIFs aren't supported yet and that's breaking the HTML report generation.

## Changes proposed in this pull request

- Hardcode extensions for figures that are actually GIFs as PNGs so they get skipped until nireports can support GIFs.