### PR TITLE
Update base image to ubuntu 22.04, CUDA 12.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/qsiprep_build:26.1.5
+    - image: pennlinc/qsiprep_build:26.1.6
   working_directory: /tmp/src/qsiprep
 
 runinstall: &runinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 COPY . /src/qsiprep
 RUN python -m build /src/qsiprep
 
-FROM pennlinc/qsiprep_build:26.1.5
+FROM pennlinc/qsiprep_build:26.1.6
 
 # Install qsiprep wheel
 COPY --from=wheelstage /src/qsiprep/dist/*.whl .


### PR DESCRIPTION
## Changes proposed in this pull request

The base image in qsiprep_build is changed to nvidia/cuda:12.2.2-runtime-ubuntu22.04, with all compiled packages pinned to the same versions as in v1.0.2.

The actual preprocessing pipeline should have only very minor differences from v1.0.2, but should solve a number of issues related to glibc (specifically #935). 

There ARE a couple minor changes to software, including FSL being updated to 6.0.7.15 (pennlinc/qsiprep_build#18), FreeSurfer being updated to 7.4.1 (pennlinc/qsiprep_build#19) and some python package updates.

Closes #935, #977, #821


