### PR TITLE
Group DWI scans by MultipartID when available

### DIFF
--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -37,7 +37,7 @@ It is also common to collect a DWI scan (or scans) in the reverse phase encoding
 to use for susceptibility distortion correction (SDC).
 
 
-.. topic:: Encoding scan merging intent with BIDS metadata
+.. admonition:: Encoding scan merging intent with BIDS metadata
 
   The most appropriate way to explicitly specify which DWIs should be merged is to use the
   `"MultipartID" metadata field <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes>`_.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -37,13 +37,15 @@ It is also common to collect a DWI scan (or scans) in the reverse phase encoding
 to use for susceptibility distortion correction (SDC).
 
 
-..topic:: Encoding scan merging intent with BIDS metadata
+.. topic:: Encoding scan merging intent with BIDS metadata
 
   The most appropriate way to explicitly specify which DWIs should be merged is to use the
-  ``MultipartID` metadata field <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes`_.
+  `"MultipartID" metadata field <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes>`_.
   This field is a unique string (per participant) that identifies a set of DWIs that should be considered as part of the same acquisition.
   If a DWI scan has the same MultipartID as another DWI scan, it will be merged with the other DWI scan.
   This can be specified across phase encoding directions (PEDs), in which case the DWIs will be merged across PEDs.
+
+  If you do not specify a ``MultipartID``, *QSIPrep* will group DWIs within each session based on the ``acq`` entity.
 
 This creates a number of possible scenarios for preprocessing your DWIs. These
 scenarios can be controlled by the ``--separate-all-dwis`` argument. If your study

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -40,7 +40,7 @@ to use for susceptibility distortion correction (SDC).
 .. admonition:: Encoding scan merging intent with BIDS metadata
 
   The most appropriate way to explicitly specify which DWIs should be merged is to use the
-  `"MultipartID" metadata field <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes>`_.
+  `"MultipartID" metadata field <https://bids-specification.readthedocs.io/en/v1.10.0/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes>`_.
   This field is a unique string (per participant) that identifies a set of DWIs that should be considered as part of the same acquisition.
   If a DWI scan has the same MultipartID as another DWI scan, it will be merged with the other DWI scan.
   This can be specified across phase encoding directions (PEDs), in which case the DWIs will be merged across PEDs.

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -30,10 +30,20 @@ Merging multiple scans from a session
 ======================================
 
 For q-space imaging sequences it is common to have multiple separate scans to
-acquire the entire sampling scheme. These scans get aligned and merged into
-a single DWI series before reconstruction. It is also common to collect
-a DWI scan (or scans) in the reverse phase encoding direction to use for
-susceptibility distortion correction (SDC).
+acquire the entire sampling scheme.
+These scans get aligned and merged into a single DWI series before reconstruction.
+
+It is also common to collect a DWI scan (or scans) in the reverse phase encoding direction
+to use for susceptibility distortion correction (SDC).
+
+
+..topic:: Encoding scan merging intent with BIDS metadata
+
+  The most appropriate way to explicitly specify which DWIs should be merged is to use the
+  ``MultipartID` metadata field <https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#multipart-split-dwi-schemes`_.
+  This field is a unique string (per participant) that identifies a set of DWIs that should be considered as part of the same acquisition.
+  If a DWI scan has the same MultipartID as another DWI scan, it will be merged with the other DWI scan.
+  This can be specified across phase encoding directions (PEDs), in which case the DWIs will be merged across PEDs.
 
 This creates a number of possible scenarios for preprocessing your DWIs. These
 scenarios can be controlled by the ``--separate-all-dwis`` argument. If your study

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -45,7 +45,7 @@ to use for susceptibility distortion correction (SDC).
   If a DWI scan has the same MultipartID as another DWI scan, it will be merged with the other DWI scan.
   This can be specified across phase encoding directions (PEDs), in which case the DWIs will be merged across PEDs.
 
-  If you do not specify a ``MultipartID``, *QSIPrep* will group DWIs within each session based on the ``acq`` entity.
+  If you do not specify a ``MultipartID``, *QSIPrep* will group all DWIs within each session.
 
 This creates a number of possible scenarios for preprocessing your DWIs. These
 scenarios can be controlled by the ``--separate-all-dwis`` argument. If your study

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -36,7 +36,7 @@ Grouping scans
    ``--dwi-denoise-window``
 
 Assuming that ``sub-1/ses-1/fmap/sub-1_dir-PA_epi.nii.gz`` has a JSON sidecar containing the ``IntendedFor`` field for fieldmap correction
-(`see here <https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#expressing-the-mr-protocol-intent-for-fieldmaps>`_)::
+(`see here <https://bids-specification.readthedocs.io/en/v1.10.0/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#expressing-the-mr-protocol-intent-for-fieldmaps>`_)::
 
   "IntendedFor": [
     "ses-1/dwi/sub-1_ses-1_acq-multishell_run-01_dwi.nii.gz",

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -35,7 +35,8 @@ Grouping scans
    This section explains ``--separate-all-dwis``, ``--denoise-after-combining`` and
    ``--dwi-denoise-window``
 
-Assuming that ``sub-1/ses-1/fmap/sub-1_dir-PA_epi.nii.gz`` has a JSON sidecar containing the ``IntendedFor`` field for fieldmap correction (`see here <https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#expressing-the-mr-protocol-intent-for-fieldmaps>`__)::
+Assuming that ``sub-1/ses-1/fmap/sub-1_dir-PA_epi.nii.gz`` has a JSON sidecar containing the ``IntendedFor`` field for fieldmap correction
+(`see here <https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#expressing-the-mr-protocol-intent-for-fieldmaps>`_)::
 
   "IntendedFor": [
     "ses-1/dwi/sub-1_ses-1_acq-multishell_run-01_dwi.nii.gz",
@@ -44,16 +45,16 @@ Assuming that ``sub-1/ses-1/fmap/sub-1_dir-PA_epi.nii.gz`` has a JSON sidecar co
   ]
 
 *QSIPrep* will infer that the dwi scans are in the same **warped space** - that their
-susceptibility distortions are shared and they can be combined before head motion correction. Since
-we didn't specify ``--separate-all-dwis`` the separate scans will be merged together before head motion
+susceptibility distortions are shared and they can be combined before head motion correction.
+Since we didn't specify ``--separate-all-dwis``,
+the separate scans will be merged together before head motion
 correction and the fully preprocessed outputs will be written to
-``derivitaves/qsiprep/sub-1/ses-1/dwi/sub-1_ses-1_acq-multishell_desc-preproc_dwi.nii.gz``. otherwise
-there will be one output in the derivatives directory for each input image in the bids input
-directory.
+``derivitaves/qsiprep/sub-1/ses-1/dwi/sub-1_ses-1_acq-multishell_desc-preproc_dwi.nii.gz``.
+Otherwise, there will be one output in the derivatives directory for each input image in the bids input directory.
 
-It is beneficial to have as much data as possible available for head motion correction. However,
-the denoising preprocessing step has important caveats that should be considered. For a
-discussion see :ref:`merge_denoise`.
+It is beneficial to have as much data as possible available for head motion correction.
+However, the denoising preprocessing step has important caveats that should be considered.
+For a discussion see :ref:`merge_denoise`.
 
 
 ******************

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -76,18 +76,18 @@ def test_get_entity_groups_with_multipartid(tmpdir):
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
-            'sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
-            'sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz',
+            'sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
+            'sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz',
         ],
-        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
-        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
-        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
@@ -100,19 +100,19 @@ def test_get_entity_groups_without_multipartid(tmpdir):
     subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
+        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
         [
-            'sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
-            'sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz',
+            'sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
+            'sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz',
         ],
-        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
-        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
-        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -119,14 +119,13 @@ def test_get_entity_groups_without_multipartid(tmpdir):
 
 def check_expected(subject_data, expected):
     """Check expected values."""
-    for key, value in expected.items():
-        if isinstance(value, str):
-            assert subject_data[key] is not None, f'Key {key} is None.'
-            assert os.path.basename(subject_data[key]) == value
-        elif isinstance(value, list):
-            assert subject_data[key] is not None, f'Key {key} is None.'
-            assert len(subject_data[key]) == len(value)
-            for item, expected_item in zip(subject_data[key], value, strict=False):
-                assert os.path.basename(item) == expected_item
-        else:
-            assert subject_data[key] is value
+    if isinstance(expected, str):
+        assert subject_data is not None, 'subject_data is None.'
+        assert os.path.basename(subject_data) == expected
+    elif isinstance(expected, list):
+        assert subject_data is not None, 'subject_data is None.'
+        assert len(subject_data) == len(expected)
+        for item, expected_item in zip(subject_data, expected, strict=False):
+            assert os.path.basename(item) == expected_item
+    else:
+        assert subject_data is expected

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -76,18 +76,18 @@ def test_get_entity_groups_with_multipartid(tmpdir):
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
-            'sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
-            'sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz',
+            'sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz',
         ],
-        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
-        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
-        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
@@ -100,19 +100,19 @@ def test_get_entity_groups_without_multipartid(tmpdir):
     subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
-        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
         [
-            'sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
-            'sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz',
         ],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
-        ['sub-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
-        ['sub-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -126,6 +126,13 @@ def check_expected(subject_data, expected):
         assert subject_data is not None, 'subject_data is None.'
         assert len(subject_data) == len(expected)
         for item, expected_item in zip(subject_data, expected, strict=False):
-            assert os.path.basename(item) == expected_item
+            if isinstance(expected_item, list):
+                # Handle nested lists
+                assert isinstance(item, list), f'Expected list but got {type(item)}'
+                assert len(item) == len(expected_item)
+                for subitem, expected_subitem in zip(item, expected_item, strict=False):
+                    assert os.path.basename(subitem) == expected_subitem
+            else:
+                assert os.path.basename(item) == expected_item
     else:
         assert subject_data is expected

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -1,0 +1,133 @@
+"""Tests for the grouping utils."""
+
+import os
+
+from bids.layout import BIDSLayout
+from niworkflows.utils.testing import generate_bids_skeleton
+
+from qsiprep.utils import grouping
+
+
+dset_multipartid = {
+    '01': [
+        {
+            'dwi': [
+                {
+                    'acq': '99dir',
+                    'dir': 'AP',
+                    'run': '1',
+                    'suffix': 'dwi',
+                    'metadata': {
+                        'MultipartID': 'apgroup',
+                    },
+                },
+                {
+                    'acq': '98dir',
+                    'dir': 'AP',
+                    'run': '2',
+                    'suffix': 'dwi',
+                    'metadata': {
+                        'MultipartID': 'apgroup',
+                    },
+                },
+                {
+                    'acq': '99dir',
+                    'dir': 'AP',
+                    'run': '3',
+                    'suffix': 'dwi',
+                },
+            ],
+        },
+    ],
+}
+dset_entities = {
+    '01': [
+        {
+            'dwi': [
+                {
+                    'acq': '99dir',
+                    'dir': 'AP',
+                    'run': '1',
+                    'suffix': 'dwi',
+                },
+                {
+                    'acq': '98dir',
+                    'dir': 'AP',
+                    'run': '2',
+                    'suffix': 'dwi',
+                },
+                {
+                    'acq': '99dir',
+                    'dir': 'AP',
+                    'run': '3',
+                    'suffix': 'dwi',
+                },
+            ],
+        },
+    ],
+}
+
+
+def test_get_entity_groups_with_multipartid(tmpdir):
+    """Test the get_entity_groups function."""
+    bids_dir = tmpdir / 'test_get_entity_groups'
+    generate_bids_skeleton(str(bids_dir), dset_multipartid)
+    layout = BIDSLayout(str(bids_dir))
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
+    expected = [
+        [
+            'sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
+            'sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz',
+        ],
+        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+    ]
+    check_expected(entity_groups, expected)
+
+    entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
+    expected = [
+        ['sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
+        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+    ]
+    check_expected(entity_groups, expected)
+
+
+def test_get_entity_groups_without_multipartid(tmpdir):
+    """Test the get_entity_groups function."""
+    bids_dir = tmpdir / 'test_get_entity_groups'
+    generate_bids_skeleton(str(bids_dir), dset_entities)
+    layout = BIDSLayout(str(bids_dir))
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
+    expected = [
+        [
+            'sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz',
+            'sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz',
+        ],
+        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+    ]
+    check_expected(entity_groups, expected)
+
+    entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
+    expected = [
+        ['sub-01_ses-01_dir-AP_acq-99dir_run-01_dwi.nii.gz'],
+        ['sub-01_ses-01_dir-AP_acq-98dir_run-02_dwi.nii.gz'],
+        ['sub-01_ses-01_dir-AP_acq-99dir_run-03_dwi.nii.gz'],
+    ]
+    check_expected(entity_groups, expected)
+
+
+def check_expected(subject_data, expected):
+    """Check expected values."""
+    for key, value in expected.items():
+        if isinstance(value, str):
+            assert subject_data[key] is not None, f'Key {key} is None.'
+            assert os.path.basename(subject_data[key]) == value
+        elif isinstance(value, list):
+            assert subject_data[key] is not None, f'Key {key} is None.'
+            assert len(subject_data[key]) == len(value)
+            for item, expected_item in zip(subject_data[key], value, strict=False):
+                assert os.path.basename(item) == expected_item
+        else:
+            assert subject_data[key] is value

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -7,7 +7,6 @@ from niworkflows.utils.testing import generate_bids_skeleton
 
 from qsiprep.utils import grouping
 
-
 dset_multipartid = {
     '01': [
         {

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -76,8 +76,8 @@ def test_get_entity_groups_with_multipartid(tmpdir):
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
             'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
         ],
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
@@ -85,8 +85,8 @@ def test_get_entity_groups_with_multipartid(tmpdir):
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
         ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
@@ -110,8 +110,8 @@ def test_get_entity_groups_without_multipartid(tmpdir):
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
         ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -100,8 +100,8 @@ def test_get_entity_groups_without_multipartid(tmpdir):
     subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
-        ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
         [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
             'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
             'sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz',
         ],

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -76,18 +76,18 @@ def test_get_entity_groups_with_multipartid(tmpdir):
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
-            'sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz',
-            'sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz'],
-        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
-        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 
@@ -100,19 +100,19 @@ def test_get_entity_groups_without_multipartid(tmpdir):
     subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
-        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
         [
-            'sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz',
         ],
     ]
     check_expected(entity_groups, expected)
 
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
     expected = [
-        ['sub-01_acq-99dir_dir-AP_run-01_dwi.nii.gz'],
-        ['sub-01_acq-98dir_dir-AP_run-02_dwi.nii.gz'],
-        ['sub-01_acq-99dir_dir-AP_run-03_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
+        ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
 

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -173,7 +173,7 @@ def get_entity_groups(layout, subject_data, combine_all_dwis):
 
             LOGGER.info(
                 '\t- %d scans in session %s',
-                len(group_files),
+                len(session_files),
                 session,
             )
             dwi_groups.append(session_files)

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -152,7 +152,9 @@ def get_entity_groups(layout, subject_data, combine_all_dwis):
             acquisitions = dwi_entities.get('acquisition', [None])
             for session in sessions:
                 session_files = [
-                    img for img in all_dwis if layout.get_file(img).entities.get('session') == session
+                    img
+                    for img in all_dwis
+                    if layout.get_file(img).entities.get('session') == session
                 ]
 
                 for acq in acquisitions:

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -152,9 +152,7 @@ def get_entity_groups(layout, subject_data, combine_all_dwis):
         acquisitions = dwi_entities.get('acquisition', [None])
         for session in sessions:
             session_files = [
-                img
-                for img in all_dwis
-                if layout.get_file(img).entities.get('session') == session
+                img for img in all_dwis if layout.get_file(img).entities.get('session') == session
             ]
 
             for acq in acquisitions:

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -171,13 +171,12 @@ def get_entity_groups(layout, subject_data, combine_all_dwis):
                 img for img in all_dwis if layout.get_file(img).entities.get('session') == session
             ]
 
-            if group_files:
-                LOGGER.info(
-                    '\t- %d scans in session %s',
-                    len(group_files),
-                    session,
-                )
-                dwi_groups.append(session_files)
+            LOGGER.info(
+                '\t- %d scans in session %s',
+                len(group_files),
+                session,
+            )
+            dwi_groups.append(session_files)
 
     return dwi_groups
 

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -92,86 +92,86 @@ def get_entity_groups(layout, subject_data, combine_all_dwis):
         Each list of DWI files is a group of scans that can be concatenated together.
     """
     all_dwis = subject_data['dwi']
-    dwi_groups = []
     if not combine_all_dwis:
         dwi_groups = [[dwi] for dwi in all_dwis]
+        return dwi_groups
 
-    else:
-        all_metadata = []
-        for f in all_dwis:
-            metadata = layout.get_file(f).get_metadata()
-            all_metadata.append(metadata)
+    all_metadata = []
+    for f in all_dwis:
+        metadata = layout.get_file(f).get_metadata()
+        all_metadata.append(metadata)
 
-        grouping_method = 'entities'  # default is to group by entities
-        if any('MultipartID' in metadata for metadata in all_metadata):
-            grouping_method = 'metadata'
+    grouping_method = 'entities'  # default is to group by entities
+    if any('MultipartID' in metadata for metadata in all_metadata):
+        grouping_method = 'metadata'
 
-        dwi_entities = {}
-        grouping_metadata = {}
-        for i_file, f in enumerate(all_dwis):
-            if grouping_method == 'metadata':
-                # One MultipartID in any DWI metadata file means we use MultipartID to group
-                grouping_metadata[f] = all_metadata[i_file].get('MultipartID', None)
-            else:
-                # Group by entity instead
-                f_entities = layout.get_file(f).get_entities()
-                for k, v in f_entities.items():
-                    if k in dwi_entities:
-                        if v not in dwi_entities[k]:
-                            dwi_entities[k].append(v)
-                    else:
-                        dwi_entities[k] = [v]
-
+    dwi_entities = {}
+    grouping_metadata = {}
+    for i_file, f in enumerate(all_dwis):
         if grouping_method == 'metadata':
-            LOGGER.info('Using MultipartID to group DWI files')
+            # One MultipartID in any DWI metadata file means we use MultipartID to group
+            grouping_metadata[f] = all_metadata[i_file].get('MultipartID', None)
         else:
-            LOGGER.info('Combining all DWI files within each available session and acquisition:')
+            # Group by entity instead
+            f_entities = layout.get_file(f).get_entities()
+            for k, v in f_entities.items():
+                if k in dwi_entities:
+                    if v not in dwi_entities[k]:
+                        dwi_entities[k].append(v)
+                else:
+                    dwi_entities[k] = [v]
 
-        if grouping_method == 'metadata':
-            # Overwrite the existing dwi_groups (list) with a dict of lists
-            dwi_groups = {}
-            for f in all_dwis:
-                group = grouping_metadata[f]
-                if group not in dwi_groups:
-                    dwi_groups[group] = []
+    if grouping_method == 'metadata':
+        LOGGER.info('Using MultipartID to group DWI files')
+    else:
+        LOGGER.info('Combining all DWI files within each available session and acquisition:')
 
-                dwi_groups[group].append(f)
+    if grouping_method == 'metadata':
+        # Overwrite the existing dwi_groups (list) with a dict of lists
+        dwi_groups = {}
+        for f in all_dwis:
+            group = grouping_metadata[f]
+            if group not in dwi_groups:
+                dwi_groups[group] = []
 
-            for multipart_id, group_files in dwi_groups.items():
-                LOGGER.info(
-                    '\t- %d scans with MultipartID %s',
-                    len(group_files),
-                    multipart_id,
-                )
+            dwi_groups[group].append(f)
 
-            # Convert to list of lists
-            dwi_groups = list(dwi_groups.values())
+        for multipart_id, group_files in dwi_groups.items():
+            LOGGER.info(
+                '\t- %d scans with MultipartID %s',
+                len(group_files),
+                multipart_id,
+            )
 
-        elif grouping_method == 'entities':
-            sessions = dwi_entities.get('session', [None])
-            acquisitions = dwi_entities.get('acquisition', [None])
-            for session in sessions:
-                session_files = [
+        # Convert to list of lists
+        dwi_groups = list(dwi_groups.values())
+
+    elif grouping_method == 'entities':
+        dwi_groups = []
+        sessions = dwi_entities.get('session', [None])
+        acquisitions = dwi_entities.get('acquisition', [None])
+        for session in sessions:
+            session_files = [
+                img
+                for img in all_dwis
+                if layout.get_file(img).entities.get('session') == session
+            ]
+
+            for acq in acquisitions:
+                group_files = [
                     img
-                    for img in all_dwis
-                    if layout.get_file(img).entities.get('session') == session
+                    for img in session_files
+                    if layout.get_file(img).entities.get('acquisition') == acq
                 ]
 
-                for acq in acquisitions:
-                    group_files = [
-                        img
-                        for img in session_files
-                        if layout.get_file(img).entities.get('acquisition') == acq
-                    ]
-
-                    if group_files:
-                        LOGGER.info(
-                            '\t- %d scans in session %s/acquisition %s',
-                            len(group_files),
-                            session,
-                            acq,
-                        )
-                        dwi_groups.append(group_files)
+                if group_files:
+                    LOGGER.info(
+                        '\t- %d scans in session %s/acquisition %s',
+                        len(group_files),
+                        session,
+                        acq,
+                    )
+                    dwi_groups.append(group_files)
 
     return dwi_groups
 

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -74,7 +74,10 @@ def group_dwi_scans(
 
 
 def get_entity_groups(layout, subject_data, combine_all_dwis):
-    """Handle the grouping of multiple DWI files within a session/acquisition.
+    """Handle the grouping of multiple DWI files.
+
+    This function will group DWI files based on the MultipartID metadata field,
+    when available, and will default to grouping by entities (acq and ses) when it is not.
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #897 and reverts #862.

## Changes proposed in this pull request

- Modify `get_entity_groups` to use the `MultipartID` metadata field when available.
    - ~~If `MultipartID` is present for some files, but not others, then the function will treat all of the files without the field as belonging to the same group. Now that I think about it, we probably want them to be treated as belonging to separate groups, right? I can make that change depending on what @mattcieslak thinks.~~
    - If `MultipartID` is present for some files, but not others, then the function will treat each file without the field as belonging to its own group.
- Stop grouping by acquisition entity by default. If users want to apply more sophisticated grouping logic, they can use `MultipartID`.
- Test `get_entity_groups`'s  behavior on simulated datasets with and without `MultipartID`.