### PR TITLE
Use template shape and resolution in anatomical reportlet

### DIFF
--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -271,6 +271,116 @@ CONFORMATION_TEMPLATE = """\t\t<h3 class="elem-title">Anatomical Conformation</h
 DISCARD_TEMPLATE = """\t\t\t\t<li><abbr title="{path}">{basename}</abbr></li>"""
 
 
+class _TemplateDimensionsInputSpec(BaseInterfaceInputSpec):
+    anat_type = traits.Enum('T1w', 'T2w', usedefault=True, desc='Anatomical image type')
+    anat_list = InputMultiObject(
+        File(exists=True), xor=['t1w_list'], desc='input anatomical images'
+    )
+    t1w_list = InputMultiObject(
+        File(exists=True),
+        xor=['anat_list'],
+        deprecated='1.14.0',
+        new_name='anat_list',
+    )
+    max_scale = traits.Float(
+        3.0, usedefault=True, desc='Maximum scaling factor in images to accept'
+    )
+
+
+class _TemplateDimensionsOutputSpec(TraitedSpec):
+    t1w_valid_list = OutputMultiObject(exists=True, desc='valid T1w images')
+    anat_valid_list = OutputMultiObject(exists=True, desc='valid anatomical images')
+    target_zooms = traits.Tuple(
+        traits.Float, traits.Float, traits.Float, desc='Target zoom information'
+    )
+    target_shape = traits.Tuple(
+        traits.Int, traits.Int, traits.Int, desc='Target shape information'
+    )
+    out_report = File(exists=True, desc='conformation report')
+
+
+class TemplateDimensions(SimpleInterface):
+    """
+    Finds template target dimensions for a series of anatomical images, filtering low-resolution
+    images, if necessary.
+
+    Along each axis, the minimum voxel size (zoom) and the maximum number of voxels (shape) are
+    found across images.
+
+    The ``max_scale`` parameter sets a bound on the degree of up-sampling performed.
+    By default, an image with a voxel size greater than 3x the smallest voxel size
+    (calculated separately for each dimension) will be discarded.
+
+    To select images that require no scaling (i.e. all have smallest voxel sizes),
+    set ``max_scale=1``.
+
+    NOTE: This is copied from niworkflows, but with changes to reflect QSIPrep-specific processing
+    such as LPS orientation instead of RAS.
+    """
+
+    input_spec = _TemplateDimensionsInputSpec
+    output_spec = _TemplateDimensionsOutputSpec
+
+    def _generate_segment(self, discards, dims, zooms):
+        items = [
+            DISCARD_TEMPLATE.format(path=path, basename=os.path.basename(path))
+            for path in discards
+        ]
+        discard_list = '\n'.join(['\t\t\t<ul>'] + items + ['\t\t\t</ul>']) if items else ''
+        zoom_fmt = '{:.02g}mm x {:.02g}mm x {:.02g}mm'.format(*zooms)
+        return CONFORMATION_TEMPLATE.format(
+            anat=self.inputs.anat_type,
+            n_anat=len(self.inputs.anat_list),
+            dims='x'.join(map(str, dims)),
+            zooms=zoom_fmt,
+            n_discards=len(discards),
+            discard_list=discard_list,
+        )
+
+    def _run_interface(self, runtime):
+        # Load images, orient as RAS, collect shape and zoom data
+        if not self.inputs.anat_list:  # Deprecate: 1.14.0
+            self.inputs.anat_list = self.inputs.t1w_list
+
+        in_names = np.array(self.inputs.anat_list)
+        orig_imgs = np.vectorize(nb.load)(in_names)
+        reoriented = np.vectorize(nb.as_closest_canonical)(orig_imgs)
+        all_zooms = np.array([img.header.get_zooms()[:3] for img in reoriented])
+        all_shapes = np.array([img.shape[:3] for img in reoriented])
+
+        # Identify images that would require excessive up-sampling
+        valid = np.ones(all_zooms.shape[0], dtype=bool)
+        while valid.any():
+            target_zooms = all_zooms[valid].min(axis=0)
+            scales = all_zooms[valid] / target_zooms
+            if np.all(scales < self.inputs.max_scale):
+                break
+            valid[valid] ^= np.any(scales == scales.max(), axis=1)
+
+        # Ignore dropped images
+        valid_fnames = np.atleast_1d(in_names[valid]).tolist()
+        self._results['anat_valid_list'] = valid_fnames
+        self._results['t1w_valid_list'] = valid_fnames  # Deprecate: 1.14.0
+
+        # Set target shape information
+        target_zooms = all_zooms[valid].min(axis=0)
+        target_shape = all_shapes[valid].max(axis=0)
+
+        self._results['target_zooms'] = tuple(target_zooms.tolist())
+        self._results['target_shape'] = tuple(target_shape.tolist())
+
+        # Create report
+        dropped_images = in_names[~valid]
+        segment = self._generate_segment(dropped_images, target_shape, target_zooms)
+        out_report = os.path.join(runtime.cwd, 'report.html')
+        with open(out_report, 'w') as fobj:
+            fobj.write(segment)
+
+        self._results['out_report'] = out_report
+
+        return runtime
+
+
 class ConformInputSpec(BaseInterfaceInputSpec):
     in_file = File(mandatory=True, desc='Input image')
     target_zooms = traits.Tuple(

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -298,7 +298,7 @@ class AnatomicalReportlet(SimpleInterface):
         ref_img = nb.load(self.inputs.reference_image)
         zooms = ref_img.header.get_zooms()
         dims = ref_img.shape
-        discards = sorted(list(set(self.inputs.anat_list) - set(self.inputs.valid_list)))
+        discards = sorted(set(self.inputs.anat_list) - set(self.inputs.valid_list))
         items = [
             DISCARD_TEMPLATE.format(path=path, basename=os.path.basename(path))
             for path in discards

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -259,7 +259,7 @@ class IntraModalMerge(SimpleInterface):
 
 CONFORMATION_TEMPLATE = """\t\t<h3 class="elem-title">Anatomical Conformation</h3>
 \t\t<ul class="elem-desc">
-\t\t\t<li>Input T1w images: {n_t1w}</li>
+\t\t\t<li>Input {anat} images: {n_anat}</li>
 \t\t\t<li>Output orientation: LPS</li>
 \t\t\t<li>Output dimensions: {dims}</li>
 \t\t\t<li>Output voxel size: {zooms}</li>
@@ -271,64 +271,41 @@ CONFORMATION_TEMPLATE = """\t\t<h3 class="elem-title">Anatomical Conformation</h
 DISCARD_TEMPLATE = """\t\t\t\t<li><abbr title="{path}">{basename}</abbr></li>"""
 
 
-class _TemplateDimensionsInputSpec(BaseInterfaceInputSpec):
+class _AnatomicalReportletInputSpec(BaseInterfaceInputSpec):
     anat_type = traits.Enum('T1w', 'T2w', usedefault=True, desc='Anatomical image type')
     anat_list = InputMultiObject(
-        File(exists=True), xor=['t1w_list'], desc='input anatomical images'
-    )
-    t1w_list = InputMultiObject(
         File(exists=True),
-        xor=['anat_list'],
-        deprecated='1.14.0',
-        new_name='anat_list',
+        desc='input anatomical images',
     )
-    max_scale = traits.Float(
-        3.0, usedefault=True, desc='Maximum scaling factor in images to accept'
+    valid_list = InputMultiObject(
+        File(exists=True),
+        desc='Valid input anatomical images',
     )
+    reference_image = File(mandatory=True, desc='Reference image (LPS-oriented template)')
 
 
-class _TemplateDimensionsOutputSpec(TraitedSpec):
-    t1w_valid_list = OutputMultiObject(exists=True, desc='valid T1w images')
-    anat_valid_list = OutputMultiObject(exists=True, desc='valid anatomical images')
-    target_zooms = traits.Tuple(
-        traits.Float, traits.Float, traits.Float, desc='Target zoom information'
-    )
-    target_shape = traits.Tuple(
-        traits.Int, traits.Int, traits.Int, desc='Target shape information'
-    )
-    out_report = File(exists=True, desc='conformation report')
+class _AnatomicalReportletOutputSpec(TraitedSpec):
+    out_report = File(exists=True, desc='Anatomical image report')
 
 
-class TemplateDimensions(SimpleInterface):
-    """
-    Finds template target dimensions for a series of anatomical images, filtering low-resolution
-    images, if necessary.
+class AnatomicalReportlet(SimpleInterface):
+    """Summarize anatomical outputs."""
 
-    Along each axis, the minimum voxel size (zoom) and the maximum number of voxels (shape) are
-    found across images.
+    input_spec = _AnatomicalReportletInputSpec
+    output_spec = _AnatomicalReportletOutputSpec
 
-    The ``max_scale`` parameter sets a bound on the degree of up-sampling performed.
-    By default, an image with a voxel size greater than 3x the smallest voxel size
-    (calculated separately for each dimension) will be discarded.
-
-    To select images that require no scaling (i.e. all have smallest voxel sizes),
-    set ``max_scale=1``.
-
-    NOTE: This is copied from niworkflows, but with changes to reflect QSIPrep-specific processing
-    such as LPS orientation instead of RAS.
-    """
-
-    input_spec = _TemplateDimensionsInputSpec
-    output_spec = _TemplateDimensionsOutputSpec
-
-    def _generate_segment(self, discards, dims, zooms):
+    def _run_interface(self, runtime):
+        ref_img = nb.load(self.inputs.reference_image)
+        zooms = ref_img.header.get_zooms()
+        dims = ref_img.shape
+        discards = sorted(list(set(self.inputs.anat_list) - set(self.inputs.valid_list)))
         items = [
             DISCARD_TEMPLATE.format(path=path, basename=os.path.basename(path))
             for path in discards
         ]
         discard_list = '\n'.join(['\t\t\t<ul>'] + items + ['\t\t\t</ul>']) if items else ''
         zoom_fmt = '{:.02g}mm x {:.02g}mm x {:.02g}mm'.format(*zooms)
-        return CONFORMATION_TEMPLATE.format(
+        segment = CONFORMATION_TEMPLATE.format(
             anat=self.inputs.anat_type,
             n_anat=len(self.inputs.anat_list),
             dims='x'.join(map(str, dims)),
@@ -336,42 +313,6 @@ class TemplateDimensions(SimpleInterface):
             n_discards=len(discards),
             discard_list=discard_list,
         )
-
-    def _run_interface(self, runtime):
-        # Load images, orient as RAS, collect shape and zoom data
-        if not self.inputs.anat_list:  # Deprecate: 1.14.0
-            self.inputs.anat_list = self.inputs.t1w_list
-
-        in_names = np.array(self.inputs.anat_list)
-        orig_imgs = np.vectorize(nb.load)(in_names)
-        reoriented = np.vectorize(nb.as_closest_canonical)(orig_imgs)
-        all_zooms = np.array([img.header.get_zooms()[:3] for img in reoriented])
-        all_shapes = np.array([img.shape[:3] for img in reoriented])
-
-        # Identify images that would require excessive up-sampling
-        valid = np.ones(all_zooms.shape[0], dtype=bool)
-        while valid.any():
-            target_zooms = all_zooms[valid].min(axis=0)
-            scales = all_zooms[valid] / target_zooms
-            if np.all(scales < self.inputs.max_scale):
-                break
-            valid[valid] ^= np.any(scales == scales.max(), axis=1)
-
-        # Ignore dropped images
-        valid_fnames = np.atleast_1d(in_names[valid]).tolist()
-        self._results['anat_valid_list'] = valid_fnames
-        self._results['t1w_valid_list'] = valid_fnames  # Deprecate: 1.14.0
-
-        # Set target shape information
-        target_zooms = all_zooms[valid].min(axis=0)
-        target_shape = all_shapes[valid].max(axis=0)
-
-        self._results['target_zooms'] = tuple(target_zooms.tolist())
-        self._results['target_shape'] = tuple(target_shape.tolist())
-
-        # Create report
-        dropped_images = in_names[~valid]
-        segment = self._generate_segment(dropped_images, target_shape, target_zooms)
         out_report = os.path.join(runtime.cwd, 'report.html')
         with open(out_report, 'w') as fobj:
             fobj.write(segment)

--- a/qsiprep/workflows/anatomical/volume.py
+++ b/qsiprep/workflows/anatomical/volume.py
@@ -38,6 +38,7 @@ from nipype.interfaces.ants import BrainExtraction, N4BiasFieldCorrection
 from nipype.interfaces.base import traits
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.images import TemplateDimensions
 from niworkflows.interfaces.reportlets.masks import ROIsPlot
 
 from ... import config
@@ -53,7 +54,7 @@ from ...interfaces.freesurfer import (
     SynthSeg,
 )
 from ...interfaces.itk import AffineToRigid, DisassembleTransform
-from ...interfaces.images import TemplateDimensions
+from ...interfaces.images import AnatomicalReportlet
 from ...interfaces.niworkflows import RobustMNINormalizationRPT
 from ...utils.gpu import gpu_enabled
 from ...utils.misc import fix_multi_source_name
@@ -458,8 +459,12 @@ FreeSurfer version {FS_VERSION}. """
               config.workflow.subject_anatomical_reference == 'sessionwise',
               anat_modality),
              'inputnode.source_file')]),
+            (anat_modality.lower(), 'inputnode.anat_list'),
         (anat_reference_wf, anat_reports_wf, [
-            ('outputnode.out_report', 'inputnode.t1_conform_report'),
+            ('outputnode.valid_list', 'inputnode.valid_list'),
+        ]),
+        (reorient_tpl_brain_to_lps, anat_reports_wf, [
+            ('out_file', 'inputnode.reference_image'),
         ]),
         (seg_rpt, anat_reports_wf, [('out_report', 'inputnode.seg_report')]),
         (anat_normalization_wf, anat_reports_wf, [
@@ -729,23 +734,25 @@ A {contrast}-reference map was computed after registration of
 
     omp_nthreads = config.nipype.omp_nthreads
 
-    # 0. Reorient anatomical image(s) to LPS and resample to common voxel space
+    # 0. Prepare anatomical image(s)
+    # Determine which anatomical images are close enough in resolution to be merged
     template_dimensions = pe.Node(TemplateDimensions(), name='template_dimensions')
+
+    # Conform to LPS and resample to common voxel space
     anat_conform = pe.MapNode(
-        Conform(deoblique_header=True), iterfield='in_file', name='anat_conform'
+        Conform(deoblique_header=True),
+        iterfield='in_file',
+        name='anat_conform',
     )
 
     workflow.connect([
-        (inputnode, template_dimensions, [('images', 't1w_list')]),
+        (inputnode, template_dimensions, [('images', 'anat_list')]),
         (template_dimensions, anat_conform, [
-            ('t1w_valid_list', 'in_file'),
+            ('anat_valid_list', 'in_file'),
             ('target_zooms', 'target_zooms'),
             ('target_shape', 'target_shape'),
         ]),
-        (template_dimensions, outputnode, [
-            ('out_report', 'out_report'),
-            ('t1w_valid_list', 'valid_list'),
-        ]),
+        (template_dimensions, outputnode, [('anat_valid_list', 'valid_list')]),
     ])  # fmt:skip
 
     # N4 fits its field by least squares in the log domain, where near-zero
@@ -1280,6 +1287,8 @@ def init_anat_reports_wf(anatomical_template) -> Workflow:
     """
     Set up a battery of datasinks to store reports in the right location
     """
+    anat_modality = config.workflow.anat_modality
+
     workflow = Workflow(name='anat_reports_wf')
 
     inputnode = pe.Node(
@@ -1290,21 +1299,40 @@ def init_anat_reports_wf(anatomical_template) -> Workflow:
                 'seg_report',
                 't1_2_mni_report',
                 'recon_report',
+                'anat_list',
+                'valid_list',
+                'reference_image',
             ]
         ),
         name='inputnode',
     )
 
-    ds_report_t1_conform = pe.Node(
+    anat_reportlet = pe.Node(
+        AnatomicalReportlet(anat_type=anat_modality),
+        name='anat_reportlet',
+    )
+    workflow.connect([
+        (inputnode, anat_reportlet, [
+            ('anat_list', 'anat_list'),
+            ('valid_list', 'valid_list'),
+            ('reference_image', 'reference_image'),
+        ]),
+    ])  # fmt:skip
+
+    ds_report_anat_conform = pe.Node(
         DerivativesDataSink(
             base_directory=config.execution.output_dir,
             datatype='figures',
             desc='conform',
             suffix=config.workflow.anat_modality,
         ),
-        name='ds_report_t1_conform',
+        name='ds_report_anat_conform',
         run_without_submitting=True,
     )
+    workflow.connect([
+        (inputnode, ds_report_anat_conform, [('source_file', 'source_file')]),
+        (anat_reportlet, ds_report_anat_conform, [('out_report', 'in_file')]),
+    ])  # fmt:skip
 
     template_entities = _template_to_report_entities(anatomical_template)
     ds_report_t1_2_mni = pe.Node(
@@ -1329,10 +1357,6 @@ def init_anat_reports_wf(anatomical_template) -> Workflow:
     )
 
     workflow.connect([
-        (inputnode, ds_report_t1_conform, [
-            ('source_file', 'source_file'),
-            ('t1_conform_report', 'in_file'),
-        ]),
         (inputnode, ds_report_t1_seg_mask, [
             ('source_file', 'source_file'),
             ('seg_report', 'in_file'),

--- a/qsiprep/workflows/anatomical/volume.py
+++ b/qsiprep/workflows/anatomical/volume.py
@@ -38,7 +38,6 @@ from nipype.interfaces.ants import BrainExtraction, N4BiasFieldCorrection
 from nipype.interfaces.base import traits
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-from niworkflows.interfaces.images import TemplateDimensions
 from niworkflows.interfaces.reportlets.masks import ROIsPlot
 
 from ... import config
@@ -54,6 +53,7 @@ from ...interfaces.freesurfer import (
     SynthSeg,
 )
 from ...interfaces.itk import AffineToRigid, DisassembleTransform
+from ...interfaces.images import TemplateDimensions
 from ...interfaces.niworkflows import RobustMNINormalizationRPT
 from ...utils.gpu import gpu_enabled
 from ...utils.misc import fix_multi_source_name
@@ -78,8 +78,7 @@ def init_anat_preproc_wf(
     t2w_do_biascorr=True,
     name='anat_preproc_wf',
 ):
-    r"""
-    This workflow controls the anatomical preprocessing stages of qsiprep.
+    r"""This workflow controls the anatomical preprocessing stages of qsiprep.
 
     This includes:
 
@@ -93,22 +92,28 @@ def init_anat_preproc_wf(
         :simple_form: yes
 
         from qsiprep.workflows.anatomical import init_anat_preproc_wf
-        wf = init_anat_preproc_wf(num_anat_images=1,
-                                  num_additional_t2ws=0,
-                                  has_rois=False)
+
+        wf = init_anat_preproc_wf(
+            num_anat_images=1,
+            num_additional_t2ws=0,
+            has_rois=False,
+        )
 
     Parameters
     ----------
     num_anat_images : :obj:`int`
         Number of anatomical images available in the chosen modality
-
     num_additional_t2ws : :obj:`int`
         If anat modality is T1w and there are available T2ws that can be
         used by DRBUDDI, how many are there?
-
     has_rois: :obj:`bool`
         Are there lesion ROI files?
-
+    anatomical_template : :obj:`str`
+        Template specification of the form <template>[+<cohort>].
+    do_biascorr : :obj:`bool`, optional
+        Whether to apply N4 bias correction to the T1w(?) or not. Default is True.
+    t2w_do_biascorr : :obj:`bool`, optional
+        Whether to apply N4 bias correction to the T2w or not. Default is True.
 
     Inputs
     ------
@@ -120,7 +125,6 @@ def init_anat_preproc_wf(
         A mask to exclude regions during standardization (as list)
     subjects_dir
         FreeSurfer SUBJECTS_DIR
-
 
     Outputs
     -------
@@ -145,8 +149,9 @@ def init_anat_preproc_wf(
         ANTs-compatible affine-and-warp transform file (inverse)
     t1_resampling_grid
         Image of the preprocessed t1 to be used as the reference output for dwis
-
     """
+    anat_modality = config.workflow.anat_modality
+    dwi_only = anat_modality == 'none'
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
@@ -179,13 +184,11 @@ def init_anat_preproc_wf(
         name='outputnode',
     )
 
-    dwi_only = config.workflow.anat_modality == 'none'
-
     # XXX: This is a temporary solution until QSIPrep supports flexible output spaces.
     get_template = pe.Node(
         GetTemplate(
             template_spec=anatomical_template,
-            anatomical_contrast=config.workflow.anat_modality,
+            anatomical_contrast=anat_modality,
         ),
         name='get_template_image',
     )
@@ -193,13 +196,13 @@ def init_anat_preproc_wf(
         afni.Calc(expr='a*b', outputtype='NIFTI_GZ'),
         name='mask_template',
     )
-    reorient_brain_to_lps = pe.Node(
+    reorient_tpl_brain_to_lps = pe.Node(
         afni.Resample(orientation='RAI', outputtype='NIFTI_GZ'),
-        name='reorient_brain_to_lps',
+        name='reorient_tpl_brain_to_lps',
     )
-    reorient_mask_to_lps = pe.Node(
+    reorient_tpl_mask_to_lps = pe.Node(
         afni.Resample(orientation='RAI', outputtype='NIFTI_GZ'),
-        name='reorient_mask_to_lps',
+        name='reorient_tpl_mask_to_lps',
     )
 
     # Create the output reference grid_image
@@ -209,9 +212,9 @@ def init_anat_preproc_wf(
             ('template_file', 'in_file_a'),
             ('mask_file', 'in_file_b'),
         ]),
-        (get_template, reorient_mask_to_lps, [('mask_file', 'in_file')]),
-        (mask_template, reorient_brain_to_lps, [('out_file', 'in_file')]),
-        (reorient_brain_to_lps, reference_grid_wf, [('out_file', 'inputnode.template_image')]),
+        (get_template, reorient_tpl_mask_to_lps, [('mask_file', 'in_file')]),
+        (mask_template, reorient_tpl_brain_to_lps, [('out_file', 'in_file')]),
+        (reorient_tpl_brain_to_lps, reference_grid_wf, [('out_file', 'inputnode.template_image')]),
         (reference_grid_wf, outputnode, [('outputnode.grid_image', 'dwi_sampling_grid')]),
     ])  # fmt:skip
 
@@ -220,26 +223,26 @@ def init_anat_preproc_wf(
             'No anatomical scans will be processed! Visual reports will show template masks.'
         )
         workflow.connect([
-            (reorient_brain_to_lps, outputnode, [('out_file', 't1_brain')]),
-            (reorient_mask_to_lps, outputnode, [
+            (reorient_tpl_brain_to_lps, outputnode, [('out_file', 't1_brain')]),
+            (reorient_tpl_mask_to_lps, outputnode, [
                 ('out_file', 't1_mask'),
                 ('out_file', 't1_seg'),
             ]),
         ])  # fmt:skip
 
-        reorient_template_to_lps = pe.Node(
+        reorient_tpl_to_lps = pe.Node(
             afni.Resample(orientation='RAI', outputtype='NIFTI_GZ'),
-            name='reorient_template_to_lps',
+            name='reorient_tpl_to_lps',
         )
         workflow.connect([
-            (get_template, reorient_template_to_lps, [('template_file', 'in_file')]),
-            (reorient_template_to_lps, outputnode, [('out_file', 't1_preproc')]),
+            (get_template, reorient_tpl_to_lps, [('template_file', 'in_file')]),
+            (reorient_tpl_to_lps, outputnode, [('out_file', 't1_preproc')]),
         ])  # fmt:skip
 
         workflow.add_nodes([inputnode])
         return workflow
 
-    contrast = config.workflow.anat_modality[:-1]
+    contrast = anat_modality[:-1]
     desc = """
 
 #### Anatomical data preprocessing
@@ -249,16 +252,18 @@ def init_anat_preproc_wf(
         f"""\
 A total of {num_anat_images} {contrast}-weighted ({contrast}w) images were found within the input
 BIDS dataset.
-All of them were corrected for intensity non-uniformity (INU)
-using `N4BiasFieldCorrection` [@n4, ANTs {ANTS_VERSION}].
 """
         if num_anat_images > 1
         else f"""\
-The {contrast}-weighted ({contrast}w) image was corrected for intensity non-uniformity (INU)
-using `N4BiasFieldCorrection` [@n4, ANTs {ANTS_VERSION}],
-and used as an anatomical reference throughout the workflow.
+The {contrast}-weighted ({contrast}w) image was used as an anatomical reference throughout the
+workflow.
 """
     )
+    if do_biascorr:
+        desc += (
+            'Each image was corrected for intensity non-uniformity (INU) using '
+            f'`N4BiasFieldCorrection` [@n4, ANTs {ANTS_VERSION}].'
+        )
 
     # Ensure there is 1 and only 1 anatomical reference
     anat_reference_wf = init_anat_template_wf(num_images=num_anat_images, do_biascorr=do_biascorr)
@@ -268,7 +273,7 @@ and used as an anatomical reference throughout the workflow.
 
     # Skull strip the anatomical reference
     synthstrip_anat_wf = init_synthstrip_wf(
-        unfatsat=config.workflow.anat_modality == 'T2w',
+        unfatsat=anat_modality == 'T2w',
         name='synthstrip_anat_wf',
     )
 
@@ -278,7 +283,7 @@ and used as an anatomical reference throughout the workflow.
     # Synthstrip is used a lot elsewhere, so make boilerplate for the anatomy-specific
     # version here. TODO: get version number automatically
     workflow.__postdesc__ = f"""\
-Brain extraction was performed on the {config.workflow.anat_modality} image using
+Brain extraction was performed on the {anat_modality} image using
 SynthStrip [@synthstrip] and automated segmentation was
 performed using SynthSeg [@synthseg1; @synthseg2] from
 FreeSurfer version {FS_VERSION}. """
@@ -322,8 +327,8 @@ FreeSurfer version {FS_VERSION}. """
         name='acpc_aseg_to_dseg',
     )
 
-    # What to do about T2w's?
-    if config.workflow.anat_modality == 'T2w':
+    # What to do about T2ws?
+    if anat_modality == 'T2w':
         workflow.connect([
             (synthstrip_anat_wf, rigid_acpc_resample_unfatsat, [
                 ('outputnode.unfatsat', 'input_image'),
@@ -331,7 +336,7 @@ FreeSurfer version {FS_VERSION}. """
             (anat_normalization_wf, rigid_acpc_resample_unfatsat, [
                 ('outputnode.to_template_rigid_transform', 'transforms'),
             ]),
-            (reorient_brain_to_lps, rigid_acpc_resample_unfatsat, [
+            (reorient_tpl_brain_to_lps, rigid_acpc_resample_unfatsat, [
                 ('out_file', 'reference_image'),
             ]),
             (rigid_acpc_resample_unfatsat, outputnode, [('output_image', 't2w_unfatsat')]),
@@ -360,7 +365,7 @@ FreeSurfer version {FS_VERSION}. """
 
     workflow.connect([
         (inputnode, anat_reference_wf, [
-            (config.workflow.anat_modality.lower(), 'inputnode.images'),
+            (anat_modality.lower(), 'inputnode.images'),
         ]),
 
         # Make a single anatomical reference. Pad it.
@@ -396,10 +401,12 @@ FreeSurfer version {FS_VERSION}. """
         (anat_reference_wf, anat_normalization_wf, [
             ('outputnode.bias_corrected', 'inputnode.anatomical_reference'),
         ]),
-        (reorient_brain_to_lps, anat_normalization_wf, [
+        (reorient_tpl_brain_to_lps, anat_normalization_wf, [
             ('out_file', 'inputnode.template_image'),
         ]),
-        (reorient_mask_to_lps, anat_normalization_wf, [('out_file', 'inputnode.template_mask')]),
+        (reorient_tpl_mask_to_lps, anat_normalization_wf, [
+            ('out_file', 'inputnode.template_mask'),
+        ]),
         (anat_normalization_wf, outputnode, [
             ('outputnode.to_template_rigid_transform', 'acpc_transform'),
             ('outputnode.from_template_rigid_transform', 'acpc_inv_transform'),
@@ -416,10 +423,10 @@ FreeSurfer version {FS_VERSION}. """
             ('outputnode.bias_corrected', 'input_image'),
         ]),
         (synthseg_anat_wf, rigid_acpc_resample_aseg, [('outputnode.aparc_image', 'input_image')]),
-        (reorient_brain_to_lps, rigid_acpc_resample_brain, [('out_file', 'reference_image')]),
-        (reorient_brain_to_lps, rigid_acpc_resample_mask, [('out_file', 'reference_image')]),
-        (reorient_brain_to_lps, rigid_acpc_resample_head, [('out_file', 'reference_image')]),
-        (reorient_brain_to_lps, rigid_acpc_resample_aseg, [('out_file', 'reference_image')]),
+        (reorient_tpl_brain_to_lps, rigid_acpc_resample_brain, [('out_file', 'reference_image')]),
+        (reorient_tpl_brain_to_lps, rigid_acpc_resample_mask, [('out_file', 'reference_image')]),
+        (reorient_tpl_brain_to_lps, rigid_acpc_resample_head, [('out_file', 'reference_image')]),
+        (reorient_tpl_brain_to_lps, rigid_acpc_resample_aseg, [('out_file', 'reference_image')]),
         (anat_normalization_wf, rigid_acpc_resample_brain, [
             ('outputnode.to_template_rigid_transform', 'transforms'),
         ]),
@@ -447,9 +454,9 @@ FreeSurfer version {FS_VERSION}. """
             ('t1_preproc', 'in_file'),
         ]),
         (inputnode, anat_reports_wf, [
-            ((config.workflow.anat_modality.lower(), fix_multi_source_name,
+            ((anat_modality.lower(), fix_multi_source_name,
               config.workflow.subject_anatomical_reference == 'sessionwise',
-              config.workflow.anat_modality),
+              anat_modality),
              'inputnode.source_file')]),
         (anat_reference_wf, anat_reports_wf, [
             ('outputnode.out_report', 'inputnode.t1_conform_report'),
@@ -461,7 +468,8 @@ FreeSurfer version {FS_VERSION}. """
     ])  # fmt:skip
 
     anat_derivatives_wf = init_anat_derivatives_wf(
-        anatomical_template=anatomical_template, has_t2w=num_additional_t2ws > 0
+        anatomical_template=anatomical_template,
+        has_t2w=num_additional_t2ws > 0,
     )
 
     workflow.connect([
@@ -500,7 +508,7 @@ FreeSurfer version {FS_VERSION}. """
 
 def init_t2w_preproc_wf(num_t2ws, do_biascorr=True, name='t2w_preproc_wf'):
     """If T1w is the anatomical contrast, you may also want to process the T2ws for
-    worlflows that can use them (ie DRBUDDI). This"""
+    worlflows that can use them (ie DRBUDDI)."""
     workflow = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(fields=['t2w_images', 't1_brain']),
@@ -671,6 +679,8 @@ def init_anat_template_wf(num_images, do_biascorr=True) -> Workflow:
     ----------
     num_images : int
         Number of anatomical images
+    do_biascorr : bool, optional
+        Whether or not to apply N4 bias correction. Default is True.
 
     Inputs
     ------

--- a/qsiprep/workflows/anatomical/volume.py
+++ b/qsiprep/workflows/anatomical/volume.py
@@ -53,8 +53,8 @@ from ...interfaces.freesurfer import (
     PrepareSynthStripGrid,
     SynthSeg,
 )
-from ...interfaces.itk import AffineToRigid, DisassembleTransform
 from ...interfaces.images import AnatomicalReportlet
+from ...interfaces.itk import AffineToRigid, DisassembleTransform
 from ...interfaces.niworkflows import RobustMNINormalizationRPT
 from ...utils.gpu import gpu_enabled
 from ...utils.misc import fix_multi_source_name
@@ -746,13 +746,13 @@ A {contrast}-reference map was computed after registration of
     )
 
     workflow.connect([
-        (inputnode, template_dimensions, [('images', 'anat_list')]),
+        (inputnode, template_dimensions, [('images', 't1w_list')]),
         (template_dimensions, anat_conform, [
-            ('anat_valid_list', 'in_file'),
+            ('t1w_valid_list', 'in_file'),
             ('target_zooms', 'target_zooms'),
             ('target_shape', 'target_shape'),
         ]),
-        (template_dimensions, outputnode, [('anat_valid_list', 'valid_list')]),
+        (template_dimensions, outputnode, [('t1w_valid_list', 'valid_list')]),
     ])  # fmt:skip
 
     # N4 fits its field by least squares in the log domain, where near-zero
@@ -1302,7 +1302,7 @@ def init_anat_reports_wf(anatomical_template) -> Workflow:
                 'anat_list',
                 'valid_list',
                 'reference_image',
-            ]
+            ],
         ),
         name='inputnode',
     )

--- a/qsiprep/workflows/anatomical/volume.py
+++ b/qsiprep/workflows/anatomical/volume.py
@@ -458,8 +458,9 @@ FreeSurfer version {FS_VERSION}. """
             ((anat_modality.lower(), fix_multi_source_name,
               config.workflow.subject_anatomical_reference == 'sessionwise',
               anat_modality),
-             'inputnode.source_file')]),
+             'inputnode.source_file'),
             (anat_modality.lower(), 'inputnode.anat_list'),
+        ]),
         (anat_reference_wf, anat_reports_wf, [
             ('outputnode.valid_list', 'inputnode.valid_list'),
         ]),


### PR DESCRIPTION
Closes #656. Closes #836.

## Changes proposed in this pull request

- Create new interface, AnatomicalReportlet, to replace the report generated by TemplateDimensions. This one uses the template's shape and resolution instead of the input anatomicals', since QSIPrep resamples the anatomical images to 1 mm3 resolution in the same grid as the template.