### PR TITLE
Pin nireports version and allow GIFs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "nibabel <= 5.2.0",
     "nilearn == 0.10.1",
     "nipype == 1.8.6",
-    "nireports",
+    "nireports >= 24.0.3",
     "niworkflows >=1.9,<= 1.10",
     "numpy <= 1.26.3",
     "pandas < 2.0.0",

--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -109,7 +109,7 @@ sections:
   reportlets:
   - bids: {datatype: figures, desc: summary, suffix: dwi}
   - bids: {datatype: figures, desc: validation, suffix: dwi}
-  - bids: {datatype: figures, desc: samplingscheme, suffix: dwi, extension: [.png]}
+  - bids: {datatype: figures, desc: samplingscheme, suffix: dwi}
     caption: |
       Animation of the DWI sampling scheme. Each separate scan is its own color
     static: false
@@ -235,7 +235,7 @@ sections:
     static: false
     subtitle: Reorientation of DWI reference image to AC-PC
 
-  - bids: {datatype: figures, desc: shorelineiters, suffix: dwi, extension: [.png]}
+  - bids: {datatype: figures, desc: shorelineiters, suffix: dwi}
     caption: |
       Difference in motion estimates over SHORELine iterations. Values close to zero
       indicate good convergence.


### PR DESCRIPTION
Closes none. Overrides the changes in #880.

## Changes proposed in this pull request

- Stop hardcoding extensions for GIF figures.
- Pin Nireports version to one that supports GIFs.