### PR TITLE
Remove unused source_file parameter from CombineMotions

### DIFF
--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -538,10 +538,7 @@ def init_hmc_model_iteration_wf(name='hmc_model_iter0'):
         (register_to_predicted, calculate_motion, [
             (('forward_transforms', _list_squeeze), 'transform_files'),
         ]),
-        (inputnode, calculate_motion, [
-            ('original_dwi_files', 'source_files'),
-            ('b0_mean', 'ref_file'),
-        ]),
+        (inputnode, calculate_motion, [('b0_mean', 'ref_file')]),
         (calculate_motion, outputnode, [('motion_file', 'motion_params')]),
         (register_to_predicted, post_bvec_transforms, [
             (('forward_transforms', _list_squeeze), 'affine_transforms'),

--- a/qsiprep/workflows/dwi/hmc_sdc.py
+++ b/qsiprep/workflows/dwi/hmc_sdc.py
@@ -154,7 +154,6 @@ def init_qsiprep_hmcsdc_wf(
         ]),
         (dwi_hmc_wf, summarize_motion, [
             ('outputnode.final_template', 'ref_file'),
-            ('outputnode.final_template', 'source_files'),
             (('outputnode.forward_transforms', _list_squeeze), 'transform_files'),
         ]),
         (dwi_hmc_wf, slice_qc, [


### PR DESCRIPTION
Closes none, but is related to #301. In #301, the source_file parameter in CombineMotions became unused, so this PR just removes the parameter to make the code more readable.

## Changes proposed in this pull request

- Remove source_file from CombineMotions and clean up related functions and workflows.