### PR TITLE
Control threading in Gibbs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=pennlinc/qsiprep-base:20260809
+ARG BASE_IMAGE=pennlinc/qsiprep-base:20260821
 ARG DWIDENOISE2_COMMIT=cd08ec1a0f5eb1dbc9962f80c20c2bb3428c4f93
 # MRtrix3 "dev" as at 2026-06-22, the commit dwidenoise2 is developed against
 ARG MRTRIX3_DWIDENOISE2_COMMIT=b98b54e9ae8168eeb9af23322a07011d4754456d

--- a/qsiprep/interfaces/tortoise.py
+++ b/qsiprep/interfaces/tortoise.py
@@ -556,7 +556,11 @@ class _GibbsInputSpec(TORTOISEInputSpec, SeriesPreprocReportInputSpec):
     nsh = traits.Int(argstr='%d', position=4)
     min_w = traits.Int()
     mask = File()
-    num_threads = traits.Int(1, usedefault=True, nohash=True)
+    num_threads = traits.Int(
+        argstr='--ncores %d',
+        nohash=True,
+        desc='number of OMP threads',
+    )
 
 
 class _GibbsOutputSpec(SeriesPreprocReportOutputSpec):

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -603,6 +603,7 @@ def init_dwi_denoising_wf(
                 Gibbs(
                     kspace_coverage=partial_fourier,
                     phase_encoding_dir=pe_code,
+                    num_threads=omp_nthreads,
                 ),
                 name='degibbser',
                 n_procs=omp_nthreads,


### PR DESCRIPTION
rpg (the Gibbs binary in TORTOISE) was using all cpus regardless of nipype trying to limit it with environment variables. This uses the patched in --ncores flag to limit threads