### PR TITLE
[FIX] synthstrip extra arg

### DIFF
--- a/qsiprep/workflows/fieldmap/pepolar.py
+++ b/qsiprep/workflows/fieldmap/pepolar.py
@@ -272,7 +272,7 @@ def init_extended_pepolar_report_wf(
             ants.N4BiasFieldCorrection(dimension=3), name="t2w_n4", n_procs=omp_nthreads
         )
 
-        strip_t2w_wf = init_synthstrip_wf(do_padding=True, omp_nthreads=omp_nthreads)
+        strip_t2w_wf = init_synthstrip_wf(do_padding=True)
 
         t2w_atropos = pe.Node(
             ants.Atropos(


### PR DESCRIPTION
I found this when testing the HBCD data locally. We don't have any T2w anat CI tests, so this flew under the radar