### PR TITLE
Calculate patch radius from number of volumes in DWI run

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -168,6 +168,7 @@ def _build_parser(**kwargs):
     PathExists = partial(_path_exists, parser=parser)
     IsFile = partial(_is_file, parser=parser)
     PositiveInt = partial(_min_one, parser=parser)
+    IntOrAuto = partial(_int_or_auto, parser=parser)
     BIDSFilter = partial(_bids_filter, parser=parser)
 
     # Arguments as specified by BIDS-Apps
@@ -363,7 +364,7 @@ def _build_parser(**kwargs):
     g_conf.add_argument(
         '--dwi-denoise-window',
         action='store',
-        type=_int_or_auto,
+        type=IntOrAuto,
         default='auto',
         help=(
             'Window size in voxels for image-based denoising: integer or "auto". '

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -111,6 +111,9 @@ def _build_parser(**kwargs):
         if value < 1:
             raise parser.error('Argument must be greater than zero.')
 
+        if value % 2 == 0:
+            raise parser.error('Argument must be an odd integer.')
+
         return value
 
     def _to_gb(value):
@@ -368,6 +371,7 @@ def _build_parser(**kwargs):
         default='auto',
         help=(
             'Window size in voxels for image-based denoising: integer or "auto". '
+            'Any non-"auto" value must be an odd, positive integer. '
             'If using the "dwidenoise" denoising method, '
             'the "auto" option will calculate a window size '
             'based on the number of volumes according to the method described by the '

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -101,7 +101,7 @@ def _build_parser(**kwargs):
 
     def _int_or_auto(value, parser):
         """Ensure an argument is an integer or 'auto'."""
-        if value == 'auto':
+        if value.lower() == 'auto':
             return value
         try:
             value = int(value)
@@ -370,7 +370,7 @@ def _build_parser(**kwargs):
         type=IntOrAuto,
         default='auto',
         help=(
-            'Window size in voxels for image-based denoising: integer or "auto". '
+            'Window size in voxels for image-based denoising: odd integer or "auto". '
             'Any non-"auto" value must be an odd, positive integer. '
             'If using the "dwidenoise" denoising method, '
             'the "auto" option will calculate a window size '
@@ -722,7 +722,7 @@ def parse_args(args=None, namespace=None):
                 'The --dwi-denoise-window option is not used when --denoise-method=patch2self'
             )
         elif config.workflow.denoise_method == 'none':
-            config.loggers.cli.error(
+            config.loggers.cli.warning(
                 'The --dwi-denoise-window option is not used when --denoise-method=none'
             )
 

--- a/qsiprep/data/boilerplate.bib
+++ b/qsiprep/data/boilerplate.bib
@@ -394,13 +394,15 @@
 }
 
 @article{mrtrix3,
-  title = {MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation},
-  author = {J-Donald and Smith, Robert and Raffelt, David and Tabbara, Rami and Dhollander, Thijs and Pietsch, Maximilian and Christiaens, Daan and Jeurissen, Ben and Yeh, Chun-Hung and Connelly, Alan"},
-  journal = {NeuroImage},
-  volume = {202},
-  pages = {116137},
-  year = {2019},
-  issn={1053-8119},
+  title={MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation},
+  author={Tournier, J-Donald and Smith, Robert and Raffelt, David and Tabbara, Rami and Dhollander, Thijs and Pietsch, Maximilian and Christiaens, Daan and Jeurissen, Ben and Yeh, Chun-Hung and Connelly, Alan},
+  journal={Neuroimage},
+  volume={202},
+  pages={116137},
+  year={2019},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2019.116137},
+  doi={10.1016/j.neuroimage.2019.116137}
 }
 
 @article{originalcsd,
@@ -535,7 +537,8 @@
   author={Fadnavis, Shreyas and Batson, Joshua and Garyfallidis, Eleftherios},
   journal={Advances in Neural Information Processing Systems},
   volume={33},
-  year={2020}
+  year={2020},
+  url={https://proceedings.neurips.cc/paper_files/paper/2020/file/bc047286b224b7bfa73d4cb02de1238d-Paper.pdf},
 }
 
 @article{noddi,
@@ -639,4 +642,16 @@
   publisher={Elsevier},
   url={https://doi.org/10.1016/j.neuroimage.2016.08.009},
   doi={10.1016/j.neuroimage.2016.08.009}
+}
+
+@article{cordero2019complex,
+  title={Complex diffusion-weighted image estimation via matrix recovery under general noise models},
+  author={Cordero-Grande, Lucilio and Christiaens, Daan and Hutter, Jana and Price, Anthony N and Hajnal, Jo V},
+  journal={Neuroimage},
+  volume={200},
+  pages={391--404},
+  year={2019},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2019.06.039},
+  doi={10.1016/j.neuroimage.2019.06.039}
 }

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -635,7 +635,7 @@ def init_dwi_model_hmc_wf(
         name='outputnode',
     )
     workflow.__desc__ = (
-        'The the SHORELine method was used to estimate head motion in b>0 '
+        'The SHORELine method was used to estimate head motion in b>0 '
         'images. This entails leaving out each b>0 image and reconstructing '
         'the others using 3dSHORE [@merlet3dshore]. The signal for the left-'
         f'out image serves as the registration target. A total of {num_iters} '

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -445,7 +445,7 @@ def init_dwi_denoising_wf(
             # Configure the denoising window
             import numpy as np
 
-            dwi_denoise_window = closest_odd(np.cbrt(n_volumes))
+            dwi_denoise_window = closest_odd(int(np.cbrt(n_volumes)))
             config.loggers.workflow.info(
                 f'Automatically using {dwi_denoise_window}, {dwi_denoise_window}, '
                 f'{dwi_denoise_window} window for dwidenoise'

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -672,19 +672,13 @@ def _as_list(item):
 def gen_denoising_boilerplate():
     """Generate a methods boilerplate for the denoising workflow."""
 
-    denoise_method = config.workflow.denoise_method
-    dwi_denoise_window = config.workflow.dwi_denoise_window
-    unringing_method = config.workflow.unringing_method
     b1_biascorrect_stage = config.workflow.b1_biascorrect_stage
     no_b0_harmonization = config.workflow.no_b0_harmonization
     b0_threshold = config.workflow.b0_threshold
-    use_phase = 'phase' not in config.workflow.ignore
     desc = [
         f'Any images with a b-value less than {b0_threshold} s/mm^2 were treated as a '
         '*b*=0 image.'
     ]
-    do_denoise = denoise_method in ('dwidenoise', 'patch2self')
-    do_unringing = unringing_method in ('rpg', 'mrdegibbs')
     harmonize_b0s = not no_b0_harmonization
     last_step = ''
 

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -525,7 +525,7 @@ def init_dwi_denoising_wf(
         else:
             desc += (
                 "DWI data were denoised using DiPy's Patch2Self algorithm [@dipy; @patch2self] "
-                "with an automatically-defined window size. "
+                'with an automatically-defined window size. '
             )
             denoiser = pe.Node(
                 Patch2Self(),

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -414,8 +414,13 @@ def init_dwi_denoising_wf(
     if (
         config.workflow.denoise_method == 'dwidenoise'
     ) and config.workflow.dwi_denoise_window == 'auto':
-        dwi_denoise_window = 5
-        config.loggers.workflow.info('Automatically using 5, 5, 5 window for dwidenoise')
+        import numpy as np
+
+        dwi_denoise_window = closest_odd(np.cbrt(n_volumes))
+        config.loggers.workflow.info(
+            f'Automatically using {dwi_denoise_window}, {dwi_denoise_window}, '
+            f'{dwi_denoise_window} window for dwidenoise'
+        )
 
     # How many steps in the denoising pipeline
     num_steps = sum(map(int, [do_denoise, do_unringing, do_biascorr, harmonize_b0s]))
@@ -734,3 +739,10 @@ def get_merged_parameter(parameter_df, parameter_name, selection_mode='all'):
         return col.mode()[0]
 
     raise Exception("selection_mode must be 'all' or 'mode'")
+
+
+def closest_odd(x):
+    if x % 2 == 0:
+        return x - 1
+    else:
+        return x

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -684,7 +684,7 @@ def gen_denoising_boilerplate():
 
     if harmonize_b0s:
         desc.append(
-            f'{last_step}the mean intensity of the DWI series was adjusted '
+            'The mean intensity of the DWI series was adjusted '
             'so all the mean intensity of the b=0 images matched across each'
             'separate DWI scanning sequence.'
         )

--- a/qsiprep/workflows/fieldmap/syn.py
+++ b/qsiprep/workflows/fieldmap/syn.py
@@ -135,7 +135,7 @@ def init_syn_sdc_wf(bold_pe=None, atlas_threshold=2):
     workflow = Workflow(name='syn_sdc_wf')
     workflow.__desc__ = f"""\
 A deformation field to correct for susceptibility distortions was estimated
-based on *fmriprep*'s *fieldmap-less* approach.
+based on *fMRIPrep*'s *fieldmap-less* approach.
 The deformation field is that resulting from co-registering the b0 reference
 to the same-subject T1w-reference with its intensity inverted [@fieldmapless1;
 @fieldmapless2].


### PR DESCRIPTION
Closes #845.

## Changes proposed in this pull request

- When using `--denoise-method dwidenoise` and `--dwi-denoise-window auto`, replace default value of 5 with what we _think_ dwidenoise's default value will be based on the number of volumes in the DWI run.
- Ignore `--dwi-denoise-window` when using `patch2self`.
    - Raise an error at the parsing step if a user selects a non-default value for `--dwi-denoise-window` _and_ either `--denoise-method none` or `--denoise-method patch2self`.
- Check that `--dwi-denoise-window` is a positive, odd integer when it is supplied.
- Update the boilerplate to include the new dwi-denoise-window value.