### PR TITLE
Sync CI setup across LINC BIDS Apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,31 @@
 version: 2.1
 
-# Dynamic config: setup workflow
-# The real pipeline lives in continue_config.yml. This setup workflow inspects
-# the diff of the pushed commit and sets two pipeline parameters.
+# ── Dynamic config: setup workflow ────────────────────────────────────
+# The real pipeline lives in continue_config.yml. This setup workflow
+# inspects the diff of the pushed commit and sets two pipeline parameters:
+#
+#   has_any_changes   true if the push contains any changed files
+#   has_code_changes  true if any changed file is under qsiprep/, scripts/,
+#                     docker/, .circleci/, or is a build/config file
+#                     (Dockerfile*, pyproject.toml, pixi.lock, tox.ini,
+#                     Makefile, .dockerignore)
+#
+# The continue workflow runs when has_code_changes is true OR when there
+# is no diff at all (tag builds, initial clones). A push that only touches
+# documentation (README, *.rst, *.md, CITATION.cff, .github/**, etc.)
+# leaves has_code_changes false and is skipped.
+#
+# `[skip ci]` / `[ci skip]` in a commit message is honored natively by
+# CircleCI at the VCS webhook level and needs no explicit handling here.
 
 setup: true
 
 orbs:
   # Version 2 uses the shell-based implementation and avoids the Python/pip
   # bootstrap path that breaks when get-pip.py drops older Python versions.
+  # The 1.x line pipes `https://bootstrap.pypa.io/get-pip.py` into the orb's
+  # default Python (now 3.9), which get-pip no longer supports, failing the
+  # filter step with "This script does not work on Python 3.9".
   path-filtering: circleci/path-filtering@2
 
 workflows:
@@ -23,6 +40,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+          # NOTE: path-filtering wraps each pattern with implicit `^...$`
+          # anchors, so every regex must match the *full* file path, not just
+          # a prefix. Prefix-style patterns therefore need an explicit `.*`
+          # suffix; single-file patterns match literally.
           mapping: |
             .*                has_any_changes   true
             qsiprep/.*        has_code_changes  true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -11,6 +11,12 @@ parameters:
 orbs:
   codecov: codecov/codecov@4.1.0
 
+# ── Reusable anchors ──────────────────────────────────────────────────
+
+# Default machine executor — used by jobs that run containers but do NOT
+# execute `docker build`. docker_layer_caching is deliberately off here
+# because it adds a ~200-credit surcharge per job and is only useful for
+# jobs that actually build images.
 _machine_defaults: &machine_defaults
   environment:
     TZ: "/usr/share/zoneinfo/America/New_York"
@@ -19,6 +25,8 @@ _machine_defaults: &machine_defaults
   working_directory: /tmp/src/qsiprep
   resource_class: large
 
+# Machine executor with docker_layer_caching — for jobs that run
+# `docker build` and benefit from warm layer caches.
 _machine_with_dlc: &machine_with_dlc
   environment:
     TZ: "/usr/share/zoneinfo/America/New_York"
@@ -28,16 +36,27 @@ _machine_with_dlc: &machine_with_dlc
   working_directory: /tmp/src/qsiprep
   resource_class: large
 
+# Shared filter block for run_tests workflow jobs — branch pushes only.
+# Tags are handled by the separate `deploy` workflow so the full integration
+# matrix is not re-run on every release (tests have already passed on the
+# main commit the tag points to).
 _default_filters: &default_filters
   tags:
     ignore: /.*/
 
+# Filter for the deploy workflow — tag pushes only, no branches.
 _tag_filters: &tag_filters
   tags:
     only: /.*/
   branches:
     ignore: /.*/
 
+# NOTE: qsiprep and qsirecon authenticate with $DOCKER_USER/$DOCKER_PASS,
+# while aslprep and xcp_d use $DOCKERHUB_USERNAME/$DOCKERHUB_TOKEN. The
+# names are deliberately left divergent until the CircleCI project env vars
+# are confirmed — the guard below means a missing variable silently skips
+# login rather than failing loudly, so renaming without setting the new var
+# would break pushes at the end of a long build.
 _docker_auth: &docker_auth
   name: Docker authentication
   command: |
@@ -48,6 +67,10 @@ _docker_auth: &docker_auth
 _setup_docker_registry: &setup_docker_registry
   name: Set up local Docker registry
   command: |
+    # registry:2 is ~25 MB and pulls in a couple of seconds over the
+    # authenticated Docker Hub connection we already have, so there's no
+    # point caching a `docker save` tarball of it — that only makes the
+    # build cache bigger and slower to save/restore.
     docker pull registry:2
     docker run -d -p 5000:5000 --restart=always --name=registry \
         -v /tmp/docker:/var/lib/registry registry:2
@@ -62,6 +85,12 @@ commands:
   restore_build_and_data:
     description: Restore workflow Docker image cache and test data cache, then start the registry
     steps:
+      # Restore the workflow-scoped key, not the shared deps key. CircleCI
+      # caches are immutable: if image_prep rebuilt the test image but the
+      # deps key already existed, its save_cache would be a no-op and this
+      # job would pull a stale image from an earlier run's registry. The
+      # workflow-scoped key is unique per run, so it always reflects the
+      # image image_prep actually produced.
       - restore_cache:
           keys:
             - build-v6-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
@@ -105,6 +134,10 @@ commands:
       - run:
           name: Prune non-QC artifacts
           when: always
+          # HTML reports and everything they embed (figures/ SVG/PNG/GIF,
+          # linked TSVs) must survive — they're how outputs get visually
+          # QC'd. Only strip large binary derivatives that the reports
+          # don't render, plus test/pycache debris.
           command: |
             find /tmp/out/ -name "*.nii.gz" -type f -delete 2>/dev/null || true
             find /tmp/out/ \( \
@@ -159,6 +192,7 @@ jobs:
             if ! docker manifest inspect $BASE_IMAGE > /dev/null 2>&1; then
               echo "Base image $BASE_IMAGE not found, building..."
               docker build -f Dockerfile.base \
+                --pull \
                 --platform linux/amd64 \
                 -t $BASE_IMAGE \
                 -t $BASE_IMAGE_NAME:latest .
@@ -300,6 +334,12 @@ jobs:
           command: |
             mkdir -p /tmp/images
             touch /tmp/images/imageprep-success.marker
+      # Two keys on purpose. The workflow-scoped key is unique per run so it
+      # is always written, guaranteeing downstream jobs restore the image
+      # this run actually produced. The deps key is shared across runs with
+      # identical Docker inputs and is what lets a later run skip the build
+      # entirely; it is a no-op once it exists, which is why it cannot be
+      # the key downstream jobs read from.
       - save_cache:
           key: build-v6-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
           paths:
@@ -312,6 +352,9 @@ jobs:
             - /tmp/images
 
   get_data:
+    # Network- and IO-bound only — no Docker daemon needed, so run on the
+    # docker executor (cimg/base:stable, ~10 credits/min) instead of the
+    # machine executor (100 credits/min).
     docker:
       - image: cimg/base:stable
     working_directory: /tmp/src/qsiprep
@@ -386,7 +429,6 @@ jobs:
             - /tmp/data
 
   integration_test:
-    <<: *machine_defaults
     parameters:
       marker:
         type: string
@@ -396,6 +438,15 @@ jobs:
       skip_marker:
         type: string
         default: ""
+      resource_class:
+        type: string
+        default: large
+    environment:
+      TZ: "/usr/share/zoneinfo/America/New_York"
+    machine:
+      image: default
+    working_directory: /tmp/src/qsiprep
+    resource_class: << parameters.resource_class >>
     steps:
       - checkout:
           path: /tmp/src/qsiprep
@@ -453,6 +504,9 @@ jobs:
             - .coverage.unit_tests
 
   merge_coverage:
+    # Runs `pip install coverage && coverage combine && coverage xml` — no
+    # Docker daemon needed. The docker executor (cimg/python, ~10 credits/min)
+    # is ~10x cheaper per minute than the machine executor it used to run on.
     docker:
       - image: cimg/python:3.12
     working_directory: /tmp/src/qsiprep

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@ Dockerfile*    text eol=lf
 *.png      binary
 *.jpg      binary
 *.nii.gz   binary
+*.gpg      binary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: pipx run ruff check .
-      - run: pipx run ruff format --diff .
+      - run: pipx run --spec ruff==0.14.11 ruff check .
+      - run: pipx run --spec ruff==0.14.11 ruff format --diff .
 
   codespell:
     name: Check for spelling errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,21 @@ The config module is the single source of truth for runtime parameters. Never pa
 
 ### Docker
 
-- Each app has a custom base image: `pennlinc/<pkg>_build:<version>`.
-- The `Dockerfile` installs the app via `pip install` into the base image.
-- Entrypoint is the CLI command (e.g., `/opt/conda/envs/<pkg>/bin/<pkg>`).
-- Labels follow the `org.label-schema` convention.
+- Each app has a base image with runtime dependencies (`Dockerfile.base`) and a main `Dockerfile` that installs the Python environment and the app itself.
+- All four apps use **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`.
+- Base image naming is uniform across the four repos: `pennlinc/<pkg>-base:<YYYYMMDD>`, pinned via `ARG BASE_IMAGE` on the first line of `Dockerfile`.
+- Entrypoint is the CLI binary in the pixi environment (e.g., `/app/.pixi/envs/<env>/bin/<pkg>`).
+- Labels follow the `org.label-schema` convention; the `test` target additionally carries `org.opencontainers.image.revision`, which CI uses to refuse running tests against a stale image.
+- The base image is rebuilt only when its `BASE_IMAGE` tag is absent from Docker Hub. Editing `Dockerfile.base` without bumping the date tag does **not** trigger a rebuild.
+- qsiprep is the only one of the four with **no templateflow prefetch stage** — the other three bake templates into the image via `scripts/fetch_templates.py`, so qsiprep downloads them at runtime instead.
+
+### CircleCI
+
+- All four repos use CircleCI **dynamic configuration**. `.circleci/config.yml` is a `setup: true` workflow that runs the `path-filtering` orb and hands off to `.circleci/continue_config.yml`, which holds the real pipeline. A docs-only push leaves `has_code_changes` false and skips the expensive matrix.
+- `continue_config.yml` defines two workflows: `run_tests` (branch pushes, gated on `has_code_changes`) and `deploy` (tag pushes only, which skips the matrix since the tagged commit already passed on `main`). qsiprep's `deploy` additionally runs `deploy_pypi`.
+- `image_prep` builds the base image (only if its tag is missing), the `test` image, and — on `main` and tags only — the production image, then pushes to Docker Hub. Integration jobs consume the test image from a local registry seeded out of the build cache.
+- The build cache uses two keys: a workflow-scoped key that downstream jobs read from (unique per run, so always written) and a shared `-deps-` key on `Dockerfile` + `pixi.lock` checksums that lets a later run skip the build entirely. Downstream jobs must not read the deps key — CircleCI caches are immutable, so it can point at an older run's image.
+- Docker Hub credentials are **not** named consistently yet: aslprep and xcp_d use `$DOCKERHUB_USERNAME`/`$DOCKERHUB_TOKEN`, qsiprep and qsirecon use `$DOCKER_USER`/`$DOCKER_PASS`. Logins are guarded by a `[[ -n ... ]]` check, so an unset variable skips login silently rather than failing.
 
 ### Release Process
 
@@ -142,8 +153,8 @@ QSIPrep is a BIDS App for preprocessing diffusion MRI (dMRI/DWI) data. It handle
 | Linter | ruff ~= 0.4.3 |
 | Pre-commit | Yes (ruff v0.6.2) |
 | Tox | Yes |
-| Docker base | `pennlinc/qsiprep_build:<ver>` |
-| Dockerfile | Multi-stage wheel build |
+| Docker base | `pennlinc/qsiprep-base:<YYYYMMDD>` |
+| Dockerfile | Pixi-based multi-stage (`build`, `test`, `qsiprep`) |
 
 ### Key Directories
 
@@ -184,7 +195,7 @@ This roadmap covers harmonization work across all four PennLINC BIDS Apps (qsipr
 ### Phase 3: Shared infrastructure
 
 11. **Extract a reusable GitHub Actions workflow** for lint + codespell + build checks, hosted in a shared repo (e.g., `PennLINC/.github`).
-12. **Standardize Dockerfile patterns** -- adopt multi-stage wheel builds (as qsiprep does) across all four repos.
+12. ~~**Standardize Dockerfile patterns**~~ -- done: all four repos now use pixi-based multi-stage builds with `pennlinc/<pkg>-base:<YYYYMMDD>` base images.
 13. **Create a shared `pennlinc-style` package or cookiecutter template** providing `pyproject.toml` lint/test config, `.pre-commit-config.yaml`, `tox.ini`, and CI workflows.
 14. **Evaluate `nipreps-versions` calver** -- the `raw-options = { version_scheme = "nipreps-calver" }` line is commented out in all four repos. Decide whether to adopt it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN chmod -R go=u $HOME
 WORKDIR /tmp
 
 FROM base AS test
-COPY --from=build /app/.pixi/envs/test /app/.pixi/envs/test
-COPY --from=build /test-shell-hook.sh /shell-hook.sh
+COPY --link --from=build /app/.pixi/envs/test /app/.pixi/envs/test
+COPY --link --from=build /test-shell-hook.sh /shell-hook.sh
 RUN cat /shell-hook.sh >> $HOME/.bashrc
 ENV PATH="/app/.pixi/envs/test/bin:$PATH"
 ENV FSLDIR="/app/.pixi/envs/test"
@@ -50,8 +50,8 @@ ARG VCS_REF
 LABEL org.opencontainers.image.revision=$VCS_REF
 
 FROM base AS qsiprep
-COPY --from=build /app/.pixi/envs/qsiprep /app/.pixi/envs/qsiprep
-COPY --from=build /shell-hook.sh /shell-hook.sh
+COPY --link --from=build /app/.pixi/envs/qsiprep /app/.pixi/envs/qsiprep
+COPY --link --from=build /shell-hook.sh /shell-hook.sh
 RUN cat /shell-hook.sh >> $HOME/.bashrc
 ENV PATH="/app/.pixi/envs/qsiprep/bin:$PATH"
 ENV FSLDIR="/app/.pixi/envs/qsiprep"


### PR DESCRIPTION
Regular synchronization of CircleCI/Docker setups across the lab's BIDS Apps.

Related to https://github.com/PennLINC/aslprep/pull/684, https://github.com/PennLINC/xcp_d/pull/1632, and https://github.com/PennLINC/qsirecon/pull/395.

 ### Summary

  Brings qsiprep's Dockerfile and CircleCI config in line with aslprep, xcp_d and
  qsirecon. The functional changes are small and low-risk; the documentation was
  substantially wrong and is the larger part of this diff.

  ### Changes

  - **`Dockerfile`** — `COPY` → `COPY --link` in the `test` and `qsiprep` stages
    (4 lines). The other three repos already use `--link` for these copies; it
    lets BuildKit reuse layers independently of the base image.
  - **`.circleci/continue_config.yml`**
    - Added `--pull` to the `Dockerfile.base` build.
    - Added a `resource_class` parameter to `integration_test` (default `large`,
      so current behavior is unchanged) matching aslprep and xcp_d, which allows
      per-test right-sizing later.
    - Comments explaining the DLC surcharge, filter split, two-key cache invariant,
      registry handling, artifact prune, executor choices, and the credential
      naming divergence.
  - **`.circleci/config.yml`** — expanded setup-workflow comments to match aslprep.
  - **`.gitattributes`** — added `*.gpg binary`.
  - **`AGENTS.md`** — see below.

  ### Docs corrections

  The Docker section described a setup qsiprep no longer has:

  | Claim | Reality |
  |---|---|
  | Base image `pennlinc/<pkg>_build:<version>` | `pennlinc/qsiprep-base:20260415` |
  | "`Dockerfile` installs the app via `pip install`" | pixi multi-stage build from `pixi.lock` |
  | Entrypoint `/opt/conda/envs/<pkg>/bin/<pkg>` | `/app/.pixi/envs/qsiprep/bin/qsiprep` |
  | Summary table: "Multi-stage wheel build" | Pixi-based multi-stage (`build`, `test`, `qsiprep`) |
  | Rec #12: "adopt multi-stage wheel builds (as qsiprep does)" | Obsolete — all four are pixi now |

  Also added a shared `### CircleCI` section and documented that qsiprep's `deploy`
  workflow additionally runs `deploy_pypi`.

  ### Known gap, deliberately not fixed here

  qsiprep is the only one of the four with **no templateflow prefetch stage** — it
  has no `scripts/` directory and no `fetch_templates.py`, so templates are
  downloaded at runtime rather than baked into the image. Adding one requires
  deciding which templates qsiprep actually needs, which is an app-level judgment
  rather than a config sync. Documented in `AGENTS.md` instead.

  ### Verification

  - Both CircleCI YAML files parse.
  - Cache keys and job/workflow structure cross-checked against the other repos.

  **Not verified:** no CircleCI run and no Docker build. `COPY --link` is the one
  change that could plausibly alter build behavior and needs a real image build.