### PR TITLE
Replace zero-magnitude b-vectors with [1 0 0]

### DIFF
--- a/qsiprep/interfaces/dwi_merge.py
+++ b/qsiprep/interfaces/dwi_merge.py
@@ -20,6 +20,7 @@ from nipype.interfaces.base import (
 )
 from nipype.utils.filemanip import fname_presuffix
 
+from ..utils.misc import safe_unit_vector
 from ..workflows.dwi.util import _get_concatenated_bids_name
 from .fmap import get_distortion_grouping
 
@@ -420,11 +421,6 @@ def find_image_pairs(original_bvecs, bvals, assignments):
     return pairs, bvecs
 
 
-def unit_vector(vector):
-    """Returns the unit vector of the vector."""
-    return vector / np.linalg.norm(vector)
-
-
 def angle_between(v1, v2):
     """Returns the angle in degrees between vectors 'v1' and 'v2'::
     >>> angle_between((1, 0, 0), (0, 1, 0))
@@ -434,8 +430,8 @@ def angle_between(v1, v2):
     >>> angle_between((1, 0, 0), (-1, 0, 0))
     180.0
     """
-    v1_u = unit_vector(v1)
-    v2_u = unit_vector(v2)
+    v1_u = safe_unit_vector(v1)
+    v2_u = safe_unit_vector(v2)
     return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0)) * 180 / np.pi
 
 
@@ -568,10 +564,8 @@ def average_bvec(bvec1, bvec2):
 
     bvec_diff = angle_between(bvec1, bvec2)
 
-    mean_bvec_plus = (bvec1 + bvec2) / 2.0
-    mean_bvec_plus = mean_bvec_plus / np.linalg.norm(mean_bvec_plus)
-    mean_bvec_minus = (bvec1 - bvec2) / 2.0
-    mean_bvec_minus = mean_bvec_minus / np.linalg.norm(mean_bvec_minus)
+    mean_bvec_plus = safe_unit_vector((bvec1 + bvec2) / 2.0)
+    mean_bvec_minus = safe_unit_vector((bvec1 - bvec2) / 2.0)
 
     if angle_between(bvec1, mean_bvec_plus) < angle_between(
         bvec1, mean_bvec_minus

--- a/qsiprep/interfaces/gradients.py
+++ b/qsiprep/interfaces/gradients.py
@@ -28,6 +28,8 @@ from scipy.spatial.transform import Rotation as R
 from sklearn.metrics import r2_score
 from transforms3d.affines import decompose44
 
+from ..utils.misc import safe_unit_vector
+
 LOGGER = logging.getLogger('nipype.interface')
 tensor_index = {'xx': (0, 0), 'xy': (0, 1), 'xz': (0, 2), 'yy': (1, 1), 'yz': (1, 2), 'zz': (2, 2)}
 
@@ -826,10 +828,6 @@ def aattp_rotate_vec(orig_vec, transform, runtime):
         bvec_txt.write('x,y,z,t\n0.0,0.0,0.0,0.0\n')
         bvec_txt.write(','.join(map(str, 5 * orig_vec)) + ',0.0\n')
 
-    def unit_vector(vector):
-        """The unit vector of the vector."""
-        return vector / np.linalg.norm(vector)
-
     # Only use the affine transforms for global bvecs
     # Reverse order and inverse to antsApplyTransformsToPoints
     transforms = f'--transform [{transform}, 1]'
@@ -844,7 +842,7 @@ def aattp_rotate_vec(orig_vec, transform, runtime):
     LOGGER.info(cmd)
     os.system(cmd)
     rotated_vec = np.loadtxt(rotated_txt, skiprows=1, delimiter=',')[:, :3]
-    rotated_unit_vec = unit_vector(rotated_vec[1] - rotated_vec[0])
+    rotated_unit_vec = safe_unit_vector(rotated_vec[1] - rotated_vec[0])
 
     return rotated_unit_vec, cmd
 

--- a/qsiprep/tests/test_utils_misc.py
+++ b/qsiprep/tests/test_utils_misc.py
@@ -1,0 +1,47 @@
+"""Tests for qsiprep.utils.misc."""
+
+import logging
+
+import numpy as np
+
+from qsiprep.utils.misc import safe_unit_vector
+
+
+def test_safe_unit_vector_zero_magnitude_substitutes_x_axis():
+    result = safe_unit_vector(np.array([0.0, 0.0, 0.0]))
+    assert np.array_equal(result, np.array([1.0, 0.0, 0.0]))
+
+
+def test_safe_unit_vector_normalizes_nonzero_vector():
+    result = safe_unit_vector(np.array([0.0, 3.0, 0.0]))
+    assert np.allclose(result, np.array([0.0, 1.0, 0.0]))
+    assert np.isclose(np.linalg.norm(result), 1.0)
+
+
+def test_safe_unit_vector_no_nan_on_zero():
+    result = safe_unit_vector(np.array([0.0, 0.0, 0.0]))
+    assert not np.any(np.isnan(result))
+
+
+def test_safe_unit_vector_warns_on_zero_magnitude(caplog):
+    with caplog.at_level(logging.WARNING, logger='nipype.interface'):
+        safe_unit_vector(np.array([0.0, 0.0, 0.0]))
+    assert any('zero-magnitude' in record.message for record in caplog.records)
+
+
+def test_average_bvec_no_nan_with_zero_magnitude_pair():
+    from qsiprep.interfaces.dwi_merge import average_bvec
+
+    # Antipodal vectors average to a zero-magnitude vector, which the old
+    # normalization turned into NaN. The guard must keep the result finite.
+    bvec1 = np.array([1.0, 0.0, 0.0])
+    bvec2 = np.array([-1.0, 0.0, 0.0])
+    averaged, _ = average_bvec(bvec1, bvec2)
+    assert not np.any(np.isnan(averaged))
+
+
+def test_angle_between_finite_for_zero_vector():
+    from qsiprep.interfaces.dwi_merge import angle_between
+
+    angle = angle_between(np.array([0.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0]))
+    assert np.isfinite(angle)

--- a/qsiprep/utils/misc.py
+++ b/qsiprep/utils/misc.py
@@ -2,6 +2,27 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Miscellaneous utility functions."""
 
+import logging
+
+import numpy as np
+
+LOGGER = logging.getLogger('nipype.interface')
+
+
+def safe_unit_vector(vector):
+    """Return the unit vector of ``vector``.
+
+    A zero-magnitude b-vector (e.g. the magnitude-zero b-vectors Philips uses
+    for b=0 volumes) cannot be normalized: dividing by a zero norm yields NaN.
+    In that case ``(1, 0, 0)`` is substituted and a warning is emitted so it is
+    clear the b-vector has been modified.
+    """
+    norm = np.linalg.norm(vector)
+    if norm == 0:
+        LOGGER.warning('Encountered a zero-magnitude b-vector; substituting (1, 0, 0).')
+        return np.array([1.0, 0.0, 0.0])
+    return vector / norm
+
 
 def check_deps(workflow):
     from nipype.utils.filemanip import which


### PR DESCRIPTION
Closes #1005.

## Changes proposed in this pull request

- Replace unit_vector function with Philips-compatible safe_unit_vector, which checks for zero-magnitude b-vectors and replaces them with [1 0 0] (and raises a warning).