### PR TITLE
Test dMRI and field map file grouping

### DIFF
--- a/qsiprep/tests/data/skeleton_complex_b0fields.yml
+++ b/qsiprep/tests/data/skeleton_complex_b0fields.yml
@@ -1,0 +1,55 @@
+# A dataset with a single subject with competing B0 fields:
+# Each DWI has a PEPOLAR field map, but also the DWI runs have
+# different phase encoding directions and can be used for
+# TOPUP-style distortion correction.
+'01':
+  - anat:
+      - suffix: T1w
+    fmap:
+      - dir: PA
+        suffix: epi
+        metadata:
+          B0FieldIdentifier:
+            - pepolar_ap_01
+            - pepolar_ap_02
+          PhaseEncodingDirection: j
+      - dir: AP
+        suffix: epi
+        metadata:
+          B0FieldIdentifier: pepolar_pa_01
+          PhaseEncodingDirection: j-
+    dwi:
+      - dir: AP
+        run: 1
+        suffix: dwi
+        metadata:
+          B0FieldIdentifier:
+            - pepolar_ap_01
+            - topup
+          B0FieldSource:
+            - pepolar_ap_01
+            - topup
+          MultipartID: ap_dwi
+          PhaseEncodingDirection: j-
+      - dir: AP
+        run: 2
+        suffix: dwi
+        metadata:
+          B0FieldIdentifier:
+            - pepolar_ap_02
+            - topup
+          B0FieldSource:
+            - pepolar_ap_02
+            - topup
+          MultipartID: ap_dwi
+          PhaseEncodingDirection: j-
+      - dir: PA
+        suffix: dwi
+        metadata:
+          B0FieldIdentifier:
+            - pepolar_pa_01
+            - topup
+          B0FieldSource:
+            - pepolar_pa_01
+            - topup
+          PhaseEncodingDirection: j

--- a/qsiprep/tests/data/skeleton_complex_relpaths.yml
+++ b/qsiprep/tests/data/skeleton_complex_relpaths.yml
@@ -1,0 +1,38 @@
+# A dataset with a single subject with competing B0 fields:
+# Each DWI has a PEPOLAR field map, but also the DWI runs have
+# different phase encoding directions and can be used for
+# TOPUP-style distortion correction.
+'01':
+  - anat:
+      - suffix: T1w
+    fmap:
+      - dir: PA
+        suffix: epi
+        metadata:
+          IntendedFor:
+            - dwi/sub-01_dir-AP_run-1_dwi.nii.gz
+            - dwi/sub-01_dir-AP_run-2_dwi.nii.gz
+          PhaseEncodingDirection: j
+      - dir: AP
+        suffix: epi
+        metadata:
+          IntendedFor:
+            - dwi/sub-01_dir-PA_dwi.nii.gz
+          PhaseEncodingDirection: j-
+    dwi:
+      - dir: AP
+        run: 1
+        suffix: dwi
+        metadata:
+          MultipartID: ap_dwi
+          PhaseEncodingDirection: j-
+      - dir: AP
+        run: 2
+        suffix: dwi
+        metadata:
+          MultipartID: ap_dwi
+          PhaseEncodingDirection: j-
+      - dir: PA
+        suffix: dwi
+        metadata:
+          PhaseEncodingDirection: j

--- a/qsiprep/tests/data/skeleton_complex_relpaths.yml
+++ b/qsiprep/tests/data/skeleton_complex_relpaths.yml
@@ -12,27 +12,27 @@
           IntendedFor:
             - dwi/sub-01_dir-AP_run-1_dwi.nii.gz
             - dwi/sub-01_dir-AP_run-2_dwi.nii.gz
-          PhaseEncodingDirection: j
+          PhaseEncodingDirection: 'j'
       - dir: AP
         suffix: epi
         metadata:
           IntendedFor:
             - dwi/sub-01_dir-PA_dwi.nii.gz
-          PhaseEncodingDirection: j-
+          PhaseEncodingDirection: 'j-'
     dwi:
       - dir: AP
         run: 1
         suffix: dwi
         metadata:
           MultipartID: ap_dwi
-          PhaseEncodingDirection: j-
+          PhaseEncodingDirection: 'j-'
       - dir: AP
         run: 2
         suffix: dwi
         metadata:
           MultipartID: ap_dwi
-          PhaseEncodingDirection: j-
+          PhaseEncodingDirection: 'j-'
       - dir: PA
         suffix: dwi
         metadata:
-          PhaseEncodingDirection: j
+          PhaseEncodingDirection: 'j'

--- a/qsiprep/tests/data/skeleton_fmap_b0fields.yml
+++ b/qsiprep/tests/data/skeleton_fmap_b0fields.yml
@@ -1,0 +1,15 @@
+# A dataset with a single subject with a single run of fmap and dwi,
+# where the fmap is linked to the dwi with the B0FieldIdentifier
+# metadata field.
+'01':
+  - fmap:
+      - dir: PA
+        suffix: epi
+        metadata:
+          B0FieldIdentifier: pepolar
+    dwi:
+      - dir: AP
+        suffix: dwi
+        metadata:
+          B0FieldIdentifier: pepolar
+          B0FieldSource: pepolar

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -237,14 +237,13 @@ def check_expected(subject_data, expected):
         assert subject_data is not None, 'subject_data is None.'
         assert len(subject_data) == len(expected), pformat(subject_data)
         for item, expected_item in zip(subject_data, expected, strict=False):
-            if isinstance(expected_item, list):
-                # Handle nested lists
-                assert isinstance(item, list), f'Expected list but got {type(item)}'
-                assert len(item) == len(expected_item)
-                for subitem, expected_subitem in zip(item, expected_item, strict=False):
-                    assert os.path.basename(subitem) == expected_subitem
-            else:
-                assert os.path.basename(item) == expected_item
+            check_expected(item, expected_item)
+    elif isinstance(expected, dict):
+        assert subject_data is not None, 'subject_data is None.'
+        assert len(subject_data) == len(expected), pformat(subject_data)
+        for key, value in expected.items():
+            assert key in subject_data, f'{key} not in subject_data.'
+            check_expected(subject_data[key], value)
     else:
         assert subject_data is expected
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -267,12 +267,89 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
         ],
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
-    check_expected(entity_groups, expected)
+    check_expected(scan_groups, expected)
 
-    entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=False)
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=False,
+        combine_scans=True,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
     expected = [
-        ['sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz'],
-        ['sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz'],
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
-    check_expected(entity_groups, expected)
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=False,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=False,
+        combine_scans=False,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=True,
+        ignore_fieldmaps=True,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=True,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=True,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -541,22 +541,19 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         {
-            'concatenated_bids_name': 'sub-01',
+            'concatenated_bids_name': 'sub-01_dir-AP',
             'dwi_series': [
-                'sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-AP_run-1_dwi.nii.gz',
+                'sub-01_dir-AP_run-2_dwi.nii.gz',
             ],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {'suffix': None},
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-PA',
+            'dwi_series': ['sub-01_dir-PA_dwi.nii.gz'],
             'dwi_series_pedir': 'j',
-            'fieldmap_info': {
-                'epi': [
-                    'sub-01_dir-AP_epi.nii.gz',
-                    'sub-01_dir-PA_epi.nii.gz',
-                ],
-                'rpe_series': [
-                    'sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01_dir-AP_run-2_dwi.nii.gz',
-                ],
-                'suffix': 'rpe_series',
-            },
+            'fieldmap_info': {'suffix': None},
         },
     ]
     check_expected(scan_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -197,7 +197,7 @@ def test_get_fieldmaps(tmp_path_factory):
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
-    assert fieldmaps[0]['metadata']['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
+    assert fieldmaps[0].get_metadata()['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
 
     # Check that BIDS URI paths are correctly handled
     bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
@@ -207,7 +207,7 @@ def test_get_fieldmaps(tmp_path_factory):
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
-    assert fieldmaps[0]['metadata']['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
+    assert fieldmaps[0].get_metadata()['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
 
     # Check that B0FieldIdentifier and B0FieldSource are correctly handled
     bids_dir = base_dir / 'dset_fmap_b0fields'

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -187,8 +187,10 @@ def test_get_entity_groups_without_multipartid(tmpdir):
 
 def test_get_fieldmaps(tmp_path_factory):
     """Test the get_fieldmaps function."""
+    base_dir = tmp_path_factory.mktemp('test_get_fieldmaps')
+
     # Check that relative paths are correctly handled
-    bids_dir = tmp_path_factory.mktemp('dset_fmap_intendedfor_relpath')
+    bids_dir = base_dir / 'dset_fmap_intendedfor_relpath')
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_relpath)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
@@ -198,7 +200,7 @@ def test_get_fieldmaps(tmp_path_factory):
     assert fieldmaps[0]['metadata']['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
 
     # Check that BIDS URI paths are correctly handled
-    bids_dir = tmp_path_factory.mktemp('dset_fmap_intendedfor_bidsuri')
+    bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
@@ -208,7 +210,7 @@ def test_get_fieldmaps(tmp_path_factory):
     assert fieldmaps[0]['metadata']['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
 
     # Check that B0FieldIdentifier and B0FieldSource are correctly handled
-    bids_dir = tmp_path_factory.mktemp('dset_fmap_b0fields')
+    bids_dir = base_dir / 'dset_fmap_b0fields'
     generate_bids_skeleton(str(bids_dir), dset_fmap_b0fields)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -248,7 +248,24 @@ def check_expected(subject_data, expected):
 
 
 def test_group_dwi_scans_with_complex_b0fields(tmpdir):
-    """Test the group_dwi_scans function."""
+    """Test the group_dwi_scans function.
+
+    In the test dataset, we have the following::
+
+    fmap/
+        sub-01_dir-AP_epi.nii.gz
+        sub-01_dir-PA_epi.nii.gz
+    dwi/
+        sub-01_dir-AP_run-1_dwi.nii.gz
+        sub-01_dir-AP_run-2_dwi.nii.gz
+        sub-01_dir-PA_dwi.nii.gz
+
+    The first two DWI runs have different B0 field identifiers, but link to the same fieldmap.
+    The third DWI run has a different B0 field identifier, and links to a different fieldmap.
+
+    We expect the first two DWI runs to be grouped together, and the third DWI run to be grouped
+    separately, based on having the same phase encoding direction.
+    """
     bids_dir = tmpdir / 'test_group_dwi_scans_with_complex_b0fields'
     dset_yaml = os.path.join(get_test_data_path(), 'skeleton_complex_b0fields.yml')
     generate_bids_skeleton(str(bids_dir), dset_yaml)
@@ -291,10 +308,10 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -308,10 +325,10 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -325,10 +342,10 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -342,10 +359,10 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -359,16 +376,20 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_dir-PA_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
 
 def test_group_dwi_scans_with_complex_relpaths(tmpdir):
-    """Test the group_dwi_scans function."""
+    """Test the group_dwi_scans function.
+
+    This is the same as test_group_dwi_scans_with_complex_b0fields,
+    but with IntendedFors using relative paths instead of B0Field* fields.
+    """
     bids_dir = tmpdir / 'test_group_dwi_scans_with_complex_relpaths'
     dset_yaml = os.path.join(get_test_data_path(), 'skeleton_complex_relpaths.yml')
     generate_bids_skeleton(str(bids_dir), dset_yaml)
@@ -411,10 +432,10 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -428,10 +449,10 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -445,10 +466,10 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -462,10 +483,10 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        ['sub-01_dir-PA_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
 
@@ -479,9 +500,9 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-1_dwi.nii.gz',
+            'sub-01_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_dir-PA_dwi.nii.gz',
         ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -207,7 +207,9 @@ def test_get_fieldmaps(tmp_path_factory):
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
-    assert fieldmaps[0].get_metadata()['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
+    assert fieldmaps[0].get_metadata()['IntendedFor'] == [
+        'bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz'
+    ]
 
     # Check that B0FieldIdentifier and B0FieldSource are correctly handled
     bids_dir = base_dir / 'dset_fmap_b0fields'

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -408,19 +408,22 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         {
-            'concatenated_bids_name': 'sub-01_dir-AP',
+            'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
-            'fieldmap_info': {'suffix': None},
-        },
-        {
-            'concatenated_bids_name': 'sub-01_dir-PA',
-            'dwi_series': ['sub-01/dwi/sub-01_dir-PA_dwi.nii.gz'],
-            'dwi_series_pedir': 'j-',
-            'fieldmap_info': {'suffix': None},
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
         },
     ]
     check_expected(scan_groups, expected)
@@ -434,11 +437,24 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         concatenate_distortion_groups=False,
     )
     expected = [
-        [
-            'sub-01_dir-AP_run-1_dwi.nii.gz',
-            'sub-01_dir-AP_run-2_dwi.nii.gz',
-        ],
-        ['sub-01_dir-PA_dwi.nii.gz'],
+        {
+            'concatenated_bids_name': 'sub-01',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
+        },
     ]
     check_expected(scan_groups, expected)
 
@@ -451,11 +467,24 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         concatenate_distortion_groups=False,
     )
     expected = [
-        [
-            'sub-01_dir-AP_run-1_dwi.nii.gz',
-            'sub-01_dir-AP_run-2_dwi.nii.gz',
-        ],
-        ['sub-01_dir-PA_dwi.nii.gz'],
+        {
+            'concatenated_bids_name': 'sub-01',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
+        },
     ]
     check_expected(scan_groups, expected)
 
@@ -468,11 +497,24 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         concatenate_distortion_groups=False,
     )
     expected = [
-        [
-            'sub-01_dir-AP_run-1_dwi.nii.gz',
-            'sub-01_dir-AP_run-2_dwi.nii.gz',
-        ],
-        ['sub-01_dir-PA_dwi.nii.gz'],
+        {
+            'concatenated_bids_name': 'sub-01',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
+        },
     ]
     check_expected(scan_groups, expected)
 
@@ -485,11 +527,24 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         concatenate_distortion_groups=False,
     )
     expected = [
-        [
-            'sub-01_dir-AP_run-1_dwi.nii.gz',
-            'sub-01_dir-AP_run-2_dwi.nii.gz',
-        ],
-        ['sub-01_dir-PA_dwi.nii.gz'],
+        {
+            'concatenated_bids_name': 'sub-01',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
+        },
     ]
     check_expected(scan_groups, expected)
 
@@ -502,10 +557,23 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         concatenate_distortion_groups=True,
     )
     expected = [
-        [
-            'sub-01_dir-AP_run-1_dwi.nii.gz',
-            'sub-01_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_dir-PA_dwi.nii.gz',
-        ],
+        {
+            'concatenated_bids_name': 'sub-01',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {
+                'epi': [
+                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
+                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                ],
+                'rpe_series': [
+                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                ],
+                'suffix': 'rpe_series',
+            },
+        },
     ]
     check_expected(scan_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -66,6 +66,74 @@ dset_entities = {
     ],
 }
 
+dset_fmap_intendedfor_relpath = {
+    '01': [
+        {
+            'fmap': [
+                {
+                    'dir': 'PA',
+                    'suffix': 'epi',
+                    'metadata': {
+                        'IntendedFor': ['dwi/sub-01_dir-AP_dwi.nii.gz'],
+                    },
+                },
+            ],
+            'dwi': [
+                {
+                    'dir': 'AP',
+                    'suffix': 'dwi',
+                },
+            ],
+        },
+    ],
+}
+dset_fmap_intendedfor_bidsuri = {
+    '01': [
+        {
+            'fmap': [
+                {
+                    'dir': 'PA',
+                    'suffix': 'epi',
+                    'metadata': {
+                        'IntendedFor': ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz'],
+                    },
+                },
+            ],
+            'dwi': [
+                {
+                    'dir': 'AP',
+                    'suffix': 'dwi',
+                },
+            ],
+        },
+    ],
+}
+dset_fmap_b0fields = {
+    '01': [
+        {
+            'fmap': [
+                {
+                    'dir': 'PA',
+                    'suffix': 'epi',
+                    'metadata': {
+                        'B0FieldIdentifier': 'pepolar',
+                    },
+                },
+            ],
+            'dwi': [
+                {
+                    'dir': 'AP',
+                    'suffix': 'dwi',
+                    'metadata': {
+                        'B0FieldIdentifier': 'pepolar',
+                        'B0FieldSource': 'pepolar',
+                    },
+                },
+            ],
+        },
+    ],
+}
+
 
 def test_get_entity_groups_with_multipartid(tmpdir):
     """Test the get_entity_groups function."""
@@ -115,6 +183,29 @@ def test_get_entity_groups_without_multipartid(tmpdir):
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(entity_groups, expected)
+
+
+def test_get_fieldmaps(tmp_path_factory):
+    """Test the get_fieldmaps function."""
+    bids_dir = tmp_path_factory.mktemp('test_get_fieldmaps')
+
+    # Check that relative paths are correctly handled
+    generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_relpath)
+    layout = BIDSLayout(str(bids_dir))
+    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
+    assert len(fieldmaps) == 1
+    assert fieldmaps[0]['suffix'] == 'epi'
+    assert fieldmaps[0]['metadata']['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
+
+    # Check that BIDS URI paths are correctly handled
+    generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
+    layout = BIDSLayout(str(bids_dir))
+    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
+    assert len(fieldmaps) == 1
+    assert fieldmaps[0]['suffix'] == 'epi'
+    assert fieldmaps[0]['metadata']['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
 
 
 def check_expected(subject_data, expected):

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -285,15 +285,15 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
         {
             'concatenated_bids_name': 'sub-01_dir-AP',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                'sub-01_dir-AP_run-1_dwi.nii.gz',
+                'sub-01_dir-AP_run-2_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {'suffix': None},
         },
         {
             'concatenated_bids_name': 'sub-01_dir-PA',
-            'dwi_series': ['sub-01/dwi/sub-01_dir-PA_dwi.nii.gz'],
+            'dwi_series': ['sub-01_dir-PA_dwi.nii.gz'],
             'dwi_series_pedir': 'j-',
             'fieldmap_info': {'suffix': None},
         },
@@ -409,17 +409,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },
@@ -439,17 +439,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },
@@ -469,17 +469,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },
@@ -499,17 +499,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },
@@ -529,17 +529,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },
@@ -559,17 +559,17 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
         {
             'concatenated_bids_name': 'sub-01',
             'dwi_series': [
-                'sub-01/dwi/sub-01_dir-PA_dwi.nii.gz',
+                'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
                 'epi': [
-                    'sub-01/fmap/sub-01_dir-AP_epi.nii.gz',
-                    'sub-01/fmap/sub-01_dir-PA_epi.nii.gz',
+                    'sub-01_dir-AP_epi.nii.gz',
+                    'sub-01_dir-PA_epi.nii.gz',
                 ],
                 'rpe_series': [
-                    'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+                    'sub-01_dir-AP_run-1_dwi.nii.gz',
+                    'sub-01_dir-AP_run-2_dwi.nii.gz',
                 ],
                 'suffix': 'rpe_series',
             },

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -187,9 +187,8 @@ def test_get_entity_groups_without_multipartid(tmpdir):
 
 def test_get_fieldmaps(tmp_path_factory):
     """Test the get_fieldmaps function."""
-    bids_dir = tmp_path_factory.mktemp('test_get_fieldmaps')
-
     # Check that relative paths are correctly handled
+    bids_dir = tmp_path_factory.mktemp('dset_fmap_intendedfor_relpath')
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_relpath)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
@@ -199,6 +198,7 @@ def test_get_fieldmaps(tmp_path_factory):
     assert fieldmaps[0]['metadata']['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
 
     # Check that BIDS URI paths are correctly handled
+    bids_dir = tmp_path_factory.mktemp('dset_fmap_intendedfor_bidsuri')
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
@@ -206,6 +206,15 @@ def test_get_fieldmaps(tmp_path_factory):
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
     assert fieldmaps[0]['metadata']['IntendedFor'] == ['bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz']
+
+    # Check that B0FieldIdentifier and B0FieldSource are correctly handled
+    bids_dir = tmp_path_factory.mktemp('dset_fmap_b0fields')
+    generate_bids_skeleton(str(bids_dir), dset_fmap_b0fields)
+    layout = BIDSLayout(str(bids_dir))
+    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
+    assert len(fieldmaps) == 1
+    assert fieldmaps[0]['suffix'] == 'epi'
 
 
 def check_expected(subject_data, expected):

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -3,6 +3,7 @@
 import os
 from pprint import pformat
 
+import pytest
 from bids.layout import BIDSLayout
 from niworkflows.utils.testing import generate_bids_skeleton
 
@@ -217,13 +218,14 @@ def test_get_fieldmaps(tmp_path_factory):
     # ]
 
     # Check that B0FieldIdentifier and B0FieldSource are correctly handled
-    bids_dir = base_dir / 'dset_fmap_b0fields'
-    generate_bids_skeleton(str(bids_dir), dset_fmap_b0fields)
-    layout = BIDSLayout(str(bids_dir))
-    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
-    fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
-    assert len(fieldmaps) == 1
-    assert fieldmaps[0]['suffix'] == 'epi'
+    # XXX: This currently fails because pybids does not support B0Field* with get_fieldmap.
+    # bids_dir = base_dir / 'dset_fmap_b0fields'
+    # generate_bids_skeleton(str(bids_dir), dset_fmap_b0fields)
+    # layout = BIDSLayout(str(bids_dir))
+    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    # fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
+    # assert len(fieldmaps) == 1
+    # assert fieldmaps[0]['suffix'] == 'epi'
 
 
 def check_expected(subject_data, expected):
@@ -247,6 +249,7 @@ def check_expected(subject_data, expected):
         assert subject_data is expected
 
 
+@pytest.mark.xfail(reason='B0Field* not supported by pybids')
 def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     """Test the group_dwi_scans function.
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -204,16 +204,17 @@ def test_get_fieldmaps(tmp_path_factory):
     ]
 
     # Check that BIDS URI paths are correctly handled
-    bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
-    generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
-    layout = BIDSLayout(str(bids_dir))
-    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
-    fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
-    assert len(fieldmaps) == 1
-    assert fieldmaps[0]['suffix'] == 'epi'
-    assert layout.get_file(fieldmaps[0]['epi']).get_metadata()['IntendedFor'] == [
-        'bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz'
-    ]
+    # XXX: This currently fails because pybids does not support BIDS URI paths.
+    # bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
+    # generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
+    # layout = BIDSLayout(str(bids_dir))
+    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    # fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
+    # assert len(fieldmaps) == 1
+    # assert fieldmaps[0]['suffix'] == 'epi'
+    # assert layout.get_file(fieldmaps[0]['epi']).get_metadata()['IntendedFor'] == [
+    #     'bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz'
+    # ]
 
     # Check that B0FieldIdentifier and B0FieldSource are correctly handled
     bids_dir = base_dir / 'dset_fmap_b0fields'

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -364,3 +364,123 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
         ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
     ]
     check_expected(scan_groups, expected)
+
+
+def test_group_dwi_scans_with_complex_relpaths(tmpdir):
+    """Test the group_dwi_scans function."""
+    bids_dir = tmpdir / 'test_group_dwi_scans_with_complex_relpaths'
+    dset_yaml = os.path.join(get_test_data_path(), 'skeleton_complex_relpaths.yml')
+    generate_bids_skeleton(str(bids_dir), dset_yaml)
+    layout = BIDSLayout(str(bids_dir))
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=True,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=True,
+    )
+    expected = [
+        {
+            'concatenated_bids_name': 'sub-01_dir-AP',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {'suffix': None},
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-PA',
+            'dwi_series': ['sub-01/dwi/sub-01_dir-PA_dwi.nii.gz'],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {'suffix': None},
+        },
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=False,
+        combine_scans=True,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=False,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=False,
+        combine_scans=False,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=True,
+        ignore_fieldmaps=True,
+        concatenate_distortion_groups=False,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)
+
+    scan_groups, _ = grouping.group_dwi_scans(
+        layout=layout,
+        subject_data=subject_data,
+        using_fsl=True,
+        combine_scans=True,
+        ignore_fieldmaps=False,
+        concatenate_distortion_groups=True,
+    )
+    expected = [
+        [
+            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
+            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
+        ],
+        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+    ]
+    check_expected(scan_groups, expected)

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -502,21 +502,30 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         {
-            'concatenated_bids_name': 'sub-01',
-            'dwi_series': [
-                'sub-01_dir-PA_dwi.nii.gz',
-            ],
+            'concatenated_bids_name': 'sub-01_dir-AP_run-1',
+            'dwi_series': ['sub-01_dir-AP_run-1_dwi.nii.gz'],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {
+                'epi': ['sub-01_dir-PA_epi.nii.gz'],
+                'suffix': 'epi',
+            },
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-AP_run-2',
+            'dwi_series': ['sub-01_dir-AP_run-2_dwi.nii.gz'],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {
+                'epi': ['sub-01_dir-PA_epi.nii.gz'],
+                'suffix': 'epi',
+            },
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-PA',
+            'dwi_series': ['sub-01_dir-PA_dwi.nii.gz'],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
-                'epi': [
-                    'sub-01_dir-AP_epi.nii.gz',
-                    'sub-01_dir-PA_epi.nii.gz',
-                ],
-                'rpe_series': [
-                    'sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01_dir-AP_run-2_dwi.nii.gz',
-                ],
-                'suffix': 'rpe_series',
+                'epi': ['sub-01_dir-AP_epi.nii.gz'],
+                'suffix': 'epi',
             },
         },
     ]

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -437,21 +437,26 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     )
     expected = [
         {
-            'concatenated_bids_name': 'sub-01',
+            'concatenated_bids_name': 'sub-01_dir-AP',
+            'dwi_series': [
+                'sub-01_dir-AP_run-1_dwi.nii.gz',
+                'sub-01_dir-AP_run-2_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {
+                'epi': ['sub-01_dir-PA_epi.nii.gz'],
+                'suffix': 'epi',
+            },
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-PA',
             'dwi_series': [
                 'sub-01_dir-PA_dwi.nii.gz',
             ],
             'dwi_series_pedir': 'j',
             'fieldmap_info': {
-                'epi': [
-                    'sub-01_dir-AP_epi.nii.gz',
-                    'sub-01_dir-PA_epi.nii.gz',
-                ],
-                'rpe_series': [
-                    'sub-01_dir-AP_run-1_dwi.nii.gz',
-                    'sub-01_dir-AP_run-2_dwi.nii.gz',
-                ],
-                'suffix': 'rpe_series',
+                'epi': ['sub-01_dir-AP_epi.nii.gz'],
+                'suffix': 'epi',
             },
         },
     ]

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -197,7 +197,9 @@ def test_get_fieldmaps(tmp_path_factory):
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
-    assert fieldmaps[0].get_metadata()['IntendedFor'] == ['dwi/sub-01_dir-AP_dwi.nii.gz']
+    assert layout.get_file(fieldmaps[0]['epi']).get_metadata()['IntendedFor'] == [
+        'dwi/sub-01_dir-AP_dwi.nii.gz'
+    ]
 
     # Check that BIDS URI paths are correctly handled
     bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
@@ -207,7 +209,7 @@ def test_get_fieldmaps(tmp_path_factory):
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
-    assert fieldmaps[0].get_metadata()['IntendedFor'] == [
+    assert layout.get_file(fieldmaps[0]['epi']).get_metadata()['IntendedFor'] == [
         'bids::sub-01/dwi/sub-01_dir-AP_dwi.nii.gz'
     ]
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -143,7 +143,7 @@ def test_get_entity_groups_with_multipartid(tmpdir):
     bids_dir = tmpdir / 'test_get_entity_groups'
     generate_bids_skeleton(str(bids_dir), dset_multipartid)
     layout = BIDSLayout(str(bids_dir))
-    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz', return_type='file')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
@@ -168,7 +168,7 @@ def test_get_entity_groups_without_multipartid(tmpdir):
     bids_dir = tmpdir / 'test_get_entity_groups'
     generate_bids_skeleton(str(bids_dir), dset_entities)
     layout = BIDSLayout(str(bids_dir))
-    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz', return_type='file')}
     entity_groups = grouping.get_entity_groups(layout, subject_data, combine_all_dwis=True)
     expected = [
         [
@@ -196,7 +196,7 @@ def test_get_fieldmaps(tmp_path_factory):
     bids_dir = base_dir / 'dset_fmap_intendedfor_relpath'
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_relpath)
     layout = BIDSLayout(str(bids_dir))
-    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='file')[0]
     fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     assert len(fieldmaps) == 1
     assert fieldmaps[0]['suffix'] == 'epi'
@@ -209,7 +209,7 @@ def test_get_fieldmaps(tmp_path_factory):
     # bids_dir = base_dir / 'dset_fmap_intendedfor_bidsuri'
     # generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_bidsuri)
     # layout = BIDSLayout(str(bids_dir))
-    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='file')[0]
     # fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     # assert len(fieldmaps) == 1
     # assert fieldmaps[0]['suffix'] == 'epi'
@@ -222,7 +222,7 @@ def test_get_fieldmaps(tmp_path_factory):
     # bids_dir = base_dir / 'dset_fmap_b0fields'
     # generate_bids_skeleton(str(bids_dir), dset_fmap_b0fields)
     # layout = BIDSLayout(str(bids_dir))
-    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]
+    # dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='file')[0]
     # fieldmaps = layout.get_fieldmap(dwi_file, return_list=True)
     # assert len(fieldmaps) == 1
     # assert fieldmaps[0]['suffix'] == 'epi'
@@ -273,7 +273,7 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
     dset_yaml = os.path.join(get_test_data_path(), 'skeleton_complex_b0fields.yml')
     generate_bids_skeleton(str(bids_dir), dset_yaml)
     layout = BIDSLayout(str(bids_dir))
-    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz', return_type='file')}
     scan_groups, _ = grouping.group_dwi_scans(
         layout=layout,
         subject_data=subject_data,
@@ -397,7 +397,7 @@ def test_group_dwi_scans_with_complex_relpaths(tmpdir):
     dset_yaml = os.path.join(get_test_data_path(), 'skeleton_complex_relpaths.yml')
     generate_bids_skeleton(str(bids_dir), dset_yaml)
     layout = BIDSLayout(str(bids_dir))
-    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz')}
+    subject_data = {'dwi': layout.get(suffix='dwi', extension='nii.gz', return_type='file')}
     scan_groups, _ = grouping.group_dwi_scans(
         layout=layout,
         subject_data=subject_data,

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -190,7 +190,7 @@ def test_get_fieldmaps(tmp_path_factory):
     base_dir = tmp_path_factory.mktemp('test_get_fieldmaps')
 
     # Check that relative paths are correctly handled
-    bids_dir = base_dir / 'dset_fmap_intendedfor_relpath')
+    bids_dir = base_dir / 'dset_fmap_intendedfor_relpath'
     generate_bids_skeleton(str(bids_dir), dset_fmap_intendedfor_relpath)
     layout = BIDSLayout(str(bids_dir))
     dwi_file = layout.get(suffix='dwi', extension='nii.gz', return_type='filename')[0]

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -259,14 +259,24 @@ def test_group_dwi_scans_with_complex_b0fields(tmpdir):
         using_fsl=True,
         combine_scans=True,
         ignore_fieldmaps=False,
-        concatenate_distortion_groups=False,
+        concatenate_distortion_groups=True,
     )
     expected = [
-        [
-            'sub-01_acq-98dir_dir-AP_run-2_dwi.nii.gz',
-            'sub-01_acq-99dir_dir-AP_run-1_dwi.nii.gz',
-        ],
-        ['sub-01_acq-99dir_dir-AP_run-3_dwi.nii.gz'],
+        {
+            'concatenated_bids_name': 'sub-01_dir-AP',
+            'dwi_series': [
+                'sub-01/dwi/sub-01_dir-AP_run-1_dwi.nii.gz',
+                'sub-01/dwi/sub-01_dir-AP_run-2_dwi.nii.gz',
+            ],
+            'dwi_series_pedir': 'j',
+            'fieldmap_info': {'suffix': None},
+        },
+        {
+            'concatenated_bids_name': 'sub-01_dir-PA',
+            'dwi_series': ['sub-01/dwi/sub-01_dir-PA_dwi.nii.gz'],
+            'dwi_series_pedir': 'j-',
+            'fieldmap_info': {'suffix': None},
+        },
     ]
     check_expected(scan_groups, expected)
 

--- a/qsiprep/tests/test_utils_grouping.py
+++ b/qsiprep/tests/test_utils_grouping.py
@@ -1,6 +1,7 @@
 """Tests for the grouping utils."""
 
 import os
+from pprint import pformat
 
 from bids.layout import BIDSLayout
 from niworkflows.utils.testing import generate_bids_skeleton
@@ -231,7 +232,7 @@ def check_expected(subject_data, expected):
         assert os.path.basename(subject_data) == expected
     elif isinstance(expected, list):
         assert subject_data is not None, 'subject_data is None.'
-        assert len(subject_data) == len(expected)
+        assert len(subject_data) == len(expected), pformat(subject_data)
         for item, expected_item in zip(subject_data, expected, strict=False):
             if isinstance(expected_item, list):
                 # Handle nested lists

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -60,9 +60,7 @@ def group_dwi_scans(
     # Group them by their warp group
     dwi_fmap_groups = []
     for dwi_entity_group in dwi_entity_groups:
-        dwi_fmap_groups.extend(
-            group_by_warpspace(dwi_entity_group, layout, ignore_fieldmaps)
-        )
+        dwi_fmap_groups.extend(group_by_warpspace(dwi_entity_group, layout, ignore_fieldmaps))
 
     if using_fsl:
         return group_for_eddy(dwi_fmap_groups)

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 
 from nipype.utils.filemanip import split_filename
 
+from .. import config
 from ..interfaces.bids import get_bids_params
 
 LOGGER = logging.getLogger('nipype.workflow')

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -816,9 +816,6 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
     dwi_metadatas = [layout.get_metadata(dwi_file) for dwi_file in dwi_files]
     # Check for any data in dwi/ that could be used for distortion correction
     dwi_series_fieldmaps = find_fieldmaps_from_other_dwis(dwi_files, dwi_metadatas)
-    LOGGER.info(
-        f'dwi_series_fieldmaps: {pprint.pformat(dwi_series_fieldmaps, indent=2, width=120)}'
-    )
 
     # Find the best fieldmap for each file.
     best_fieldmap = {}
@@ -827,7 +824,6 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
         all_fmaps = [dwi_series_fieldmaps[dwi_file]]
         if not ignore_fieldmaps:
             fmap_fmaps = layout.get_fieldmap(dwi_file, return_list=True)
-            LOGGER.info(f'fmap_fmaps: {pprint.pformat(fmap_fmaps, indent=2, width=120)}')
             all_fmaps += fmap_fmaps
 
         # Find the highest priority fieldmap for this dwi file
@@ -837,8 +833,6 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
         # Add the dwi file to a list of those corrected by this fieldmap
         fmap_key = tuple(best_fmap[best_fmap['suffix']]) if best_fmap['suffix'] else 'None'
         grouped_by_fmap[fmap_key].append(dwi_file)
-
-    LOGGER.info(f'grouped_by_fmap: {pprint.pformat(grouped_by_fmap, indent=2, width=120)}')
 
     # Create the final groups
     dwi_groups = []

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -39,16 +39,24 @@ def group_dwi_scans(
 
     Parameters
     ----------
-    bids_layout : :obj:`pybids.BIDSLayout`
+    layout : :obj:`pybids.BIDSLayout`
         A PyBIDS layout
-    using_fsl : :obj:`bool`
-        Should a plus and minus series be grouped together for TOPUP/eddy?
-    combine_scans : :obj:`bool`
-        Should scan concatention happen?
-    ignore_fieldmaps : :obj:`bool`
-        Should fieldmaps be ignored?
-    concatenate_distortion_groups : :obj:`bool`
-        Will distortion groups get merged at the end of the pipeline?
+    subject_data : :obj:`dict`
+        A dictionary of BIDS data for a single subject.
+        The keys are the BIDS entities and the values are lists of BIDS filenames.
+        The ``dwi`` key is required.
+    using_fsl : :obj:`bool`, optional
+        If True, group plus and minus series together for TOPUP/eddy.
+        Default is False.
+    combine_scans : :obj:`bool`, optional
+        If True, group scans together based on their BIDS entities.
+        Default is True.
+    ignore_fieldmaps : :obj:`bool`, optional
+        If True, ignore fieldmaps.
+        Default is False.
+    concatenate_distortion_groups : :obj:`bool`, optional
+        If True, merge distortion groups at the end of the pipeline.
+        Default is False.
 
     Returns
     -------
@@ -808,6 +816,9 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
     dwi_metadatas = [layout.get_metadata(dwi_file) for dwi_file in dwi_files]
     # Check for any data in dwi/ that could be used for distortion correction
     dwi_series_fieldmaps = find_fieldmaps_from_other_dwis(dwi_files, dwi_metadatas)
+    LOGGER.info(
+        f'dwi_series_fieldmaps: {pprint.pformat(dwi_series_fieldmaps, indent=2, width=120)}'
+    )
 
     # Find the best fieldmap for each file.
     best_fieldmap = {}
@@ -825,6 +836,8 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
         # Add the dwi file to a list of those corrected by this fieldmap
         fmap_key = tuple(best_fmap[best_fmap['suffix']]) if best_fmap['suffix'] else 'None'
         grouped_by_fmap[fmap_key].append(dwi_file)
+
+    LOGGER.info(f'grouped_by_fmap: {pprint.pformat(grouped_by_fmap, indent=2, width=120)}')
 
     # Create the final groups
     dwi_groups = []

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -401,7 +401,7 @@ def find_fieldmaps_from_other_dwis(dwi_files, dwi_file_metadatas):
     """
 
     scans_to_pe_dirs = {
-        fname: meta.get('PhaseEncodingDirection', 'None')
+        fname: meta.get('PhaseEncodingDirection', None)
         for fname, meta in zip(dwi_files, dwi_file_metadatas, strict=False)
     }
     pe_dirs_to_scans = defaultdict(list)

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -20,13 +20,13 @@ from collections import defaultdict
 
 from nipype.utils.filemanip import split_filename
 
-from .. import config
 from ..interfaces.bids import get_bids_params
 
 LOGGER = logging.getLogger('nipype.workflow')
 
 
 def group_dwi_scans(
+    layout,
     subject_data,
     using_fsl=False,
     combine_scans=True,
@@ -55,13 +55,13 @@ def group_dwi_scans(
         concatenation. The values are lists of dwi files in that group.
     """
     # Handle the grouping of multiple dwi files within a session
-    dwi_entity_groups = get_entity_groups(config.execution.layout, subject_data, combine_scans)
+    dwi_entity_groups = get_entity_groups(layout, subject_data, combine_scans)
 
     # Group them by their warp group
     dwi_fmap_groups = []
     for dwi_entity_group in dwi_entity_groups:
         dwi_fmap_groups.extend(
-            group_by_warpspace(dwi_entity_group, config.execution.layout, ignore_fieldmaps)
+            group_by_warpspace(dwi_entity_group, layout, ignore_fieldmaps)
         )
 
     if using_fsl:

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -827,6 +827,7 @@ def group_by_warpspace(dwi_files, layout, ignore_fieldmaps):
         all_fmaps = [dwi_series_fieldmaps[dwi_file]]
         if not ignore_fieldmaps:
             fmap_fmaps = layout.get_fieldmap(dwi_file, return_list=True)
+            LOGGER.info(f'fmap_fmaps: {pprint.pformat(fmap_fmaps, indent=2, width=120)}')
             all_fmaps += fmap_fmaps
 
         # Find the highest priority fieldmap for this dwi file

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -319,7 +319,8 @@ to workflows in *QSIPrep*'s documentation]\
     # Handle the grouping of multiple dwi files within a session
     # concatenation_scheme maps the outputs to their final concatenation group
     dwi_fmap_groups, concatenation_scheme = group_dwi_scans(
-        subject_data,
+        layout=config.execution.layout,
+        subject_data=subject_data,
         using_fsl=True,
         combine_scans=not config.workflow.separate_all_dwis,
         ignore_fieldmaps='fieldmaps' in config.workflow.ignore,


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Write tests to cover field map collection and DWI scan grouping, using mocked up datasets.
- Modify the utility function `group_dwi_scans` to accept the BIDSLayout as a parameter instead of relying on the config object. This makes it easier to test. Also the nipreps folks only use the config in workflow functions. They tend to pass fields from it into interfaces and utility functions.