### PR TITLE
Apply ignore fields to subj_data

### DIFF
--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -81,8 +81,6 @@ of the file you will send to ``--bids-filter-file``. The queries in *QSIPrep* ar
 
   {
       "fmap": {"datatype": "fmap"},
-      "sbref": {"datatype": "func", "suffix": "sbref"},
-      "flair": {"datatype": "anat", "suffix": "FLAIR"},
       "t2w": {"datatype": "anat", "suffix": "T2w"},
       "t1w": {"datatype": "anat", "suffix": "T1w"},
       "roi": {"datatype": "anat", "suffix": "roi"},

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -315,7 +315,7 @@ def _build_parser(**kwargs):
         action='store',
         nargs='+',
         default=[],
-        choices=['fieldmaps', 'sbref', 't2w', 'flair', 'fmap-jacobian', 'phase'],
+        choices=['fieldmaps', 't2w', 'phase'],
         help='Ignore selected aspects of the input dataset to disable corresponding '
         'parts of the workflow (a space delimited list)',
     )

--- a/qsiprep/interfaces/bids.py
+++ b/qsiprep/interfaces/bids.py
@@ -137,12 +137,9 @@ class BIDSDataGrabberInputSpec(BaseInterfaceInputSpec):
 class BIDSDataGrabberOutputSpec(TraitedSpec):
     out_dict = traits.Dict(desc='output data structure')
     fmap = OutputMultiPath(desc='output fieldmaps')
-    bold = OutputMultiPath(desc='output functional images')
-    sbref = OutputMultiPath(desc='output sbrefs')
     t1w = OutputMultiPath(desc='output T1w images')
     roi = OutputMultiPath(desc='output ROI images')
     t2w = OutputMultiPath(desc='output T2w images')
-    flair = OutputMultiPath(desc='output FLAIR images')
     dwi = OutputMultiPath(desc='output DWI images')
 
 
@@ -213,7 +210,7 @@ class BIDSDataGrabber(SimpleInterface):
                 f'No DWI images found for subject sub-{self.inputs.subject_id}'
             )
 
-        for imtype in ['flair', 'fmap', 'sbref', 'roi', 'dwi']:
+        for imtype in ['fmap', 'roi', 'dwi']:
             if not bids_dict[imtype]:
                 LOGGER.warning("No '%s' images found for sub-%s", imtype, self.inputs.subject_id)
 

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -229,6 +229,10 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
         )
         for dtype, query in queries.items()
     }
+    # Remove data types that are in the ignore list (this will catch t2w)
+    for dtype in subj_data.keys():
+        if dtype in config.workflow.ignore:
+            subj_data[dtype] = []
 
     config.loggers.workflow.log(
         25,

--- a/qsiprep/utils/bids.py
+++ b/qsiprep/utils/bids.py
@@ -199,8 +199,6 @@ def collect_data(bids_dir, participant_label, session_id=None, filters=None, bid
 
     queries = {
         'fmap': {'datatype': 'fmap'},
-        'sbref': {'datatype': 'func', 'suffix': 'sbref'},
-        'flair': {'datatype': 'anat', 'suffix': 'FLAIR'},
         't2w': {'datatype': 'anat', 'suffix': 'T2w'},
         't1w': {'datatype': 'anat', 'suffix': 'T1w'},
         'roi': {'datatype': 'anat', 'suffix': 'roi'},

--- a/qsiprep/workflows/anatomical/volume.py
+++ b/qsiprep/workflows/anatomical/volume.py
@@ -106,8 +106,6 @@ def init_anat_preproc_wf(
         List of T1-weighted structural images
     t2w
         List of T2-weighted structural images
-    flair
-        List of FLAIR images
     roi
         A mask to exclude regions during standardization (as list)
     subjects_dir
@@ -143,7 +141,7 @@ def init_anat_preproc_wf(
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['t1w', 't2w', 'roi', 'flair', 'subjects_dir', 'subject_id'],
+            fields=['t1w', 't2w', 'roi', 'subjects_dir', 'subject_id'],
         ),
         name='inputnode',
     )

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -290,7 +290,6 @@ to workflows in *QSIPrep*'s documentation]\
             ('t1w', 'inputnode.t1w'),
             ('t2w', 'inputnode.t2w'),
             ('roi', 'inputnode.roi'),
-            ('flair', 'inputnode.flair'),
         ]),
         (summary, anat_preproc_wf, [('subject_id', 'inputnode.subject_id')]),
         (bidssrc, ds_report_summary, [

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -183,7 +183,6 @@ def init_dwi_preproc_wf(
         niu.IdentityInterface(
             fields=[
                 'dwi_files',
-                'sbref_file',
                 'subjects_dir',
                 'subject_id',
                 't1_preproc',
@@ -218,7 +217,6 @@ def init_dwi_preproc_wf(
                 'dwi_mask',
                 'hmc_xforms',
                 'fieldwarps',
-                'sbref_file',
                 'original_files',
                 'original_bvecs',
                 'raw_qc_file',

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -186,7 +186,6 @@ def init_dwi_finalize_wf(
                 'hmc_xforms',
                 'fieldwarps',
                 'output_grid',
-                'sbref_file',
                 'subjects_dir',
                 'subject_id',
                 't1_preproc',


### PR DESCRIPTION
Closes #952.

## Changes proposed in this pull request

- Remove internal fields for handling flair, sbref, and bold files.
- Remove `fmap-jacobians`, `flair`, and `sbref` options from `--ignore`.
- Get `--ignore t2w` working.