### PR TITLE
Set minimum dwi_denoise_window to 3

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -107,7 +107,7 @@ def _build_parser(**kwargs):
     def _int_or_auto(value, parser):
         """Ensure an argument is an odd integer >= 3 or 'auto'."""
         if value.lower() == 'auto':
-            return value
+            return 'auto'
         try:
             value = int(value)
         except ValueError as exc:

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -105,7 +105,7 @@ def _build_parser(**kwargs):
         return value
 
     def _int_or_auto(value, parser):
-        """Ensure an argument is an integer or 'auto'."""
+        """Ensure an argument is an odd integer >= 3 or 'auto'."""
         if value.lower() == 'auto':
             return value
         try:
@@ -113,11 +113,11 @@ def _build_parser(**kwargs):
         except ValueError as exc:
             raise parser.error('Argument must be an integer or "auto".') from exc
 
-        if value < 1:
-            raise parser.error('Argument must be greater than zero.')
+        if value < 3:
+            raise parser.error('Argument must be an odd integer >= 3.')
 
         if value % 2 == 0:
-            raise parser.error('Argument must be an odd integer.')
+            raise parser.error('Argument must be an odd integer >= 3.')
 
         return value
 

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -450,6 +450,7 @@ def init_dwi_denoising_wf(
             import numpy as np
 
             dwi_denoise_window = closest_odd(int(np.ceil(np.cbrt(n_volumes))))
+            dwi_denoise_window = np.maximum(dwi_denoise_window, 3)
             config.loggers.workflow.info(
                 f'Automatically using {dwi_denoise_window}, {dwi_denoise_window}, '
                 f'{dwi_denoise_window} window for dwidenoise'

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -445,12 +445,12 @@ def init_dwi_denoising_wf(
 
         dwi_denoise_window = config.workflow.dwi_denoise_window
         auto_str = ''
-        if denoise_method == 'dwidenoise' and config.workflow.dwi_denoise_window == 'auto':
+        if denoise_method == 'dwidenoise' and dwi_denoise_window == 'auto':
             # Configure the denoising window
             import numpy as np
 
             dwi_denoise_window = closest_odd(int(np.ceil(np.cbrt(n_volumes))))
-            dwi_denoise_window = np.maximum(dwi_denoise_window, 3)
+            dwi_denoise_window = max(dwi_denoise_window, 3)
             config.loggers.workflow.info(
                 f'Automatically using {dwi_denoise_window}, {dwi_denoise_window}, '
                 f'{dwi_denoise_window} window for dwidenoise'


### PR DESCRIPTION
Closes #1063.

## Changes proposed in this pull request

- Ensure dwi_denoise_window is at least 3, as a value of 1 raises an error in `dwidenoise`.