### PR TITLE
Fix session processing for datasets with mixed modalities

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -800,10 +800,11 @@ def parse_args(args=None, namespace=None):
 
     # Examine the available sessions for each participant
     for subject_id in participant_label:
+        # Find sessions with DWI data
         sessions = config.execution.layout.get_sessions(
             subject=subject_id,
             session=session_filters or Query.OPTIONAL,
-            suffix=['T1w', 'T2w', 'dwi'],
+            suffix=['dwi'],
         )
 
         # If there are no sessions, there is only one option:
@@ -811,7 +812,7 @@ def parse_args(args=None, namespace=None):
             if config.workflow.subject_anatomical_reference == 'sessionwise':
                 config.loggers.workflow.warning(
                     f'Subject {subject_id} had no sessions, '
-                    "but --subject-anatomical-reference was set to 'sessionwise'. "
+                    'but --subject-anatomical-reference was set to "sessionwise". '
                     'Outputs will NOT appear in a session directory for '
                     f'{subject_id}.',
                 )
@@ -823,6 +824,12 @@ def parse_args(args=None, namespace=None):
             for session in sessions:
                 processing_groups.append([subject_id, [session]])
         else:
+            # We can now use sessions that have anatomical data, but no DWI
+            sessions = config.execution.layout.get_sessions(
+                subject=subject_id,
+                session=session_filters or Query.OPTIONAL,
+                suffix=['dwi', 'T1w', 'T2w'],
+            )
             processing_groups.append([subject_id, sessions])
 
     # Make a nicely formatted message showing what we will process

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -206,8 +206,11 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
     }
     bids_filters = filters or {}
     for acq, entities in bids_filters.items():
-        if 'session' in queries[acq]:
-            config.loggers.workflow.warning('BIDS filter file value for session may conflict with values specified on the command line')
+        if ('session' in queries[acq]) and (session_id is not None):
+            config.loggers.workflow.warning(
+                'BIDS filter file value for session may conflict with values specified '
+                'on the command line'
+            )
         queries[acq]['session'] = session_id or Query.OPTIONAL
         queries[acq].update(entities)
 

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -206,6 +206,7 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
     }
     bids_filters = filters or {}
     for acq, entities in bids_filters.items():
+        queries[acq]['session'] = session_id or Query.OPTIONAL
         queries[acq].update(entities)
 
     subj_data = {
@@ -213,7 +214,6 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
             layout.get(
                 return_type='file',
                 subject=participant_label,
-                session=session_id or Query.OPTIONAL,
                 extension=['nii', 'nii.gz'],
                 **query,
             )

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -206,6 +206,8 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
     }
     bids_filters = filters or {}
     for acq, entities in bids_filters.items():
+        if 'session' in queries[acq]:
+            config.loggers.workflow.warning('BIDS filter file value for session may conflict with values specified on the command line')
         queries[acq]['session'] = session_id or Query.OPTIONAL
         queries[acq].update(entities)
 


### PR DESCRIPTION
Closes none, but addresses two bugs identified by @araikes.

## Changes proposed in this pull request

- Directly merge "session_id" (from the processing list) into the BIDS queries (which include the BIDS filters, which in turn may include "session") within `collect_data`.
    - This should fix a bug that comes from using `--subject-anatomical-reference sessionwise` in combination with a `--bids-filter-file` that includes `session` fields.
- Limit session-wise processing to sessions with DWI data.
    - This should fix a bug that comes from using `--subject-anatomical-reference sessionwise` on a dataset where some sessions have anatomical data without a corresponding DWI scan.