### PR TITLE
Add tips on B1 bias correction on normed data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -367,7 +367,7 @@ texinfo_documents = [
 linkcode_resolve = make_linkcode_resolve(
     'qsiprep',
     (
-        'https://github.com/pennlinc/qsiprep/blob/{revision}/{package}/{path}#L{lineno}'  # noqa: FS003
+        'https://github.com/pennlinc/qsiprep/blob/{revision}/{package}/{path}#L{lineno}'
     ),
 )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,9 +366,7 @@ texinfo_documents = [
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
     'qsiprep',
-    (
-        'https://github.com/pennlinc/qsiprep/blob/{revision}/{package}/{path}#L{lineno}'
-    ),
+    'https://github.com/pennlinc/qsiprep/blob/{revision}/{package}/{path}#L{lineno}',
 )
 
 # -----------------------------------------------------------------------------

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -143,6 +143,13 @@ default (using ``dwibiascorrect``) and can be disabled with the
 across scans (i.e. scaled to an average value) by default, but this can be
 turned off using ``--dwi-no-b0-harmonization``.
 
+.. tip::
+
+  If prescan normalization is enabled,
+  we recommend using ``--b1-biascorrect-stage none``.
+  This will skip B1 bias field correction,
+  which may introduce artifacts on normalized data.
+
 Together, denoising (MP-PCA or patch2self), Gibbs unringing B1 bias field
 correction and b=0 intensity normalization are referred to as *denoising* in
 *QSIPrep*. Each of these image processing operations has assumptions about its

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -405,10 +405,15 @@ def _build_parser(**kwargs):
         action='store',
         choices=['final', 'none', 'legacy'],
         default='final',
-        help="Which stage to apply B1 bias correction. The default 'final' will "
-        'apply it after all the data has been resampled to its final space. '
-        "'none' will skip B1 bias correction and 'legacy' will behave consistent "
-        'with qsiprep < 0.17.',
+        help=(
+            'Which stage to apply B1 bias correction. '
+            'The default "final" will apply it after all the data has been resampled '
+            'to its final space. '
+            '"none" will skip B1 bias correction and '
+            '"legacy" will behave consistent with qsiprep < 0.17. '
+            'For prescan-normalized data, we recommend using "none", '
+            'as bias correction may introduce artifacts on normalized data.'
+        ),
     )
     g_conf.add_argument(
         '--no-b0-harmonization',

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -167,7 +167,7 @@ def init_merge_and_denoise_wf(
             # Set up a strict query for a phase file based on the magnitude file.
             all_entities = layout.get_entities(metadata=False)
             # No other non-matching entities allowed
-            query = {k: Query.NONE for k in all_entities.keys()}
+            query = dict.fromkeys(all_entities.keys(), Query.NONE)
             query.update(layout.get_file(dwi_file).get_entities())
             query['part'] = 'phase'
             phase_files = layout.get(**query)


### PR DESCRIPTION
Closes #932.

## Changes proposed in this pull request

- Add notes on disabling B1 bias correction on prescan-normalized data to documentation.