### PR TITLE
Document --ignore fieldmaps

### DIFF
--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -752,6 +752,13 @@ If a GRE fieldmap or SyN-based fieldmapless distortion correction
 are detected, these will be performed on the outputs of ``eddy``.
 For details see :ref:`dwi_sdc`.
 
+.. tip::
+
+  If you want to disable susceptibility distortion correction, you should use the ``--ignore fieldmaps`` option.
+  This will completely disable susceptibility distortion correction,
+  whether using field maps or reverse phase-encoded dMRI runs.
+
+
 .. workflow::
     :graph2use: orig
     :simple_form: yes

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -752,13 +752,6 @@ If a GRE fieldmap or SyN-based fieldmapless distortion correction
 are detected, these will be performed on the outputs of ``eddy``.
 For details see :ref:`dwi_sdc`.
 
-.. tip::
-
-  If you want to disable susceptibility distortion correction, you should use the ``--ignore fieldmaps`` option.
-  This will completely disable susceptibility distortion correction,
-  whether using field maps or reverse phase-encoded dMRI runs.
-
-
 .. workflow::
     :graph2use: orig
     :simple_form: yes

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -321,8 +321,12 @@ def _build_parser(**kwargs):
         nargs='+',
         default=[],
         choices=['fieldmaps', 't2w', 'phase'],
-        help='Ignore selected aspects of the input dataset to disable corresponding '
-        'parts of the workflow (a space delimited list)',
+        help=(
+            'Ignore selected aspects of the input dataset to disable corresponding '
+            'parts of the workflow (a space delimited list). '
+            '"fieldmaps" will completely disable susceptibility distortion correction, '
+            'whether using field maps or reverse phase-encoded dMRI runs.'
+        ),
     )
     g_conf.add_argument(
         '--infant',


### PR DESCRIPTION
Closes #965.

## Changes proposed in this pull request

- Clarify in preprocessing page and parser help string that `--ignore fieldmaps` disabled susceptibility distortion correction completely.