### PR TITLE
Clean up intramodal template workflows and add boilerplate text

### DIFF
--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -669,10 +669,15 @@ How to combine images across distorted groups.
         action='store',
         default=0,
         type=int,
-        help='Number of iterations for finding the midpoint image '
-        'from the b0 templates from all groups. Has no effect if there '
-        'is only one group. If 0, all b0 templates are directly registered '
-        'to the t1w image.',
+        help=(
+            'Number of iterations for finding the midpoint image '
+            'from the b0 templates from all DWI runs and sessions. '
+            'Has no effect if there is only one group. '
+            'If 0, all b0 templates are directly registered to the t1w image. '
+            'Enabling the intramodal template method when there are multiple runs/sessions '
+            'results in a single DWI reference image, which makes it possible to '
+            'directly compare AC-PC-space preprocessed DWI data across groups.'
+        ),
     )
     g_coreg.add_argument(
         '--intramodal-template-transform',

--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -30,9 +30,9 @@ sections:
     subtitle: Spatial normalization of the anatomical reference
 
   - bids: {datatype: figures, desc: intramodalcoreg, suffix: [T1w, T2w]}
-    caption: Coregistration between the intramodal DWI template to the anatomical reference image.
+    caption: Coregistration of the intramodal DWI template to the anatomical reference image.
     static: false
-    subtitle: Coregistration of the Intramodal to anatomical templates
+    subtitle: Coregistration of the intramodal to anatomical templates
 
 - name: <em>B<sub>0</sub></em> field mapping
   ordering: session,acquisition,run,fmapid
@@ -239,7 +239,7 @@ sections:
     caption: |
       b=0 reference image warped to the across-scan/session intramodal template.
     static: false
-    subtitle: Alignment of dMRI to Intramodal Template
+    subtitle: Alignment of dMRI to intramodal template
 
   - bids: {datatype: figures, desc: acpc, suffix: dwi}
     caption: |

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -418,25 +418,34 @@ to workflows in *QSIPrep*'s documentation]\
         else:
             make_intramodal_template = True
 
-    anat_source_file = fix_multi_source_name(
-        subject_data[info_modality],
-        include_session=config.workflow.subject_anatomical_reference == 'sessionwise',
-        anatomical_contrast=config.workflow.anat_modality,
-    )
-    intramodal_template_wf = init_intramodal_template_wf(
-        t1w_source_file=anat_source_file,
-        inputs_list=sorted(outputs_to_files.keys()),
-        transform=config.workflow.intramodal_template_transform,
-        num_iterations=config.workflow.intramodal_template_iters or 2,
-        name='intramodal_template_wf',
-    )
-    # TemplateQC and the per-group orig->intramodal transform export exist only
-    # for linear templates: mvtc2 exposes no per-input aligned images, and its
-    # per-group transform is an [affine, warp] pair that does not fit a
-    # single-file .mat sink.
-    intramodal_linear = config.workflow.intramodal_template_transform in ('Rigid', 'Affine')
-
     if make_intramodal_template:
+        anat_source_file = fix_multi_source_name(
+            subject_data[info_modality],
+            include_session=config.workflow.subject_anatomical_reference == 'sessionwise',
+            anatomical_contrast=config.workflow.anat_modality,
+        )
+
+        intramodal_template_wf = init_intramodal_template_wf(
+            t1w_source_file=anat_source_file,
+            inputs_list=sorted(outputs_to_files.keys()),
+            transform=config.workflow.intramodal_template_transform,
+            num_iterations=config.workflow.intramodal_template_iters or 2,
+            name='intramodal_template_wf',
+        )
+        workflow.connect([
+            (anat_preproc_wf, intramodal_template_wf, [
+                ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
+                ('outputnode.t1_brain', 'inputnode.t1_brain'),
+                ('outputnode.t1_mask', 'inputnode.t1_mask'),
+                ('outputnode.t1_seg', 'inputnode.t1_seg'),
+                ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
+                ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
+                ('outputnode.t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform'),
+                ('outputnode.t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
+                ('outputnode.dwi_sampling_grid', 'inputnode.dwi_sampling_grid'),
+            ]),
+        ])  # fmt:skip
+
         ds_intramodal_template = pe.Node(
             DerivativesDataSink(
                 source_file=anat_source_file,
@@ -451,6 +460,15 @@ to workflows in *QSIPrep*'s documentation]\
             name='ds_intramodal_template',
             run_without_submitting=True,
         )
+        workflow.connect([
+            (intramodal_template_wf, ds_intramodal_template, [
+                # The ACPC-resampled template, NOT outputnode.intramodal_template:
+                # that one is in the template's own midpoint space, and tagging
+                # it space-ACPC would mislabel it.
+                ('outputnode.intramodal_template_acpc', 'in_file'),
+            ]),
+        ])  # fmt:skip
+
         # Without this the intramodal space is a dead end: nothing can be mapped
         # into or out of it after the fact.
         ds_intramodal_to_acpc = pe.Node(
@@ -466,6 +484,17 @@ to workflows in *QSIPrep*'s documentation]\
             name='ds_intramodal_to_acpc',
             run_without_submitting=True,
         )
+        workflow.connect([
+            (intramodal_template_wf, ds_intramodal_to_acpc, [
+                ('outputnode.intramodal_template_to_t1_affine', 'in_file'),
+            ]),
+        ])  # fmt:skip
+
+        # TemplateQC and the per-group orig->intramodal transform export exist only
+        # for linear templates: mvtc2 exposes no per-input aligned images, and its
+        # per-group transform is an [affine, warp] pair that does not fit a
+        # single-file .mat sink.
+        intramodal_linear = config.workflow.intramodal_template_transform in ('Rigid', 'Affine')
         if intramodal_linear:
             ds_template_qc = pe.Node(
                 DerivativesDataSink(
@@ -479,6 +508,12 @@ to workflows in *QSIPrep*'s documentation]\
                 name='ds_template_qc',
                 run_without_submitting=True,
             )
+            workflow.connect([
+                (intramodal_template_wf, ds_template_qc, [
+                    ('outputnode.template_qc_file', 'in_file'),
+                ]),
+            ])  # fmt:skip
+
             ds_template_agreement = pe.Node(
                 DerivativesDataSink(
                     source_file=anat_source_file,
@@ -494,43 +529,10 @@ to workflows in *QSIPrep*'s documentation]\
                 run_without_submitting=True,
             )
             workflow.connect([
-                (intramodal_template_wf, ds_template_qc, [
-                    ('outputnode.template_qc_file', 'in_file'),
-                ]),
                 (intramodal_template_wf, ds_template_agreement, [
                     ('outputnode.template_agreement_map', 'in_file'),
                 ]),
             ])  # fmt:skip
-
-        workflow.connect([
-            (intramodal_template_wf, ds_intramodal_to_acpc, [
-                ('outputnode.intramodal_template_to_t1_affine', 'in_file'),
-            ]),
-        ])  # fmt:skip
-
-        workflow.connect([
-            (intramodal_template_wf, ds_intramodal_template, [
-                # The ACPC-resampled template, NOT outputnode.intramodal_template:
-                # that one is in the template's own midpoint space, and tagging
-                # it space-ACPC would mislabel it.
-                ('outputnode.intramodal_template_acpc', 'in_file'),
-            ]),
-        ])  # fmt:skip
-
-    if make_intramodal_template:
-        workflow.connect([
-            (anat_preproc_wf, intramodal_template_wf, [
-                ('outputnode.t1_preproc', 'inputnode.t1_preproc'),
-                ('outputnode.t1_brain', 'inputnode.t1_brain'),
-                ('outputnode.t1_mask', 'inputnode.t1_mask'),
-                ('outputnode.t1_seg', 'inputnode.t1_seg'),
-                ('outputnode.t1_aseg', 'inputnode.t1_aseg'),
-                ('outputnode.t1_aparc', 'inputnode.t1_aparc'),
-                ('outputnode.t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform'),
-                ('outputnode.t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform'),
-                ('outputnode.dwi_sampling_grid', 'inputnode.dwi_sampling_grid'),
-            ]),
-        ])  # fmt:skip
 
     # create a processing pipeline for the dwis in each session
     for output_fname, dwi_info in outputs_to_files.items():
@@ -600,28 +602,6 @@ to workflows in *QSIPrep*'s documentation]\
         if make_intramodal_template:
             input_name = f'inputnode.{output_wfname}_b0_template'
             output_name = f'outputnode.{output_wfname}_transform'
-            if intramodal_linear:
-                # Per-group hop into the template space. Paired with
-                # from-intramodal_to-ACPC above, this closes the round trip:
-                # BIDS b=0 -> intramodal -> ACPC -> MNI, and back.
-                ds_orig_to_intramodal = pe.Node(
-                    DerivativesDataSink(
-                        source_file=source_file,
-                        base_directory=config.execution.output_dir,
-                        datatype='anat',
-                        mode='image',
-                        extension='.mat',
-                        **{'from': 'orig', 'to': 'intramodal'},
-                        suffix='xfm',
-                    ),
-                    name=f'ds_orig_to_intramodal_{output_wfname}',
-                    run_without_submitting=True,
-                )
-                workflow.connect([
-                    (intramodal_template_wf, ds_orig_to_intramodal, [
-                        (output_name, 'in_file'),
-                    ]),
-                ])  # fmt:skip
 
             workflow.connect([
                 (dwi_preproc_wf, intramodal_template_wf, [
@@ -644,6 +624,27 @@ to workflows in *QSIPrep*'s documentation]\
                     ),
                 ]),
             ])  # fmt:skip
+
+            if intramodal_linear:
+                # Per-group hop into the template space. Paired with
+                # from-intramodal_to-ACPC above, this closes the round trip:
+                # BIDS b=0 -> intramodal -> ACPC -> MNI, and back.
+                ds_orig_to_intramodal = pe.Node(
+                    DerivativesDataSink(
+                        source_file=source_file,
+                        base_directory=config.execution.output_dir,
+                        datatype='anat',
+                        mode='image',
+                        extension='.mat',
+                        **{'from': 'orig', 'to': 'intramodal'},
+                        suffix='xfm',
+                    ),
+                    name=f'ds_orig_to_intramodal_{output_wfname}',
+                    run_without_submitting=True,
+                )
+                workflow.connect([
+                    (intramodal_template_wf, ds_orig_to_intramodal, [(output_name, 'in_file')]),
+                ])  # fmt:skip
 
         if merging_distortion_groups:
             image_name = f'inputnode.{output_wfname}_image'

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -426,8 +426,8 @@ to workflows in *QSIPrep*'s documentation]\
         )
 
         intramodal_template_wf = init_intramodal_template_wf(
-            t1w_source_file=anat_source_file,
             inputs_list=sorted(outputs_to_files.keys()),
+            t1w_source_file=anat_source_file,
             transform=config.workflow.intramodal_template_transform,
             num_iterations=config.workflow.intramodal_template_iters or 2,
             name='intramodal_template_wf',

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -334,7 +334,7 @@ def init_b0_hmc_wf(
     prioritize_omp=False,
     use_masks=False,
     initialize_com=False,
-    num_iters=None,
+    num_iters=2,
     settings='shoreline',
 ) -> Workflow:
     """Align a set of images, optionally building an unbiased template from them.
@@ -347,9 +347,10 @@ def init_b0_hmc_wf(
     actually fires (1e-06 rather than 1e-08). Measured on 0.94 mm T1w against the
     merge template: 16x faster, reaching an identical metric value to five
     decimal places. See test_template_registration_settings.py.
+
+    TODO: Rename to init_unbiased_alignment_wf.
+    Used in three places: intramodal template, anatomical merge, dwi hmc.
     """
-    if num_iters is None:
-        num_iters = 2
     if align_to is None:
         align_to = config.workflow.b0_motion_corr_to
     if transform is None:
@@ -361,9 +362,10 @@ def init_b0_hmc_wf(
     if align_to == 'iterative' and num_iters < 2:
         raise ValueError('Must specify a positive number of iterations')
 
-    alignment_wf = Workflow(name=name)
+    workflow = Workflow(name=name)
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['b0_images', 'template_mask']), name='inputnode'
+        niu.IdentityInterface(fields=['b0_images', 'template_mask']),
+        name='inputnode',
     )
     outputnode = pe.Node(
         niu.IdentityInterface(
@@ -373,7 +375,7 @@ def init_b0_hmc_wf(
                 'iteration_templates',
                 'motion_params',
                 'aligned_images',
-            ]
+            ],
         ),
         name='outputnode',
     )
@@ -387,13 +389,14 @@ def init_b0_hmc_wf(
             f'of {config.workflow.hmc_model} registrations. '
         )
         initial_template = pe.Node(
-            ants.AverageImages(normalize=True, dimension=3), name='initial_template'
+            ants.AverageImages(normalize=True, dimension=3),
+            name='initial_template',
         )
-        alignment_wf.connect(inputnode, 'b0_images', initial_template, 'images')  # fmt:skip
+        workflow.connect([(inputnode, initial_template, [('b0_images', 'images')])])
+
         # Store the registration targets
         iter_templates = pe.Node(niu.Merge(num_iters), name='iteration_templates')
-        alignment_wf.connect(initial_template, 'output_average_image',
-                             iter_templates, 'in1')  # fmt:skip
+        workflow.connect([(initial_template, iter_templates, [('output_average_image', 'in1')])])
 
         initial_reg = linear_alignment_workflow(
             iternum=0,
@@ -402,13 +405,17 @@ def init_b0_hmc_wf(
             initialize_com=initialize_com,
             settings=settings,
         )
-        if use_masks:
-            alignment_wf.connect(inputnode, 'template_mask',
-                                 initial_reg, 'inputnode.template_mask')  # fmt:skip
-        alignment_wf.connect(initial_template, 'output_average_image',
-                             initial_reg, 'inputnode.template_image')  # fmt:skip
-        alignment_wf.connect(inputnode, 'b0_images', initial_reg,
-                             'inputnode.image_paths')  # fmt:skip
+        workflow.connect([
+            (inputnode, initial_reg, [
+                ('b0_images', 'inputnode.image_paths'),
+                # only used if use_masks
+                ('template_mask', 'inputnode.template_mask'),
+            ]),
+            (initial_template, initial_reg, [
+                ('output_average_image', 'inputnode.template_image'),
+            ]),
+        ])  # fmt:skip
+
         reg_iters = [initial_reg]
         for iternum in range(1, num_iters):
             reg_iters.append(
@@ -420,26 +427,31 @@ def init_b0_hmc_wf(
                     settings=settings,
                 )
             )
-            if use_masks:
-                alignment_wf.connect(inputnode, 'template_mask',
-                                     reg_iters[-1], 'inputnode.template_mask')  # fmt:skip
-            alignment_wf.connect(reg_iters[-2], 'outputnode.updated_template',
-                                 reg_iters[-1], 'inputnode.template_image')  # fmt:skip
-            alignment_wf.connect(inputnode, 'b0_images', reg_iters[-1],
-                                 'inputnode.image_paths')  # fmt:skip
-            alignment_wf.connect(reg_iters[-1], 'outputnode.updated_template',
-                                 iter_templates, 'in%d' % (iternum + 1))  # fmt:skip
+            workflow.connect([
+                (inputnode, reg_iters[-1], [
+                    ('b0_images', 'inputnode.image_paths'),
+                    # only used if use_masks
+                    ('template_mask', 'inputnode.template_mask'),
+                ]),
+                (reg_iters[-2], reg_iters[-1], [
+                    ('outputnode.updated_template', 'inputnode.template_image'),
+                ]),
+                (reg_iters[-1], iter_templates, [
+                    ('outputnode.updated_template', f'in{iternum + 1}'),
+                ]),
+            ])  # fmt:skip
 
         # Attach to outputs
         # The last iteration aligned to the output from the second-to-last
-        alignment_wf.connect(reg_iters[-2], 'outputnode.updated_template',
-                             outputnode, 'final_template')  # fmt:skip
-        alignment_wf.connect(reg_iters[-1], 'outputnode.affine_transforms',
-                             outputnode, 'forward_transforms')  # fmt:skip
-        alignment_wf.connect(reg_iters[-1], 'outputnode.registered_image_paths',
-                             outputnode, 'aligned_images')  # fmt:skip
-        alignment_wf.connect(iter_templates, 'out', outputnode,
-                             'iteration_templates')  # fmt:skip
+        workflow.connect([
+            (reg_iters[-2], outputnode, [('outputnode.updated_template', 'final_template')]),
+            (reg_iters[-1], outputnode, [
+                ('outputnode.affine_transforms', 'forward_transforms'),
+                ('outputnode.registered_image_paths', 'aligned_images'),
+            ]),
+            (iter_templates, outputnode, [('out', 'iteration_templates')]),
+        ])  # fmt:skip
+
     elif align_to == 'first':
         desc += (
             'Each b=0 image was registered to the first b=0 image using '
@@ -452,22 +464,24 @@ def init_b0_hmc_wf(
             initialize_com=initialize_com,
             settings=settings,
         )
-        if use_masks:
-            alignment_wf.connect(inputnode, 'template_mask',
-                                 reg_to_first, 'inputnode.template_mask')  # fmt:skip
-
-        alignment_wf.connect([
+        workflow.connect([
             (inputnode, reg_to_first, [
                 (('b0_images', first_image), 'inputnode.template_image'),
-                ('b0_images', 'inputnode.image_paths')]),
+                ('b0_images', 'inputnode.image_paths'),
+                # only used if use_masks
+                ('template_mask', 'inputnode.template_mask'),
+            ]),
             (reg_to_first, outputnode, [
                 ('averaged_images.output_average_image', 'final_template'),
                 ('outputnode.affine_transforms', 'forward_transforms'),
-                ('outputnode.registered_image_paths', 'aligned_images')])
+                ('outputnode.registered_image_paths', 'aligned_images'),
+            ]),
         ])  # fmt:skip
+
     if boilerplate:
-        alignment_wf.__desc__ = desc
-    return alignment_wf
+        workflow.__desc__ = desc
+
+    return workflow
 
 
 def first_image(image_list):

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -64,6 +64,11 @@ def init_intramodal_template_wf(
     """
     omp_nthreads = config.nipype.omp_nthreads
     workflow = Workflow(name=name)
+    workflow.__desc__ = (
+        'An unbiased DWI reference image was constructed from b=0 volumes across runs and '
+        'sessions, allowing each run to be registered to the same AC-PC space. '
+    )
+
     input_names = [name.replace('-', '_') + '_b0_template' for name in inputs_list]
     output_names = [name.replace('-', '_') + '_transform' for name in inputs_list]
 
@@ -127,6 +132,11 @@ def init_intramodal_template_wf(
     # Rigid be offered at all -- it is not in the mvtc2 enum.
     linear_only = transform in ('Rigid', 'Affine')
     if linear_only:
+        workflow.__desc__ += (
+            f'The unbiased b=0 template was constructed over {num_iterations} iterations '
+            f'of {transform} registrations.'
+        )
+
         # initialize_com because sessions can differ by centimetres of table
         # position, which the shoreline settings' two resolution levels and
         # absent initialization will not recover from.
@@ -166,6 +176,10 @@ def init_intramodal_template_wf(
 
         template_node, template_field = linear_template_wf, 'outputnode.final_template'
     else:
+        workflow.__desc__ += (
+            'The unbiased b=0 template was constructed using '
+            f'antsMultivariateTemplateConstruction2, using {transform} transforms.'
+        )
         runtime_opts = {'num_cores': 1, 'parallel_control': 0}
         if omp_nthreads > 1:
             runtime_opts = {'num_cores': omp_nthreads, 'parallel_control': 2}

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -64,9 +64,7 @@ def init_intramodal_template_wf(
     omp_nthreads = config.nipype.omp_nthreads
     workflow = Workflow(name=name)
     workflow.__desc__ = (
-        'An unbiased DWI reference image was constructed by coregistering all b=0 volumes across '
-        'runs and sessions to each other, allowing each run to be registered to the same AC-PC '
-        'reference image. '
+        'An unbiased template was constructed from the b=0 reference of each DWI run. '
     )
 
     input_names = [name.replace('-', '_') + '_b0_template' for name in inputs_list]
@@ -136,8 +134,8 @@ def init_intramodal_template_wf(
     linear_only = transform in ('Rigid', 'Affine')
     if linear_only:
         workflow.__desc__ += (
-            f'The unbiased b=0 template was constructed over {num_iterations} iterations '
-            f'of {transform} registrations.'
+            f'These were iteratively aligned to the evolving template over {num_iterations} '
+            f'iterations of {transform} registrations. '
         )
 
         # initialize_com because sessions can differ by centimetres of table
@@ -180,8 +178,8 @@ def init_intramodal_template_wf(
         template_node, template_field = linear_template_wf, 'outputnode.final_template'
     else:
         workflow.__desc__ += (
-            'The unbiased b=0 template was constructed using '
-            f'antsMultivariateTemplateConstruction2.sh, using {transform} transforms.'
+            'These were aligned to the template using antsMultivariateTemplateConstruction2.sh '
+            f'with {transform} transforms. '
         )
         runtime_opts = {'num_cores': 1, 'parallel_control': 0}
         if omp_nthreads > 1:
@@ -204,6 +202,11 @@ def init_intramodal_template_wf(
         ])  # fmt:skip
 
         template_node, template_field = ants_mvtc2, 'templates'
+
+    workflow.__desc__ += (
+        'This template was coregistered to the anatomical reference a single time, and every DWI '
+        'run inherited that shared template-to-anatomical transform. '
+    )
 
     # calculate dwi registration to T1w
     b0_coreg_wf = init_b0_to_anat_registration_wf(

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -85,15 +85,6 @@ def init_intramodal_template_wf(
         ),
         name='inputnode',
     )
-    merge_inputs = pe.Node(niu.Merge(len(input_names)), name='merge_inputs')
-    rename_inputs = pe.MapNode(
-        niu.Rename(keep_ext=True), iterfield=['in_file', 'format_string'], name='rename_inputs'
-    )
-    rename_inputs.inputs.format_string = input_names
-    rename_inputs.synchronize = True
-    for input_num, input_name in enumerate(input_names):
-        workflow.connect(inputnode, input_name, merge_inputs, 'in%d' % (input_num + 1))
-
     outputnode = pe.Node(
         niu.IdentityInterface(
             fields=output_names
@@ -109,6 +100,20 @@ def init_intramodal_template_wf(
         ),
         name='outputnode',
     )
+
+    merge_inputs = pe.Node(niu.Merge(len(input_names)), name='merge_inputs')
+    for input_num, input_name in enumerate(input_names):
+        workflow.connect(inputnode, input_name, merge_inputs, 'in%d' % (input_num + 1))
+
+    rename_inputs = pe.MapNode(
+        niu.Rename(keep_ext=True),
+        iterfield=['in_file', 'format_string'],
+        name='rename_inputs',
+    )
+    rename_inputs.inputs.format_string = input_names
+    rename_inputs.synchronize = True
+    workflow.connect([(merge_inputs, rename_inputs, [('out', 'in_file')])])
+
     split_outputs = pe.Node(
         niu.Split(splits=[1] * len(input_names), squeeze=True), name='split_outputs'
     )
@@ -119,11 +124,6 @@ def init_intramodal_template_wf(
     # linear-only templates are built with init_b0_hmc_wf instead. That also lets
     # Rigid be offered at all -- it is not in the mvtc2 enum.
     linear_only = transform in ('Rigid', 'Affine')
-
-    workflow.connect([
-        (merge_inputs, rename_inputs, [('out', 'in_file')]),
-    ])  # fmt:skip
-
     if linear_only:
         # initialize_com because sessions can differ by centimetres of table
         # position, which the shoreline settings' two resolution levels and
@@ -137,9 +137,6 @@ def init_intramodal_template_wf(
             settings='unbiased_template',
             name='intramodal_linear_template',
         )
-        # Per-input agreement with the template, linear-only: mvtc2 does not
-        # expose the per-input aligned images TemplateQC needs.
-        template_qc = pe.Node(TemplateQC(labels=list(inputs_list)), name='template_qc')
         workflow.connect([
             (rename_inputs, linear_template_wf, [('out_file', 'inputnode.b0_images')]),
             (linear_template_wf, split_outputs, [
@@ -148,6 +145,12 @@ def init_intramodal_template_wf(
             (linear_template_wf, outputnode, [
                 ('outputnode.final_template', 'intramodal_template'),
             ]),
+        ])  # fmt:skip
+
+        # Per-input agreement with the template, linear-only: mvtc2 does not
+        # expose the per-input aligned images TemplateQC needs.
+        template_qc = pe.Node(TemplateQC(labels=list(inputs_list)), name='template_qc')
+        workflow.connect([
             (linear_template_wf, template_qc, [
                 ('outputnode.final_template', 'template'),
                 ('outputnode.aligned_images', 'aligned_images'),
@@ -158,11 +161,13 @@ def init_intramodal_template_wf(
                 ('agreement_map', 'template_agreement_map'),
             ]),
         ])  # fmt:skip
+
         template_node, template_field = linear_template_wf, 'outputnode.final_template'
     else:
         runtime_opts = {'num_cores': 1, 'parallel_control': 0}
         if omp_nthreads > 1:
             runtime_opts = {'num_cores': omp_nthreads, 'parallel_control': 2}
+
         ants_mvtc2 = pe.Node(
             MultivariateTemplateConstruction2(
                 dimension=3,
@@ -178,6 +183,7 @@ def init_intramodal_template_wf(
             (ants_mvtc2, split_outputs, [('forward_transforms', 'inlist')]),
             (ants_mvtc2, outputnode, [('templates', 'intramodal_template')]),
         ])  # fmt:skip
+
         template_node, template_field = ants_mvtc2, 'templates'
 
     # calculate dwi registration to T1w
@@ -185,6 +191,19 @@ def init_intramodal_template_wf(
         write_report=True,
         transform_type=config.workflow.b0_to_anat_transform,
     )
+    workflow.connect([
+        (inputnode, b0_coreg_wf, [
+            ('t1_brain', 'inputnode.t1_brain'),
+            ('subjects_dir', 'inputnode.subjects_dir'),
+            ('t1_seg', 'inputnode.t1_seg'),
+            ('subject_id', 'inputnode.subject_id'),
+        ]),
+        (template_node, b0_coreg_wf, [(template_field, 'inputnode.ref_b0_brain')]),
+        (b0_coreg_wf, outputnode, [
+            ('outputnode.itk_b0_to_t1', 'intramodal_template_to_t1_affine'),
+        ]),
+    ])  # fmt:skip
+
     ds_report_imtcoreg = pe.Node(
         DerivativesDataSink(
             datatype='figures',
@@ -195,23 +214,7 @@ def init_intramodal_template_wf(
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
-
-    workflow.connect([
-        (inputnode, b0_coreg_wf, [
-            ('t1_brain', 'inputnode.t1_brain'),
-            ('subjects_dir', 'inputnode.subjects_dir'),
-            ('t1_seg', 'inputnode.t1_seg'),
-            ('subject_id', 'inputnode.subject_id'),
-        ]),
-        (b0_coreg_wf, ds_report_imtcoreg, [('outputnode.report', 'in_file')]),
-        (b0_coreg_wf, outputnode, [
-            ('outputnode.itk_b0_to_t1', 'intramodal_template_to_t1_affine'),
-        ]),
-    ])  # fmt:skip
-
-    workflow.connect(
-        template_node, template_field, b0_coreg_wf, 'inputnode.ref_b0_brain'
-    )  # fmt:skip
+    workflow.connect([(b0_coreg_wf, ds_report_imtcoreg, [('outputnode.report', 'in_file')])])
 
     # The template lives in its own midpoint space, not ACPC: anything written
     # out has to go through the coregistration b0_coreg_wf computes, or it would
@@ -224,10 +227,8 @@ def init_intramodal_template_wf(
         (inputnode, template_to_acpc, [('t1_brain', 'reference_image')]),
         (b0_coreg_wf, template_to_acpc, [('outputnode.itk_b0_to_t1', 'transforms')]),
         (template_to_acpc, outputnode, [('output_image', 'intramodal_template_acpc')]),
+        (template_node, template_to_acpc, [(template_field, 'input_image')]),
     ])  # fmt:skip
-    workflow.connect(
-        template_node, template_field, template_to_acpc, 'input_image'
-    )  # fmt:skip
 
     # White matter contours for the registration reportlet: invert the
     # template->anat affine to carry the anatomical segmentation into template
@@ -242,290 +243,16 @@ def init_intramodal_template_wf(
         ),
         name='seg_to_template',
     )
-    template_wm = pe.Node(ExtractWM(), name='template_wm')
     workflow.connect([
         (inputnode, seg_to_template, [('t1_seg', 'input_image')]),
         (b0_coreg_wf, seg_to_template, [('outputnode.itk_b0_to_t1', 'transforms')]),
+        (template_node, seg_to_template, ([template_field, 'reference_image'])),
+    ])  # fmt:skip
+
+    template_wm = pe.Node(ExtractWM(), name='template_wm')
+    workflow.connect([
         (seg_to_template, template_wm, [('output_image', 'in_seg')]),
         (template_wm, outputnode, [('out', 'intramodal_template_wm_seg')]),
-    ])  # fmt:skip
-    workflow.connect(
-        template_node, template_field, seg_to_template, 'reference_image'
-    )  # fmt:skip
-
-    return workflow
-
-
-def init_qsiprep_intramodal_template_wf(
-    inputs_list,
-    transform='Rigid',
-    num_iterations=2,
-    name='intramodal_template_wf',
-):
-    """Create an unbiased intramodal template for a subject.
-    This aligns the b=0 references
-    from all the scans of a subject. Can be rigid, affine or nonlinear (BSplineSyN).
-
-    Parameters
-    ----------
-    inputs_list: list of inputs
-        List if identifiers for the input b=0 images.
-    transform: 'Rigid', 'Affine', 'BSplineSyN'
-        Which transform to ultimately use. If 'BSplineSyN', first 2 iterations of Affine will
-        be run.
-    num_iterations: int
-        Default: 2.
-
-    Inputs
-    ------
-    [workflow_name]_image...
-        One input for each input image. There is no input called inputs_list
-    t1w_image
-
-    Outputs
-    -------
-    [workflow_name]_transform
-        transform files to the intramodal template
-
-    intramodal_template_to_t1w_transform
-        Transform from the b0
-
-    """
-    workflow = Workflow(name=name)
-    input_names = [name + '_b0_template' for name in inputs_list]
-    output_names = [name + '_transform' for name in inputs_list]
-
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=input_names + ['t1w_brain']), name='inputnode'
-    )
-    merge_inputs = pe.Node(niu.Merge(len(input_names)), name='merge_inputs')
-    for input_num, input_name in enumerate(input_names):
-        workflow.connect(inputnode, input_name, merge_inputs, 'in%d' % (input_num + 1))
-
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=output_names + ['intramodal_template', 'intramodal_template_to_t1w_transform']
-        ),
-        name='outputnode',
-    )
-    split_outputs = pe.Node(
-        niu.Split(splits=[1] * len(input_names), squeeze=True), name='split_outputs'
-    )
-    for output_num, output_name in enumerate(output_names):
-        workflow.connect(split_outputs, 'out%d' % (output_num + 1), outputnode, output_name)
-
-    # N4 correct
-    n4_correct = pe.MapNode(
-        ants.N4BiasFieldCorrection(
-            dimension=3,
-            copy_header=True,
-            n_iterations=[50, 50, 40, 30],
-            shrink_factor=2,
-            convergence_threshold=0.00000001,
-            bspline_fitting_distance=200,
-            bspline_order=3,
-        ),
-        name='n4_correct',
-        iterfield=['input_image'],
-    )
-
-    # Should we add nonlinear iterations?
-    do_nonlinear = transform not in ('Rigid', 'Affine')
-
-    # Align the b=0 images from all runs (Linear)
-    initial_transform = 'Affine' if do_nonlinear else transform
-    intramodal_b0_affine_template = init_b0_hmc_wf(
-        align_to='iterative',
-        num_iters=2,
-        transform=initial_transform,
-        spatial_bias_correct=True,
-        name='intramodal_b0_affine_template',
-    )
-
-    workflow.connect([
-        (merge_inputs, n4_correct, [('out', 'input_image')]),
-        (n4_correct, intramodal_b0_affine_template, [('output_image', 'inputnode.b0_images')]),
-    ])  # fmt:skip
-    if not do_nonlinear:
-        workflow.connect([
-            (intramodal_b0_affine_template, split_outputs, [
-                (('outputnode.forward_transforms', _list_squeeze), 'inlist'),
-            ]),
-        ])  # fmt:skip
-    else:
-        nonlinear_alignment_wf = init_nonlinear_alignment_wf(num_iters=num_iterations)
-        workflow.connect([
-            (n4_correct, nonlinear_alignment_wf, [('output_image', 'inputnode.images')]),
-            (intramodal_b0_affine_template, nonlinear_alignment_wf, [
-                ('outputnode.final_template', 'inputnode.initial_template'),
-            ]),
-            (nonlinear_alignment_wf, split_outputs, [('outputnode.forward_transforms', 'inlist')]),
-        ])  # fmt:skip
-
-    return workflow
-
-
-def nonlinear_alignment_iteration(iternum=0, gradient_step=0.2):
-    """
-    Takes a template image and a set of input images, does
-    a linear alignment to the template and updates it with the
-    inverse of the average affine transform to the new template
-
-    Returns a workflow
-
-    """
-    iteration_wf = Workflow(name='nl_iterative_alignment_%03d' % iternum)
-    input_node_fields = ['image_paths', 'template_image', 'iteration_num']
-    inputnode = pe.Node(niu.IdentityInterface(fields=input_node_fields), name='inputnode')
-    inputnode.inputs.iteration_num = iternum
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                'registered_image_paths',
-                'affine_transforms',
-                'warp_transforms',
-                'composite_transforms',
-                'updated_template',
-            ]
-        ),
-        name='outputnode',
-    )
-    ants_settings = str(load_data('intramodal_nonlinear.json'))
-    reg = ants.Registration(from_file=ants_settings)
-    iter_reg = pe.MapNode(reg, name='nlreg_%03d' % iternum, iterfield=['moving_image'])
-
-    # Average the images
-    averaged_images = pe.Node(
-        ants.AverageImages(normalize=True, dimension=3), name='averaged_images'
-    )
-
-    # Shape update to template:
-    # Average the affines so that the inverse can be applied to the template
-    affines_to_list = pe.Node(niu.Merge(1), name='affines_to_list')
-    warps_to_list = pe.Node(niu.Merge(1), name='warps_to_list')
-    avg_affines = pe.Node(
-        ants.AverageAffineTransform(dimension=3, output_affine_transform='AveragedAffines.mat'),
-        name='avg_affines',
-    )
-
-    # Average the warps:
-    average_warps = pe.Node(ants.AverageImages(dimension=3, normalize=False), name='average_warps')
-    # Scale by the gradient step
-    scale_warp = pe.Node(
-        ants.MultiplyImages(
-            dimension=3, second_input=gradient_step, output_product_image='scaled_warp.nii.gz'
-        ),
-        name='scale_warp',
-    )
-    # Align the warps to the template image
-    align_warp = pe.Node(
-        ants.ApplyTransforms(input_image_type=1, invert_transform_flags=[True]), name='align_warp'
-    )
-
-    # transform the template for the shape update
-    shape_update_template = pe.Node(
-        ants.ApplyTransforms(
-            interpolation='LanczosWindowedSinc',
-            invert_transform_flags=[True, False, False, False, False],
-        ),
-        name='shape_update_template',
-    )
-    shape_update_merge = pe.Node(niu.Merge(5), name='shape_update_merge')
-
-    # Run the images through antsRegistration
-    def get_first(input_pairs):
-        return [input_pair[0] for input_pair in input_pairs]
-
-    def get_second(input_pairs):
-        return [input_pair[1] for input_pair in input_pairs]
-
-    iteration_wf.connect([
-        (inputnode, iter_reg, [
-            ('image_paths', 'moving_image'),
-            ('template_image', 'fixed_image')]),
-        (iter_reg, affines_to_list, [(('forward_transforms', get_first), 'in1')]),
-        (affines_to_list, avg_affines, [('out', 'transforms')]),
-        (iter_reg, warps_to_list, [(('forward_transforms', get_second), 'in1')]),
-        (iter_reg, averaged_images, [('warped_image', 'images')]),
-
-        # Average the warps, scale them, and transform to be aligned with the template
-        (warps_to_list, average_warps, [('out', 'images')]),
-        (average_warps, scale_warp, [('output_average_image', 'first_input')]),
-        (scale_warp, align_warp, [
-            ('output_product_image', 'input_image')]),
-        (avg_affines, align_warp, [('affine_transform', 'transforms')]),
-        (inputnode, align_warp, [('template_image', 'reference_image')]),
-        (avg_affines, shape_update_merge, [('affine_transform', 'in1')]),
-        (align_warp, shape_update_merge, [
-            ('output_image', 'in2'), ('output_image', 'in3'),
-            ('output_image', 'in4'), ('output_image', 'in5')]),
-        (shape_update_merge, shape_update_template, [('out', 'transforms')]),
-        (averaged_images, shape_update_template, [
-            ('output_average_image', 'input_image'),
-            ('output_average_image', 'reference_image')]),
-        (shape_update_template, outputnode, [('output_image', 'updated_template')]),
-        (iter_reg, outputnode, [
-            ('forward_transforms', 'affine_transforms'),
-            ('warped_image', 'registered_image_paths')])
-    ])  # fmt:skip
-
-    return iteration_wf
-
-
-def init_nonlinear_alignment_wf(num_iters=2, name='nonlinear_alignment_wf'):
-    """Creates a workflow that does nonlinear template creation."""
-    workflow = Workflow(name=name)
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=['images', 'initial_template']), name='inputnode'
-    )
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                'final_template',
-                'forward_transforms',
-                'iteration_templates',
-                'motion_params',
-                'aligned_images',
-            ]
-        ),
-        name='outputnode',
-    )
-
-    # Save the iteration templates
-    iter_templates = pe.Node(niu.Merge(num_iters), name='iteration_templates')
-
-    initial_reg = nonlinear_alignment_iteration(iternum=0)
-
-    workflow.connect([
-        (inputnode, iter_templates, [('initial_template', 'in1')]),
-        (inputnode, initial_reg, [
-            ('initial_template', 'inputnode.template_image'),
-            ('images', 'inputnode.image_paths'),
-        ]),
-    ])  # fmt:skip
-
-    reg_iters = [initial_reg]
-    for iternum in range(1, num_iters):
-        reg_iters.append(nonlinear_alignment_iteration(iternum=iternum))
-        workflow.connect([
-            (reg_iters[-2], reg_iters[-1], [
-                ('outputnode.updated_template', 'inputnode.template_image'),
-            ]),
-            (inputnode, reg_iters[-1], [('images', 'inputnode.image_paths')]),
-            (reg_iters[-1], iter_templates, [
-                ('outputnode.updated_template', 'in%d' % (iternum + 1)),
-            ]),
-        ])  # fmt:skip
-
-    # Attach to outputs
-    # The last iteration aligned to the output from the second-to-last
-    workflow.connect([
-        (reg_iters[-2], outputnode, [('outputnode.updated_template', 'final_template')]),
-        (reg_iters[-1], outputnode, [
-            ('outputnode.affine_transforms', 'forward_transforms'),
-            ('outputnode.registered_image_paths', 'aligned_images'),
-        ]),
-        (iter_templates, outputnode, [('out', 'iteration_templates')]),
     ])  # fmt:skip
 
     return workflow

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -20,6 +20,7 @@ from ...interfaces.images import ExtractWM
 from ...interfaces.template_qc import TemplateQC
 from .hmc import init_b0_hmc_wf
 from .registration import init_b0_to_anat_registration_wf
+from .util import _list_squeeze
 
 DEFAULT_MEMORY_MIN_GB = 0.01
 
@@ -256,7 +257,3 @@ def init_intramodal_template_wf(
     ])  # fmt:skip
 
     return workflow
-
-
-def _list_squeeze(in_list):
-    return [item[0] for item in in_list]

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -130,7 +130,8 @@ def init_intramodal_template_wf(
     # antsMultivariateTemplateConstruction2 only offers BSplineSyN/SyN/Affine, so
     # linear-only templates are built with init_b0_hmc_wf instead. That also lets
     # Rigid be offered at all -- it is not in the mvtc2 enum.
-    # aMTC2's Affine option doesn't work well, so we use init_b0_hmc_wf for that instead.
+    # aMTC2's Affine option produces equivalent results to init_b0_hmc_wf, but is slower,
+    # so we just use init_b0_hmc_wf for Affine.
     linear_only = transform in ('Rigid', 'Affine')
     if linear_only:
         workflow.__desc__ += (

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -30,7 +30,6 @@ def init_intramodal_template_wf(
     t1w_source_file,
     transform='BSplineSyN',
     num_iterations=2,
-    mem_gb=3,
     name='intramodal_template_wf',
 ):
     """Create an unbiased intramodal template for a subject. This aligns the b=0 references

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -64,8 +64,9 @@ def init_intramodal_template_wf(
     omp_nthreads = config.nipype.omp_nthreads
     workflow = Workflow(name=name)
     workflow.__desc__ = (
-        'An unbiased DWI reference image was constructed from b=0 volumes across runs and '
-        'sessions, allowing each run to be registered to the same AC-PC space. '
+        'An unbiased DWI reference image was constructed by coregistering all b=0 volumes across '
+        'runs and sessions to each other, allowing each run to be registered to the same AC-PC '
+        'reference image. '
     )
 
     input_names = [name.replace('-', '_') + '_b0_template' for name in inputs_list]
@@ -180,7 +181,7 @@ def init_intramodal_template_wf(
     else:
         workflow.__desc__ += (
             'The unbiased b=0 template was constructed using '
-            f'antsMultivariateTemplateConstruction2, using {transform} transforms.'
+            f'antsMultivariateTemplateConstruction2.sh, using {transform} transforms.'
         )
         runtime_opts = {'num_cores': 1, 'parallel_control': 0}
         if omp_nthreads > 1:

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -109,7 +109,7 @@ def init_intramodal_template_wf(
 
     merge_inputs = pe.Node(niu.Merge(len(input_names)), name='merge_inputs')
     for input_num, input_name in enumerate(input_names):
-        workflow.connect(inputnode, input_name, merge_inputs, 'in%d' % (input_num + 1))
+        workflow.connect([(inputnode, merge_inputs, [(input_name, f'in{input_num + 1}')])])
 
     rename_inputs = pe.MapNode(
         niu.Rename(keep_ext=True),
@@ -121,10 +121,11 @@ def init_intramodal_template_wf(
     workflow.connect([(merge_inputs, rename_inputs, [('out', 'in_file')])])
 
     split_outputs = pe.Node(
-        niu.Split(splits=[1] * len(input_names), squeeze=True), name='split_outputs'
+        niu.Split(splits=[1] * len(input_names), squeeze=True),
+        name='split_outputs',
     )
     for output_num, output_name in enumerate(output_names):
-        workflow.connect(split_outputs, 'out%d' % (output_num + 1), outputnode, output_name)
+        workflow.connect([(split_outputs, outputnode, [(f'out{output_num + 1}', output_name)])])
 
     # antsMultivariateTemplateConstruction2 only offers BSplineSyN/SyN/Affine, so
     # linear-only templates are built with init_b0_hmc_wf instead. That also lets

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -39,6 +39,8 @@ def init_intramodal_template_wf(
     ----------
     inputs_list: list of inputs
         List if identifiers for the input b=0 images.
+    t1w_source_file : str
+        Generalized anatomical image path that accounts for entities in all inputs.
     transform: 'Rigid', 'Affine', 'BSplineSyN'
         Which transform to ultimately use. If 'BSplineSyN', first 2 iterations of Affine will
         be run.

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -13,7 +13,6 @@ from nipype.interfaces import utility as niu
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from ... import config
-from ...data import load as load_data
 from ...interfaces import DerivativesDataSink
 from ...interfaces.ants import MultivariateTemplateConstruction2
 from ...interfaces.images import ExtractWM

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -130,6 +130,7 @@ def init_intramodal_template_wf(
     # antsMultivariateTemplateConstruction2 only offers BSplineSyN/SyN/Affine, so
     # linear-only templates are built with init_b0_hmc_wf instead. That also lets
     # Rigid be offered at all -- it is not in the mvtc2 enum.
+    # aMTC2's Affine option doesn't work well, so we use init_b0_hmc_wf for that instead.
     linear_only = transform in ('Rigid', 'Affine')
     if linear_only:
         workflow.__desc__ += (
@@ -262,7 +263,7 @@ def init_intramodal_template_wf(
     workflow.connect([
         (inputnode, seg_to_template, [('t1_seg', 'input_image')]),
         (b0_coreg_wf, seg_to_template, [('outputnode.itk_b0_to_t1', 'transforms')]),
-        (template_node, seg_to_template, ([template_field, 'reference_image'])),
+        (template_node, seg_to_template, [(template_field, 'reference_image')]),
     ])  # fmt:skip
 
     template_wm = pe.Node(ExtractWM(), name='template_wm')


### PR DESCRIPTION
Closes #822.

## Changes proposed in this pull request

- Remove the unused functions `init_qsiprep_intramodal_template_wf`, `nonlinear_alignment_iteration`, `init_nonlinear_alignment_wf`, and `_list_squeeze` from `qsiprep.workflows.dwi.intramodal_template`. We always add them back if we want.
- Remove unused mem_gb arg from `init_intramodal_template_wf`.
- Reorganize intramodal template workflow and relevant portions of `init_single_subject_wf`.
    - I'd like to move the DataSinks into `init_intramodal_template_wf` at some point as well, but decided to hold off to keep this fairly small.
- Add boilerplate for intramodal template workflow.
    - I'd appreciate feedback on this.