### PR TITLE
Configure shared libraries for DSIStudio commands at runtime

### DIFF
--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -22,10 +22,36 @@ from .. import config
 
 LOGGER = logging.getLogger('nipype.interface')
 DSI_STUDIO_VERSION = '94b9c79'
+_APPTAINER_LIBRARY_PATH = '/.singularity.d/libs'
+
+
+def _get_dsi_studio_environment(environ=None):
+    # Exclude host libraries injected by Apptainer's --nv.
+    environment = dict(os.environ if environ is None else environ)
+    library_path = environment.get('LD_LIBRARY_PATH')
+    if library_path is None:
+        return environment
+    apptainer_path = op.normpath(_APPTAINER_LIBRARY_PATH)
+    library_paths = library_path.split(os.pathsep)
+    library_paths = [path for path in library_paths if op.normpath(path) != apptainer_path]
+    environment['LD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
+    return environment
 
 
 class DSIStudioCommandLineInputSpec(CommandLineInputSpec):
     num_threads = traits.Int(1, usedefault=True, argstr='--thread_count=%d', nohash=True)
+
+
+class DSIStudioCommandLine(CommandLine):
+    """Run DSI Studio without libraries injected by Apptainer."""
+
+    def _run_interface(self, runtime, correct_return_codes=(0,)):
+        environment = {**os.environ, **self.inputs.environ}
+        environment = _get_dsi_studio_environment(environment)
+        if 'LD_LIBRARY_PATH' in environment:
+            value = environment['LD_LIBRARY_PATH']
+            self.inputs.environ['LD_LIBRARY_PATH'] = value
+        return super()._run_interface(runtime, correct_return_codes)
 
 
 class DSIStudioCreateSrcInputSpec(DSIStudioCommandLineInputSpec):
@@ -62,7 +88,7 @@ class DSIStudioCreateSrcOutputSpec(TraitedSpec):
     output_src = File(desc='Output file (.src.gz)', name_source='subject_id')
 
 
-class DSIStudioCreateSrc(CommandLine):
+class DSIStudioCreateSrc(DSIStudioCommandLine):
     input_spec = DSIStudioCreateSrcInputSpec
     output_spec = DSIStudioCreateSrcOutputSpec
     _cmd = 'dsi_studio --action=src '
@@ -126,7 +152,13 @@ class DSIStudioQC(SimpleInterface):
         # (which *cannot* be symbolic links for some reason).
         src_file = fname_presuffix(self.inputs.src_file, newpath=runtime.cwd)
         cmd = ['dsi_studio', '--action=qc', '--source=' + src_file]
-        proc = Popen(cmd, cwd=runtime.cwd, stdout=PIPE, stderr=PIPE)
+        proc = Popen(
+            cmd,
+            cwd=runtime.cwd,
+            env=_get_dsi_studio_environment(),
+            stdout=PIPE,
+            stderr=PIPE,
+        )
         out, err = proc.communicate()
         if out:
             LOGGER.info(out.decode())
@@ -224,7 +256,7 @@ class DSIStudioGQIReconstructionInputSpec(DSIStudioReconstructionInputSpec):
     ratio_of_mean_diffusion_distance = traits.Float(1.25, usedefault=True, argstr='--param0=%.4f')
 
 
-class DSIStudioGQIReconstruction(CommandLine):
+class DSIStudioGQIReconstruction(DSIStudioCommandLine):
     input_spec = DSIStudioGQIReconstructionInputSpec
     output_spec = DSIStudioReconstructionOutputSpec
     _cmd = 'dsi_studio --action=rec --method=4'

--- a/qsiprep/tests/test_interfaces_dsi_studio.py
+++ b/qsiprep/tests/test_interfaces_dsi_studio.py
@@ -1,0 +1,80 @@
+"""Tests for the qsiprep.interfaces.dsi_studio module."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from nipype.interfaces.base import CommandLine
+
+import qsiprep.interfaces.dsi_studio as dsi_studio_mod
+from qsiprep.interfaces.dsi_studio import (
+    DSIStudioCreateSrc,
+    DSIStudioGQIReconstruction,
+    DSIStudioSrcQC,
+    _get_dsi_studio_environment,
+)
+
+APPTAINER_PATH = '/.singularity.d/libs'
+
+
+def test_get_dsi_studio_environment_removes_apptainer_path():
+    """Remove only the Apptainer library directory."""
+    paths = ['/opt/freesurfer/lib', APPTAINER_PATH, '/opt/conda/lib']
+    environment = {
+        'LD_LIBRARY_PATH': os.pathsep.join(paths),
+        'OTHER_VARIABLE': 'value',
+    }
+
+    result = _get_dsi_studio_environment(environment)
+
+    expected = os.pathsep.join(['/opt/freesurfer/lib', '/opt/conda/lib'])
+    assert result['LD_LIBRARY_PATH'] == expected
+    assert result['OTHER_VARIABLE'] == 'value'
+
+
+def test_get_dsi_studio_environment_handles_edge_cases():
+    """Handle a trailing slash and a missing library path."""
+    environment = {'LD_LIBRARY_PATH': APPTAINER_PATH + os.sep}
+    assert _get_dsi_studio_environment(environment)['LD_LIBRARY_PATH'] == ''
+    environment = {'OTHER_VARIABLE': 'value'}
+    assert _get_dsi_studio_environment(environment) == environment
+
+
+@pytest.mark.parametrize(
+    'interface_class',
+    [DSIStudioCreateSrc, DSIStudioGQIReconstruction],
+)
+def test_dsi_studio_command_line_sanitizes_environment(interface_class, monkeypatch, tmp_path):
+    """Sanitize both DSI Studio command-line actions."""
+    paths = [APPTAINER_PATH, '/opt/freesurfer/lib']
+    monkeypatch.setenv('LD_LIBRARY_PATH', os.pathsep.join(paths))
+    captured_environment = {}
+
+    def _run_interface(self, runtime, correct_return_codes=(0,)):
+        captured_environment.update(self.inputs.environ)
+        return runtime
+
+    monkeypatch.setattr(CommandLine, '_run_interface', _run_interface)
+    interface = interface_class()
+    interface._run_interface(SimpleNamespace(cwd=str(tmp_path)))
+
+    assert captured_environment['LD_LIBRARY_PATH'] == '/opt/freesurfer/lib'
+
+
+def test_dsi_studio_qc_sanitizes_environment(monkeypatch, tmp_path):
+    """Sanitize the direct QC subprocess environment."""
+    paths = ['/opt/freesurfer/lib', APPTAINER_PATH]
+    monkeypatch.setenv('LD_LIBRARY_PATH', os.pathsep.join(paths))
+    src_file = tmp_path / 'input.src.gz'
+    src_file.touch()
+    process = Mock()
+    process.communicate.return_value = (b'', b'')
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(dsi_studio_mod, 'Popen', popen)
+
+    interface = DSIStudioSrcQC(src_file=str(src_file))
+    interface._run_interface(SimpleNamespace(cwd=str(tmp_path)))
+
+    environment = popen.call_args.kwargs['env']
+    assert environment['LD_LIBRARY_PATH'] == '/opt/freesurfer/lib'


### PR DESCRIPTION
I believe this should address #1067. 

## Changes proposed in this pull request

- Exclude host libraries added to Apptainer when using `--nv` in DSIStudio interface.