### PR TITLE
Use same cropped FOV for before and after images in reportlets

### DIFF
--- a/qsiprep/interfaces/denoise.py
+++ b/qsiprep/interfaces/denoise.py
@@ -12,7 +12,7 @@ import os
 import nibabel as nb
 import numpy as np
 import pandas as pd
-from nilearn.image import iter_img, load_img, threshold_img
+from nilearn.image import crop_img, iter_img, load_img, threshold_img
 from nipype import logging
 from nipype.interfaces.base import isdefined, traits
 from nipype.interfaces.mixins import reporting
@@ -121,7 +121,10 @@ class SeriesPreprocReport(reporting.ReportCapableInterface):
             contour_nii = load_img(self.inputs.mask)
         else:
             mask_nii = threshold_img(denoised_lowb_nii, 50)
-        cuts = cuts_from_bbox(contour_nii or mask_nii, cuts=self._n_cuts)
+
+        ref_nii = contour_nii or mask_nii
+        cuts = cuts_from_bbox(ref_nii, cuts=self._n_cuts)
+        _, crop_offset = crop_img(ref_nii, return_offset=True)
 
         # What image should be contoured?
         if field_nii is None:
@@ -144,6 +147,7 @@ class SeriesPreprocReport(reporting.ReportCapableInterface):
                 'moving-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Raw Image',
                 lowb_contour=lowb_field_nii,
                 highb_contour=highb_field_nii,
@@ -155,6 +159,7 @@ class SeriesPreprocReport(reporting.ReportCapableInterface):
                 'fixed-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Denoised',
                 lowb_contour=lowb_field_nii,
                 highb_contour=highb_field_nii,

--- a/qsiprep/interfaces/fmap.py
+++ b/qsiprep/interfaces/fmap.py
@@ -1044,6 +1044,9 @@ class PEPOLARReport(SimpleInterface):
         fa_down_corrected_img = nb.load(self.inputs.down_fa_corrected_image)
         uncorrected_fa = image.math_img('(a+b)/2', a=fa_up_img, b=fa_down_img)
         corrected_fa = image.math_img('(a+b)/2', a=fa_up_corrected_img, b=fa_down_corrected_img)
+
+        _, crop_offset = image.crop_img(uncorrected_fa, return_offset=True)
+
         compose_view(
             plot_fa_reg(
                 corrected_fa,
@@ -1052,6 +1055,7 @@ class PEPOLARReport(SimpleInterface):
                 estimate_brightness=False,
                 label='FA: After',
                 cuts=cuts,
+                crop_offset=crop_offset,
             ),
             plot_fa_reg(
                 uncorrected_fa,
@@ -1060,6 +1064,7 @@ class PEPOLARReport(SimpleInterface):
                 estimate_brightness=False,
                 label='FA: Before',
                 cuts=cuts,
+                crop_offset=crop_offset,
             ),
             out_file=fa_sdc_svg,
         )
@@ -1179,6 +1184,7 @@ def plot_fa_reg(
     blip_down_plot_params=None,
     order=('z', 'x', 'y'),
     cuts=None,
+    crop_offset=None,
     estimate_brightness=False,
     label=None,
     compress='auto',
@@ -1197,7 +1203,9 @@ def plot_fa_reg(
         raise NotImplementedError
 
     out_files = []
-    seg_contour_img = image.crop_img(seg_contour_img)
+    seg_contour_img = (
+        seg_contour_img if crop_offset is None else seg_contour_img.slicer[crop_offset]
+    )
     zeros_bg_img = image.new_img_like(
         seg_contour_img, np.zeros(seg_contour_img.shape), copy_header=True
     )

--- a/qsiprep/interfaces/fmap.py
+++ b/qsiprep/interfaces/fmap.py
@@ -1085,7 +1085,7 @@ def plot_pepolar(
     blip_down_plot_params=None,
     order=('z', 'x', 'y'),
     cuts=None,
-    crop_offset=crop_offset,
+    crop_offset=None,
     estimate_brightness=False,
     label=None,
     blip_down_contour=None,

--- a/qsiprep/interfaces/fmap.py
+++ b/qsiprep/interfaces/fmap.py
@@ -994,6 +994,8 @@ class PEPOLARReport(SimpleInterface):
         b0_up_corrected_img = nb.load(self.inputs.b0_up_corrected_image)
         b0_down_corrected_img = nb.load(self.inputs.b0_down_corrected_image)
         cuts = cuts_from_bbox(seg_img, self._n_cuts)
+        _, crop_offset = image.crop_img(seg_img, return_offset=True)
+
         b0_sdc_svg = op.join(runtime.cwd, 'b0_blipupdown_sdc.svg')
         compose_view(
             plot_pepolar(
@@ -1003,6 +1005,7 @@ class PEPOLARReport(SimpleInterface):
                 'moving-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Original',
                 upper_label_suffix=': Blip Up',
                 lower_label_suffix=': Blip Down',
@@ -1015,6 +1018,7 @@ class PEPOLARReport(SimpleInterface):
                 'fixed-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Corrected',
                 upper_label_suffix=': Blip Up',
                 lower_label_suffix=': Blip Down',
@@ -1081,6 +1085,7 @@ def plot_pepolar(
     blip_down_plot_params=None,
     order=('z', 'x', 'y'),
     cuts=None,
+    crop_offset=crop_offset,
     estimate_brightness=False,
     label=None,
     blip_down_contour=None,
@@ -1111,7 +1116,9 @@ def plot_pepolar(
             blip_up_img.get_fdata(dtype='float32').reshape(-1), plot_params
         )
 
-    seg_contour_img = image.crop_img(seg_contour_img)
+    seg_contour_img = (
+        seg_contour_img if crop_offset is None else seg_contour_img.slicer[crop_offset]
+    )
     zeros_bg_img = image.new_img_like(
         seg_contour_img, np.zeros(seg_contour_img.shape), copy_header=True
     )

--- a/qsiprep/interfaces/itk.py
+++ b/qsiprep/interfaces/itk.py
@@ -81,7 +81,7 @@ class ACPCReport(SimpleInterface):
         translation_img = nb.load(self.inputs.translation_image)
         rigid_img = nb.load(self.inputs.rigid_image)
         # combine images so crop offset captures both
-        sum_img = nim.math_image('a + b', a=translation_img, b=rigid_img)
+        sum_img = nim.math_img('a + b', a=translation_img, b=rigid_img)
         _, crop_offset = nim.crop_img(sum_img, return_offset=True)
 
         # Call composer

--- a/qsiprep/interfaces/itk.py
+++ b/qsiprep/interfaces/itk.py
@@ -14,6 +14,7 @@ import subprocess
 from mimetypes import guess_type
 
 import nibabel as nb
+import nilearn.image as nim
 import numpy as np
 import SimpleITK as sitk
 from dipy.core import geometry as geom
@@ -77,20 +78,28 @@ class ACPCReport(SimpleInterface):
 
     def _run_interface(self, runtime):
         out_report = runtime.cwd + '/ACPCReport.svg'
+        translation_img = nb.load(self.inputs.translation_image)
+        rigid_img = nb.load(self.inputs.rigid_img)
+        # combine images so crop offset captures both
+        sum_img = nim.math_image('a + b', a=translation_img, b=rigid_img)
+        _, crop_offset = nim.crop_img(sum_img, return_offset=True)
+
         # Call composer
         compose_view(
             plot_acpc(
-                nb.load(self.inputs.translation_image),
+                translation_img,
                 'moving-image',
                 estimate_brightness=True,
                 label='Original',
+                crop_offset=crop_offset,
                 compress=False,
             ),
             plot_acpc(
-                nb.load(self.inputs.rigid_image),
+                rigid_img,
                 'fixed-image',
                 estimate_brightness=True,
                 label='AC-PC',
+                crop_offset=crop_offset,
                 compress=False,
             ),
             out_file=out_report,

--- a/qsiprep/interfaces/itk.py
+++ b/qsiprep/interfaces/itk.py
@@ -79,7 +79,7 @@ class ACPCReport(SimpleInterface):
     def _run_interface(self, runtime):
         out_report = runtime.cwd + '/ACPCReport.svg'
         translation_img = nb.load(self.inputs.translation_image)
-        rigid_img = nb.load(self.inputs.rigid_img)
+        rigid_img = nb.load(self.inputs.rigid_image)
         # combine images so crop offset captures both
         sum_img = nim.math_image('a + b', a=translation_img, b=rigid_img)
         _, crop_offset = nim.crop_img(sum_img, return_offset=True)

--- a/qsiprep/interfaces/mrtrix.py
+++ b/qsiprep/interfaces/mrtrix.py
@@ -11,7 +11,7 @@ import os
 
 import nibabel as nb
 import numpy as np
-from nilearn.image import load_img, threshold_img
+from nilearn.image import crop_img, load_img, threshold_img
 from nipype import logging
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
@@ -562,7 +562,10 @@ class MRDeGibbs(SeriesPreprocReport, MRTrix3Base):
             contour_nii = load_img(self.inputs.mask)
         else:
             mask_nii = threshold_img(denoised_lowb_nii, 50)
-        cuts = cuts_from_bbox(contour_nii or mask_nii, cuts=self._n_cuts)
+
+        ref_nii = contour_nii or mask_nii
+        cuts = cuts_from_bbox(ref_nii, cuts=self._n_cuts)
+        _, crop_offset = crop_img(ref_nii, return_offset=True)
 
         diff_lowb_nii = nb.Nifti1Image(
             orig_lowb_nii.get_fdata() - denoised_lowb_nii.get_fdata(),
@@ -581,6 +584,7 @@ class MRDeGibbs(SeriesPreprocReport, MRTrix3Base):
                 'moving-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='De-Gibbs',
                 lowb_contour=None,
                 highb_contour=None,
@@ -592,6 +596,7 @@ class MRDeGibbs(SeriesPreprocReport, MRTrix3Base):
                 'fixed-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Estimated Ringing',
                 lowb_contour=None,
                 highb_contour=None,

--- a/qsiprep/interfaces/tortoise.py
+++ b/qsiprep/interfaces/tortoise.py
@@ -601,7 +601,10 @@ class Gibbs(SeriesPreprocReport, TORTOISECommandLine):
             contour_nii = nim.load_img(self.inputs.mask)
         else:
             mask_nii = nim.threshold_img(denoised_lowb_nii, 50)
-        cuts = cuts_from_bbox(contour_nii or mask_nii, cuts=self._n_cuts)
+
+        ref_nii = contour_nii or mask_nii
+        cuts = cuts_from_bbox(ref_nii, cuts=self._n_cuts)
+        _, crop_offset = nim.crop_img(ref_nii, return_offset=True)
 
         diff_lowb_nii = nb.Nifti1Image(
             orig_lowb_nii.get_fdata() - denoised_lowb_nii.get_fdata(),
@@ -620,6 +623,7 @@ class Gibbs(SeriesPreprocReport, TORTOISECommandLine):
                 'moving-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='De-Gibbs',
                 lowb_contour=None,
                 highb_contour=None,
@@ -631,6 +635,7 @@ class Gibbs(SeriesPreprocReport, TORTOISECommandLine):
                 'fixed-image',
                 estimate_brightness=True,
                 cuts=cuts,
+                crop_offset=crop_offset,
                 label='Estimated Ringing',
                 lowb_contour=None,
                 highb_contour=None,

--- a/qsiprep/viz/utils.py
+++ b/qsiprep/viz/utils.py
@@ -113,7 +113,6 @@ def plot_acpc(
     div_id,
     plot_params=None,
     order=('z', 'x', 'y'),
-    cuts=None,
     crop_offset=None,
     estimate_brightness=False,
     label=None,

--- a/qsiprep/viz/utils.py
+++ b/qsiprep/viz/utils.py
@@ -1,8 +1,7 @@
 """Visualization utilities."""
 
-import numpy as np
 from lxml import etree
-from nilearn import image, plotting
+from nilearn import plotting
 from niworkflows.viz.utils import SVGNS, extract_svg, robust_set_limits, uuid4
 from svgutils.transform import SVGFigure
 

--- a/qsiprep/viz/utils.py
+++ b/qsiprep/viz/utils.py
@@ -15,6 +15,7 @@ def plot_denoise(
     highb_plot_params=None,
     order=('z', 'x', 'y'),
     cuts=None,
+    crop_offset=None,
     estimate_brightness=False,
     label=None,
     lowb_contour=None,
@@ -40,17 +41,14 @@ def plot_denoise(
 
     # Do the low-b image first
     out_files = []
+
+    # Plot each cut axis for low-b
     if estimate_brightness:
         plot_params = robust_set_limits(
             lowb_nii.get_fdata(dtype='float32').reshape(-1), plot_params
         )
-    # Plot each cut axis for low-b
-    lowb_nii_data = lowb_nii.get_fdata(dtype='float32')
-    if np.all(lowb_nii_data <= 1e-8):
-        lowb_nii_cropped = lowb_nii
-    else:
-        lowb_nii_cropped = image.crop_img(lowb_nii)
 
+    lowb_nii_cropped = lowb_nii if crop_offset is None else lowb_nii.slicer[crop_offset]
     for i, mode in enumerate(list(order)):
         plot_params['display_mode'] = mode
         plot_params['cut_coords'] = cuts[mode]
@@ -82,12 +80,7 @@ def plot_denoise(
             highb_nii.get_fdata(dtype='float32').reshape(-1), highb_plot_params
         )
 
-    highb_nii_data = highb_nii.get_fdata(dtype='float32')
-    if np.all(highb_nii_data <= 1e-8):
-        highb_nii_cropped = highb_nii
-    else:
-        highb_nii_cropped = image.crop_img(highb_nii)
-
+    highb_nii_cropped = highb_nii if crop_offset is None else highb_nii.slicer[crop_offset]
     for i, mode in enumerate(list(order)):
         highb_plot_params['display_mode'] = mode
         highb_plot_params['cut_coords'] = cuts[mode]
@@ -122,6 +115,7 @@ def plot_acpc(
     plot_params=None,
     order=('z', 'x', 'y'),
     cuts=None,
+    crop_offset=None,
     estimate_brightness=False,
     label=None,
     compress='auto',
@@ -139,12 +133,9 @@ def plot_acpc(
         )
 
     # Plot each cut axis for low-b
-    acpc_registered_img_data = acpc_registered_img.get_fdata(dtype='float32')
-    if np.all(acpc_registered_img_data <= 1e-8):
-        acpc_registered_img_cropped = acpc_registered_img
-    else:
-        acpc_registered_img_cropped = image.crop_img(acpc_registered_img)
-
+    acpc_registered_img_cropped = (
+        acpc_registered_img if crop_offset is None else acpc_registered_img.slicer[crop_offset]
+    )
     for i, mode in enumerate(list(order)):
         plot_params['display_mode'] = mode
         plot_params['cut_coords'] = [-20.0, 0.0, 20.0]


### PR DESCRIPTION
There was a bug in the reportlets that crop fields of view introduced by #997. The result was that, in some cases (like `rpg` where the early-stopping bug occurs), the FOV of the before and after images was different, resulting in mismatches between the two images.

## Changes proposed in this pull request

- For reportlets that use `plot_denoise` or `plot_acpc` (the two plotting utility functions that crop the images being plotted), crop one image beforehand and use its offsets to crop both the before and after images within the plotting utility function.