### PR TITLE
ENH: Update eddy_params.json

### DIFF
--- a/qsiprep/data/eddy_params.json
+++ b/qsiprep/data/eddy_params.json
@@ -1,5 +1,5 @@
 {
-  "flm": "linear",
+  "flm": "quadratic",
   "slm": "linear",
   "fep": false,
   "interp": "spline",


### PR DESCRIPTION
## Changes proposed in this pull request

Change the default eddy flm from linear to quadratic. This matches the eddy default.

The slm remains linear, as recommended for lower-resolution data.


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->

I don't think the defaults are mentioned in the docs.

