### PR TITLE
Add new gradient plot to htmls

### DIFF
--- a/.circleci/DSCSDSI_outputs.txt
+++ b/.circleci/DSCSDSI_outputs.txt
@@ -40,7 +40,7 @@ qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_coreg.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-sdc_b0.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_dwi_denoise_acq_HASC55AP_dwi_wf_denoising.svg
-qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_sampling_scheme.gif
+qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-samplingscheme_dwi.html
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_shoreline_animation.gif
 qsiprep/sub-tester/figures/sub-tester_seg_brainmask.svg
 qsiprep/sub-tester/figures/sub-tester_t1_2_mni.svg

--- a/.circleci/DSDTI_nofmap_outputs.txt
+++ b/.circleci/DSDTI_nofmap_outputs.txt
@@ -41,7 +41,7 @@ qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_denoising.svg
-qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_sampling_scheme.gif
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-samplingscheme_dwi.html
 qsiprep/sub-PNC/figures/sub-PNC_seg_brainmask.svg
 qsiprep/sub-PNC/figures/sub-PNC_t1_2_mni.svg
 qsiprep/sub-PNC.html

--- a/.circleci/DSDTI_outputs.txt
+++ b/.circleci/DSDTI_outputs.txt
@@ -42,7 +42,7 @@ qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_denoising.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_unringing.svg
-qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_sampling_scheme.gif
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-samplingscheme_dwi.html
 qsiprep/sub-PNC/figures/sub-PNC_seg_brainmask.svg
 qsiprep/sub-PNC/figures/sub-PNC_t1_2_mni.svg
 qsiprep/sub-PNC.html

--- a/.circleci/DSDTI_synsdc_outputs.txt
+++ b/.circleci/DSDTI_synsdc_outputs.txt
@@ -41,7 +41,7 @@ qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_dwi_denoise_acq_realistic_dwi_wf_denoising.svg
-qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_sampling_scheme.gif
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-samplingscheme_dwi.html
 qsiprep/sub-PNC/figures/sub-PNC_seg_brainmask.svg
 qsiprep/sub-PNC/figures/sub-PNC_t1_2_mni.svg
 qsiprep/sub-PNC.html

--- a/.circleci/IntramodalTemplate_outputs.txt
+++ b/.circleci/IntramodalTemplate_outputs.txt
@@ -27,13 +27,13 @@ qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_carpetplot.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_coreg.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_dwi_denoise_ses_1_acq_HASC55PA_dwi_wf_biascorr.svg
-qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_sampling_scheme.gif
+qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_desc-samplingscheme_dwi.html
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_tointramodal.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_carpetplot.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_coreg.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_dwi_denoise_ses_2_acq_HASC55AP_dwi_wf_biascorr.svg
-qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_sampling_scheme.gif
+qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_desc-samplingscheme_dwi.html
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_tointramodal.svg
 qsiprep/sub-tester/figures/sub-tester_t1_2_mni.svg
 qsiprep/sub-tester.html

--- a/.circleci/get_data.sh
+++ b/.circleci/get_data.sh
@@ -341,7 +341,7 @@ Contents:
  - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_carpetplot.svg
  - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_coreg.svg
  - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
- - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_sampling_scheme.gif
+ - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-samplingscheme_dwi.html
  - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_seg_brainmask.svg
  - data/singleshell_output/qsiprep/sub-PNC/figures/sub-PNC_t1_2_mni.svg
  - data/singleshell_output/qsiprep/sub-PNC.html

--- a/docs/notebooks/grouping_tutorial.md
+++ b/docs/notebooks/grouping_tutorial.md
@@ -85,9 +85,9 @@ def group(*records, **options):
     return build_grouping(list(records), subject_id='01', **options)
 
 
-def show(grouping, height=560, backend='fsl'):
+def show(grouping, height=560):
     """Display the explanatory HTML page for a grouping inline."""
-    page = _html.escape(render_html(grouping, backend=backend))
+    page = _html.escape(render_html(grouping))
     display(
         HTML(
             f'<iframe srcdoc="{page}" style="width:100%;height:{height}px;'
@@ -394,7 +394,7 @@ dwi = scan('sub-01_dir-AP_dwi.nii.gz', PhaseEncodingDirection='j-')
 t1w = scan('sub-01_T1w.nii.gz', folder='anat', suffix='T1w', PhaseEncodingDirection=None, TotalReadoutTime=None)
 t2w = scan('sub-01_T2w.nii.gz', folder='anat', suffix='T2w', PhaseEncodingDirection=None, TotalReadoutTime=None)
 g = group(dwi, t1w, t2w)
-show(g, height=680, backend='tortoise')
+show(g, height=680)
 ```
 
 Command-line flags climb the ladder explicitly (provenance **cli-override**,
@@ -427,9 +427,9 @@ for backend in ('fsl', 'tortoise', 'mixed'):
     print(describe_processing(g, backend))
 ```
 
-The HTML page shows the same information: the chosen backend's steps are
-expanded on each output box, with the alternatives collapsed underneath
-("if run with the … workflow instead").
+The text preview above is where the per-backend steps live. The HTML grouping
+page concentrates on the grouping itself — which scans combine, which fieldmap
+corrects which group, and the resulting sampling scheme.
 
 ## Appendix: `IntendedFor` (deprecated)
 

--- a/qsiprep/cli/group.py
+++ b/qsiprep/cli/group.py
@@ -149,7 +149,7 @@ def main(argv=None):
         if args.html:
             path = _per_subject_path(args.html, subject, multi)
             with open(path, 'w') as fobj:
-                fobj.write(render_html(grouping, backend=args.backend[0]))
+                fobj.write(render_html(grouping))
             print(f'sub-{subject}: wrote {path}')
         if grouping.errors:
             exit_code = 1

--- a/qsiprep/data/qspace_viewer.css
+++ b/qsiprep/data/qspace_viewer.css
@@ -1,0 +1,47 @@
+/* Styling for the interactive q-space sampling-scheme viewer
+ * (qspace_viewer.js). Only the reusable .qspace-viewer / .qs-* rules live
+ * here; the host page provides its own layout, tabs, and theme. */
+
+.qspace-viewer { position: relative; }
+.qs-summary { font-size: 11.5px; color: #475569; margin: 0 0 9px;
+  font-variant-numeric: tabular-nums; }
+.qs-controls {
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+  margin: 0 0 10px;
+}
+.qs-seg { display: inline-flex; align-items: center; gap: 6px; }
+.qs-seg-label { font-size: 11.5px; color: #64748b; }
+.qs-seg-btn, .qs-btn {
+  border: 1px solid #cbd5e1; background: #fff; color: #334155;
+  font-size: 11.5px; padding: 3px 10px; border-radius: 7px; cursor: pointer;
+}
+.qs-seg-btn.on { background: #0f172a; color: #fff; border-color: #0f172a; }
+.qs-btn:hover { background: #f1f5f9; }
+.qs-check { font-size: 11.5px; color: #475569; display: inline-flex;
+  align-items: center; gap: 3px; cursor: pointer; }
+.qs-legend { display: flex; gap: 5px; flex-wrap: wrap; margin-left: auto; }
+.qs-leg {
+  display: inline-flex; align-items: center; gap: 5px;
+  border: 1px solid #e2e8f0; background: #fff; color: #334155;
+  border-radius: 99px; padding: 2px 9px 2px 6px; font-size: 11px; cursor: pointer;
+}
+.qs-leg.off { opacity: 0.4; text-decoration: line-through; }
+.qs-sw { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+
+.qs-stage { display: flex; gap: 12px; }
+.qs-cell { flex: 1 1 0; min-width: 0; }
+.qs-title { text-align: center; font-size: 11.5px; color: #64748b; margin: 0 0 2px; }
+.qs-canvas {
+  width: 100%; height: 340px; display: block;
+  background: #fcfdfe; border: 1px solid #eef2f6; border-radius: 10px;
+  touch-action: none; cursor: grab;
+}
+.qs-canvas:active { cursor: grabbing; }
+.qs-tip {
+  position: absolute; pointer-events: none; z-index: 5;
+  background: #0f172a; color: #fff; font-size: 11px; line-height: 1.35;
+  padding: 5px 8px; border-radius: 6px; white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.25);
+}
+.qs-note { font-size: 11px; color: #475569; margin: 9px 0 0; line-height: 1.4;
+  background: #f1f5f9; border-radius: 6px; padding: 5px 9px; }

--- a/qsiprep/data/qspace_viewer.js
+++ b/qsiprep/data/qspace_viewer.js
@@ -493,6 +493,12 @@
     if (window.ResizeObserver) {
       new ResizeObserver(function () { render(); }).observe(stage);
     }
+    // A canvas laid out to zero width at first paint — e.g. when the host page's
+    // stylesheet is still loading — renders blank. Re-render once the page has
+    // fully loaded so the backing store picks up the settled width.
+    if (document.readyState !== "complete") {
+      window.addEventListener("load", render);
+    }
 
     syncSeg();
     buildLegend();

--- a/qsiprep/data/qspace_viewer.js
+++ b/qsiprep/data/qspace_viewer.js
@@ -1,0 +1,510 @@
+/* QSIPrep q-space sampling-scheme viewer.
+ *
+ * Dependency-free (no Plotly/Three/D3), self-contained, offline-ready. One
+ * `<div class="qspace-viewer">` per scheme, carrying its data as an embedded
+ * `<script type="application/json">`. The same widget serves both reports:
+ *   - group report  : one panel, the concatenated *acquired* scheme.
+ *   - subject report : two linked panels, before vs after preprocessing.
+ *
+ * Each point is q = sqrt(b) * bvec. Color is driven by a categorical key that
+ * the caller supplies per point (input-file index and phase-encoding dir);
+ * the "Color by" control just switches which key maps to the palette, so
+ * adding more keys later is a data change, not a code change.
+ */
+(function () {
+  "use strict";
+
+  // Okabe-Ito colorblind-safe categorical palette.
+  var PALETTE = ["#0072B2", "#D55E00", "#009E73", "#E69F00",
+                 "#CC79A7", "#56B4E9", "#F0E442", "#000000"];
+  var B0_COLOR = "#9aa7b8";      // b=0 volumes sit at the origin
+  var AXIS_COLOR = "#c3ccd8";
+
+  // b-values are displayed rounded to the nearest 100 so small acquisition
+  // deviations (e.g. 1585, 4985) do not read as distinct shells.
+  function roundB(b) { return Math.round(b / 100) * 100; }
+
+  function elem(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+
+  function init(root) {
+    var src = root.querySelector('script[type="application/json"]');
+    if (!src) return;
+    var data = JSON.parse(src.textContent);
+
+    var panels = data.panels;              // [{title, coords:[[x,y,z],...]}]
+    var meta = data.meta;                  // [{b,file,pe}] indexed like coords
+    var files = data.files || [];          // file index -> label
+    var pes = data.pes || [];              // pe order for the legend
+    var axisLabels = data.axisLabels || ["x", "y", "z"];      // +ends
+    var axisLabelsNeg = data.axisLabelsNeg || null;           // -ends (optional)
+    // A volume counts as b=0 (direction meaningless) at or below this value;
+    // the emitter passes qsiprep's real b0 threshold. Default: only exactly 0.
+    var b0Threshold = data.b0Threshold != null ? data.b0Threshold : 0;
+    function isB0(m) { return m.b <= b0Threshold; }
+    // Unique diffusion-weighted shells, for the concentric reference rings.
+    var shells = Array.from(new Set(meta.filter(function (m) { return !isB0(m); })
+                                        .map(function (m) { return m.b; })))
+                      .sort(function (a, b) { return a - b; });
+    // maxR and per-shell ring radius are measured per panel (see viewGeometry),
+    // so panels at different radial scales (e.g. sqrt(b) vs b) each auto-fit,
+    // and the rings match whatever radial convention the caller used.
+
+    // Which categorical key colors the points, and how to read it per point.
+    var MODES = {
+      file: { label: "input file", cats: files,
+              of: function (m) { return m.file; } },
+      pe:   { label: "phase encoding", cats: pes,
+              of: function (m) { return pes.indexOf(m.pe); } }
+    };
+
+    var st = {
+      mode: files.length ? "file" : "pe",
+      az: 0.5, el: 0.35, scale: 1,
+      hidden: { file: {}, pe: {} },        // per-mode toggled-off categories
+      spin: false,
+      antipodal: false,
+      hover: null                          // {view, cl}
+    };
+
+    // Coincident samples: volumes sharing a q-coordinate (identical b and
+    // direction) — e.g. the AP and PA copy of every direction in an appa
+    // scheme. They fall on one pixel, so we cluster them and draw a split
+    // marker; otherwise the last one drawn silently hides the rest.
+    // Membership is direction/b identity, so it holds across panels (rotation
+    // and sqrt/linear scaling preserve coincidence) — compute once.
+    var clusters = (function () {
+      var scale = 1e-6, c0 = panels[0].coords;
+      c0.forEach(function (c) {
+        var r = Math.hypot(c[0], c[1], c[2]); if (r > scale) scale = r;
+      });
+      scale *= 1e-3;                                   // 0.1% of the max radius
+      var byKey = {};
+      c0.forEach(function (c, i) {
+        var k = Math.round(c[0] / scale) + "|" + Math.round(c[1] / scale) +
+                "|" + Math.round(c[2] / scale);
+        (byKey[k] || (byKey[k] = [])).push(i);
+      });
+      return Object.keys(byKey).map(function (k) { return { idx: byKey[k] }; });
+    })();
+    var hasCoincident = clusters.some(function (cl) { return cl.idx.length > 1; });
+
+    // One-line scheme summary.
+    var summaryText = (function () {
+      var nB0 = meta.filter(isB0).length;
+      var nCoin = clusters.filter(function (cl) { return cl.idx.length > 1; }).length;
+      var parts = [meta.length + " volumes"];
+      if (nB0) parts.push(nB0 + " × b=0");
+      if (shells.length && shells.length <= 6) {
+        var rounded = Array.from(new Set(shells.map(roundB)));
+        parts.push("b=" + rounded.join("/"));
+      } else if (shells.length) {
+        parts.push(shells.length + " b-values (max " +
+                   roundB(shells[shells.length - 1]) + ")");
+      }
+      if (files.length > 1) parts.push(files.length + " series");
+      if (nCoin) parts.push(nCoin + " shared coordinate" + (nCoin > 1 ? "s" : ""));
+      return parts.join("  ·  ");
+    })();
+
+    // Per-panel geometry: max radius (for auto-fit) and the measured radius of
+    // each shell (for the reference rings). Computed once per panel.
+    function viewGeometry(panel) {
+      var mr = 1e-6, sum = {}, cnt = {};
+      panel.coords.forEach(function (c, i) {
+        var r = Math.hypot(c[0], c[1], c[2]);
+        if (r > mr) mr = r;
+        var b = meta[i].b;
+        if (b > b0Threshold) { sum[b] = (sum[b] || 0) + r; cnt[b] = (cnt[b] || 0) + 1; }
+      });
+      var sr = {};
+      shells.forEach(function (b) { if (cnt[b]) sr[b] = sum[b] / cnt[b]; });
+      return { maxR: mr, shellRadius: sr };
+    }
+
+    // ---- DOM scaffold -----------------------------------------------------
+    root.innerHTML = "";
+    root.appendChild(elem("div", "qs-summary", summaryText));
+    var controls = elem("div", "qs-controls");
+    root.appendChild(controls);
+
+    // Color-by segmented control (only when there's a real choice).
+    if (files.length > 1 && pes.length > 1) {
+      var seg = elem("div", "qs-seg");
+      seg.appendChild(elem("span", "qs-seg-label", "Color by"));
+      ["file", "pe"].forEach(function (m) {
+        var b = elem("button", "qs-seg-btn", MODES[m].label);
+        b.dataset.mode = m;
+        b.onclick = function () { st.mode = m; syncSeg(); buildLegend(); render(); };
+        seg.appendChild(b);
+      });
+      controls.appendChild(seg);
+    }
+
+    var spinWrap = elem("label", "qs-check");
+    var spinBox = elem("input");
+    spinBox.type = "checkbox";
+    spinBox.onchange = function () { st.spin = spinBox.checked; if (st.spin) tick(); };
+    spinWrap.appendChild(spinBox);
+    spinWrap.appendChild(document.createTextNode(" spin"));
+    controls.appendChild(spinWrap);
+
+    var antiWrap = elem("label", "qs-check");
+    var antiBox = elem("input");
+    antiBox.type = "checkbox";
+    antiBox.onchange = function () { st.antipodal = antiBox.checked; render(); };
+    antiWrap.appendChild(antiBox);
+    antiWrap.appendChild(document.createTextNode(" antipodal"));
+    controls.appendChild(antiWrap);
+
+    var resetBtn = elem("button", "qs-btn", "reset view");
+    resetBtn.onclick = function () { st.az = 0.5; st.el = 0.35; st.scale = 1; render(); };
+    controls.appendChild(resetBtn);
+
+    var legend = elem("div", "qs-legend");
+    controls.appendChild(legend);
+
+    // One canvas per panel; all share rotation/zoom/visibility.
+    var stage = elem("div", "qs-stage");
+    root.appendChild(stage);
+    var views = panels.map(function (p) {
+      var cell = elem("div", "qs-cell");
+      cell.appendChild(elem("div", "qs-title", p.title || ""));
+      var canvas = elem("canvas", "qs-canvas");
+      cell.appendChild(canvas);
+      stage.appendChild(cell);
+      var g = viewGeometry(p);
+      return { panel: p, canvas: canvas, ctx: canvas.getContext("2d"), proj: [],
+               maxR: g.maxR, shellRadius: g.shellRadius };
+    });
+
+    var tip = elem("div", "qs-tip");
+    tip.style.display = "none";
+    root.appendChild(tip);
+
+    // Self-documenting note: only shown when the scheme actually has coincidence.
+    if (hasCoincident) {
+      root.appendChild(elem("div", "qs-note",
+        "&#9680; a split marker is one q-space coordinate sampled by more than " +
+        "one series / phase-encoding direction &mdash; hover to list them"));
+    }
+
+    // ---- controls state ---------------------------------------------------
+    function syncSeg() {
+      controls.querySelectorAll(".qs-seg-btn").forEach(function (b) {
+        b.classList.toggle("on", b.dataset.mode === st.mode);
+      });
+    }
+
+    function buildLegend() {
+      legend.innerHTML = "";
+      var mode = MODES[st.mode];
+      mode.cats.forEach(function (label, i) {
+        var off = st.hidden[st.mode][i];
+        var item = elem("button", "qs-leg" + (off ? " off" : ""));
+        var sw = elem("span", "qs-sw");
+        sw.style.background = PALETTE[i % PALETTE.length];
+        item.appendChild(sw);
+        item.appendChild(document.createTextNode(label));
+        item.onclick = function () {
+          st.hidden[st.mode][i] = !st.hidden[st.mode][i];
+          buildLegend();
+          render();
+        };
+        legend.appendChild(item);
+      });
+    }
+
+    // ---- projection + drawing --------------------------------------------
+    function project(c, cx, cy, s) {
+      // Rotate azimuth about vertical (y), then elevation about horizontal (x).
+      var ca = Math.cos(st.az), sa = Math.sin(st.az);
+      var x1 = c[0] * ca + c[2] * sa;
+      var z1 = -c[0] * sa + c[2] * ca;
+      var y1 = c[1];
+      var ce = Math.cos(st.el), se = Math.sin(st.el);
+      var y2 = y1 * ce - z1 * se;
+      var z2 = y1 * se + z1 * ce;
+      return { x: cx + s * x1, y: cy - s * y2, depth: z2 };
+    }
+
+    function render() {
+      var mode = MODES[st.mode];
+      views.forEach(function (v) {
+        var dpr = window.devicePixelRatio || 1;
+        var w = v.canvas.clientWidth, h = v.canvas.clientHeight;
+        if (v.canvas.width !== w * dpr || v.canvas.height !== h * dpr) {
+          v.canvas.width = w * dpr; v.canvas.height = h * dpr;
+        }
+        var ctx = v.ctx;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        ctx.clearRect(0, 0, w, h);
+        var cx = w / 2, cy = h / 2;
+        var half = Math.min(w, h) / 2 - 22;
+        if (half <= 1) return;                 // canvas too small to draw
+        var s = half / v.maxR * st.scale;
+
+        drawShells(ctx, cx, cy, s, v.shellRadius);
+        drawAxes(ctx, cx, cy, s, v.maxR);
+
+        // Antipodal mirror: faint -g copy of each diffusion-weighted sample, so
+        // a half-sphere acquisition reads as the full shell it is equivalent to.
+        if (st.antipodal) {
+          ctx.globalAlpha = 0.16;
+          ctx.fillStyle = "#94a3b8";
+          clusters.forEach(function (cl) {
+            if (isB0(meta[cl.idx[0]])) return;
+            var shown = cl.idx.some(function (i) {
+              return !st.hidden[st.mode][mode.of(meta[i])];
+            });
+            if (!shown) return;
+            var c = v.panel.coords[cl.idx[0]];
+            var pr = project([-c[0], -c[1], -c[2]], cx, cy, s);
+            ctx.beginPath(); ctx.arc(pr.x, pr.y, 2.4, 0, 6.2832); ctx.fill();
+          });
+          ctx.globalAlpha = 1;
+        }
+
+        // Build the visible, depth-sorted list of clusters. Coincident samples
+        // share one screen position, so we draw per cluster, not per point.
+        var drawList = [];
+        clusters.forEach(function (cl) {
+          var vis = cl.idx.filter(function (i) {
+            var m = meta[i];
+            return isB0(m) || !st.hidden[st.mode][mode.of(m)];
+          });
+          if (!vis.length) return;
+          var pr = project(v.panel.coords[cl.idx[0]], cx, cy, s);
+          drawList.push({ cl: cl, vis: vis, x: pr.x, y: pr.y, depth: pr.depth });
+        });
+        drawList.sort(function (a, b) { return a.depth - b.depth; });
+        v.proj = drawList;
+
+        var dmax = v.maxR * s || 1;
+        drawList.forEach(function (d) {
+          var t = (d.depth * s + dmax) / (2 * dmax);      // 0 far .. 1 near
+          var b0 = isB0(meta[d.vis[0]]);
+          var baseR = b0 ? 3.2 : 2.6 + 2.8 * t;
+          ctx.globalAlpha = b0 ? 0.92 : 0.5 + 0.5 * t;
+
+          if (b0) {
+            // Neutral labeled marker; direction is undefined at b=0.
+            ctx.fillStyle = B0_COLOR;
+            ctx.beginPath(); ctx.arc(d.x, d.y, baseR, 0, 6.2832); ctx.fill();
+            ctx.lineWidth = 1; ctx.strokeStyle = "#64748b"; ctx.stroke();
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = "#475569";
+            ctx.font = "9px ui-sans-serif,system-ui,sans-serif";
+            ctx.fillText("b=0" + (d.vis.length > 1 ? " ×" + d.vis.length : ""),
+                         d.x + baseR + 2, d.y - baseR);
+          } else {
+            var cats = [];
+            d.vis.forEach(function (i) {
+              var c = mode.of(meta[i]);
+              if (cats.indexOf(c) < 0) cats.push(c);
+            });
+            if (cats.length <= 1) {
+              ctx.fillStyle = PALETTE[cats[0] % PALETTE.length];
+              ctx.beginPath(); ctx.arc(d.x, d.y, baseR, 0, 6.2832); ctx.fill();
+            } else {
+              // Split marker; grow with wedge count so thin slices stay legible.
+              var rr = baseR + 1.4 + 0.8 * Math.min(cats.length - 2, 4);
+              var a = -Math.PI / 2, step = 2 * Math.PI / cats.length;
+              cats.forEach(function (c) {
+                ctx.fillStyle = PALETTE[c % PALETTE.length];
+                ctx.beginPath(); ctx.moveTo(d.x, d.y);
+                ctx.arc(d.x, d.y, rr, a, a + step); ctx.closePath(); ctx.fill();
+                a += step;
+              });
+            }
+          }
+          if (st.hover && st.hover.view === v && st.hover.cl === d.cl) {
+            ctx.globalAlpha = 1;
+            ctx.lineWidth = 1.5;
+            ctx.strokeStyle = "#0f172a";
+            ctx.beginPath();
+            ctx.arc(d.x, d.y, baseR + 3, 0, 6.2832);
+            ctx.stroke();
+          }
+        });
+        ctx.globalAlpha = 1;
+      });
+    }
+
+    var LOG10 = Math.log(10);
+    function niceStep(x) {
+      var p = Math.pow(10, Math.floor(Math.log(x) / LOG10));
+      var f = x / p;
+      return (f < 1.5 ? 1 : f < 3 ? 2 : f < 7 ? 5 : 10) * p;
+    }
+    function interpRadius(bs, sr, b) {
+      if (b <= bs[0]) return sr[bs[0]] * b / bs[0];
+      for (var i = 1; i < bs.length; i++) {
+        if (b <= bs[i]) {
+          var t = (b - bs[i - 1]) / (bs[i] - bs[i - 1]);
+          return sr[bs[i - 1]] + t * (sr[bs[i]] - sr[bs[i - 1]]);
+        }
+      }
+      return sr[bs[bs.length - 1]] * b / bs[bs.length - 1];
+    }
+    // Which b-values get a labeled ring. Few shells -> one ring each. Many
+    // distinct b-values (Cartesian/DSI grid) -> a handful of round-number
+    // rings, radius interpolated from the points so the convention still holds.
+    function ringTicks(shellRadius) {
+      var bs = Object.keys(shellRadius).map(Number)
+                     .sort(function (a, b) { return a - b; });
+      if (!bs.length) return [];
+      if (bs.length <= 8) {
+        return bs.map(function (b) { return { b: b, r: shellRadius[b] }; });
+      }
+      var maxb = bs[bs.length - 1], step = niceStep(maxb / 4), ticks = [];
+      for (var b = step; b <= maxb + 1e-6; b += step) ticks.push(b);
+      if (ticks[ticks.length - 1] < maxb * 0.98) ticks.push(maxb);
+      return ticks.map(function (b) {
+        return { b: b, r: interpRadius(bs, shellRadius, b) };
+      });
+    }
+
+    // Concentric b-value reference rings. Orthographic projection maps each
+    // shell sphere to a circle of the same radius regardless of rotation, so
+    // these stay fixed while the axes turn through them.
+    function drawShells(ctx, cx, cy, s, shellRadius) {
+      ctx.font = "10px ui-sans-serif,system-ui,sans-serif";
+      ctx.textBaseline = "middle";
+      ringTicks(shellRadius).forEach(function (t) {
+        var r = t.r * s;
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, 0, 6.2832);
+        ctx.strokeStyle = "rgba(148,163,184,0.32)";
+        ctx.setLineDash([3, 3]);
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.setLineDash([]);
+        // Label up-and-right of the ring, with a white halo for legibility.
+        var lx = cx + r * 0.7071 + 4, ly = cy - r * 0.7071;
+        var label = "b=" + roundB(t.b);
+        ctx.lineWidth = 3;
+        ctx.strokeStyle = "rgba(252,253,254,0.95)";
+        ctx.strokeText(label, lx, ly);
+        ctx.fillStyle = "#94a3b8";
+        ctx.fillText(label, lx, ly);
+      });
+      ctx.textBaseline = "alphabetic";
+    }
+
+    function drawAxes(ctx, cx, cy, s, maxR) {
+      var units = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+      ctx.strokeStyle = AXIS_COLOR;
+      ctx.lineWidth = 1;
+      ctx.font = "600 11px ui-sans-serif,system-ui,sans-serif";
+      units.forEach(function (e, k) {
+        var pos = project([e[0] * maxR, e[1] * maxR, e[2] * maxR], cx, cy, s);
+        var neg = project([-e[0] * maxR, -e[1] * maxR, -e[2] * maxR], cx, cy, s);
+        ctx.beginPath();
+        ctx.moveTo(neg.x, neg.y);
+        ctx.lineTo(pos.x, pos.y);
+        ctx.stroke();
+        ctx.fillStyle = "#64748b";
+        ctx.fillText(axisLabels[k], pos.x + 3, pos.y - 3);
+        if (axisLabelsNeg) ctx.fillText(axisLabelsNeg[k], neg.x + 3, neg.y - 3);
+      });
+    }
+
+    // ---- interaction ------------------------------------------------------
+    var drag = null;
+    stage.addEventListener("pointerdown", function (e) {
+      drag = { x: e.clientX, y: e.clientY };
+      st.spin = false; spinBox.checked = false;
+      stage.setPointerCapture(e.pointerId);
+    });
+    stage.addEventListener("pointermove", function (e) {
+      if (drag) {
+        st.az += (e.clientX - drag.x) * 0.01;
+        st.el += (e.clientY - drag.y) * 0.01;
+        st.el = Math.max(-1.5, Math.min(1.5, st.el));
+        drag.x = e.clientX; drag.y = e.clientY;
+        render();
+      } else {
+        hoverAt(e);
+      }
+    });
+    stage.addEventListener("pointerup", function () { drag = null; });
+    stage.addEventListener("pointerleave", function () {
+      drag = null; st.hover = null; tip.style.display = "none"; render();
+    });
+    stage.addEventListener("wheel", function (e) {
+      e.preventDefault();
+      st.scale *= e.deltaY < 0 ? 1.1 : 0.9;
+      st.scale = Math.max(0.4, Math.min(4, st.scale));
+      render();
+    }, { passive: false });
+
+    function hoverAt(e) {
+      var found = null;
+      for (var vi = 0; vi < views.length; vi++) {
+        var v = views[vi];
+        var rect = v.canvas.getBoundingClientRect();
+        if (e.clientX < rect.left || e.clientX > rect.right ||
+            e.clientY < rect.top || e.clientY > rect.bottom) continue;
+        var mx = e.clientX - rect.left, my = e.clientY - rect.top;
+        for (var j = v.proj.length - 1; j >= 0; j--) {      // nearest = topmost
+          var d = v.proj[j];
+          if (Math.hypot(d.x - mx, d.y - my) < 8) {
+            found = { view: v, d: d, sx: e.clientX, sy: e.clientY };
+            break;
+          }
+        }
+        if (found) break;
+      }
+      var changed = (found && (!st.hover || st.hover.cl !== found.d.cl)) ||
+                    (!found && st.hover);
+      st.hover = found ? { view: found.view, cl: found.d.cl } : null;
+      if (found) {
+        // List every (visible) sample at this coordinate.
+        var lines = found.d.vis.map(function (i) {
+          var m = meta[i];
+          return (files[m.file] || "?") + " &middot; PE " + m.pe +
+                 " &middot; b=" + (isB0(m) ? 0 : roundB(m.b));
+        });
+        var head = found.d.vis.length > 1
+          ? "<b>" + found.d.vis.length + " samples here</b><br>" : "";
+        tip.innerHTML = head + lines.join("<br>");
+        var box = root.getBoundingClientRect();
+        tip.style.left = (found.sx - box.left + 12) + "px";
+        tip.style.top = (found.sy - box.top + 12) + "px";
+        tip.style.display = "block";
+      } else {
+        tip.style.display = "none";
+      }
+      if (changed) render();
+    }
+
+    function tick() {
+      if (!st.spin) return;
+      st.az += 0.006;
+      render();
+      requestAnimationFrame(tick);
+    }
+
+    if (window.ResizeObserver) {
+      new ResizeObserver(function () { render(); }).observe(stage);
+    }
+
+    syncSeg();
+    buildLegend();
+    render();
+  }
+
+  function boot() {
+    document.querySelectorAll(".qspace-viewer").forEach(init);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -2,6 +2,11 @@ package: qsiprep
 title: Visual report for participant '{subject}' - QSIPrep
 sections:
 
+- name: DWI Grouping
+  reportlets:
+  - bids: {datatype: figures, desc: grouping, suffix: [T1w, T2w, dwi]}
+    subtitle: How QSIPrep grouped and processed this subject's DWI scans
+
 - name: Summary
   reportlets:
   - bids: {datatype: figures, desc: summary, suffix: [T1w, T2w, dwi]}

--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -112,8 +112,8 @@ sections:
   - bids: {datatype: figures, desc: validation, suffix: dwi}
   - bids: {datatype: figures, desc: samplingscheme, suffix: dwi}
     caption: |
-      Animation of the DWI sampling scheme. Each separate scan is its own color
-    static: false
+      Interactive DWI sampling scheme in q-space, before and after preprocessing.
+      Drag to rotate, scroll to zoom; each input scan is a separate color.
     subtitle: DWI Sampling Scheme
 
   - bids: {datatype: figures, desc: fmapCoreg, suffix: dwi}

--- a/qsiprep/grouping/__init__.py
+++ b/qsiprep/grouping/__init__.py
@@ -45,7 +45,7 @@ from .adapters import (
     unit_to_sidecar,
 )
 from .inference import build_grouping
-from .interactive import render_html
+from .interactive import render_html, render_report_segment
 from .metadata import index_subject
 from .models import (
     ConcatenationGroup,
@@ -83,6 +83,7 @@ __all__ = [
     'full_report',
     'index_subject',
     'render_html',
+    'render_report_segment',
     'report_text',
     'to_legacy_scan_groups',
     'to_preproc_units',

--- a/qsiprep/grouping/interactive.py
+++ b/qsiprep/grouping/interactive.py
@@ -1,7 +1,10 @@
 """Render a :class:`~.models.DWIGrouping` as a self-contained explanatory page.
 
-:func:`render_html` returns a single HTML document (no external assets) that
-reads top to bottom as a story:
+The grouping widget is produced two ways from the same markup:
+:func:`render_html` returns a full standalone HTML document (for
+``qsiprep-group --html``, phrased as a plan); :func:`render_report_segment`
+returns a scoped fragment inlined directly into the subject report (phrased in
+past tense, for a run that already happened). It reads top to bottom as a story:
 
 1. **Fieldmaps** - one card per estimation, explaining the method in plain
    words, showing the blip-up/blip-down pairing for PEPOLAR, and stating why
@@ -12,9 +15,9 @@ reads top to bottom as a story:
    hold the scan rows. Every scan appears exactly once; membership in a
    fieldmap estimation is a letter chip on the row, so identity is carried by
    letters (A, B, ...) while color stays dedicated to provenance. Borrowed
-   b=0 sources are called out in a sentence. Each output ends with tabs: an
-   interactive view of its concatenated sampling scheme (shown first) and a
-   plain-language processing preview per backend.
+   b=0 sources are called out in a sentence. Each output ends with an
+   interactive view of its concatenated sampling scheme. (The step-by-step
+   processing narrative lives in a separate workflow display, not here.)
 3. **Notes** - the grouping's warnings and errors.
 
 The page works without JavaScript; a small inline script adds hover
@@ -29,8 +32,7 @@ import html
 from ..viz.qspace import q_points, scheme_div, scheme_payload, viewer_assets
 from .metadata import get_b0_threshold, sibling_bval, sibling_bvec
 from .models import CorrectionMethod, DWIGrouping, Provenance
-from .report import processing_steps, shell_label
-from .validation import BACKEND_DESCRIPTIONS, BACKENDS
+from .report import shell_label
 
 #: Provenance value -> (fill, stroke).
 _PROVENANCE_COLORS = {
@@ -99,113 +101,108 @@ _WHY_CONCAT = {
     'is its own output.',
 }
 
+#: The root class every rule is scoped under, so the page can be inlined
+#: directly into the subject report (a Bootstrap document) without its global
+#: ``body``/``h1``/``h2`` styles leaking out, and without Bootstrap's ``.badge``
+#: / ``code`` / heading rules leaking in. Also the standalone page's container.
+ROOT_CLASS = 'qsi-grouping'
+
 _CSS = """
-:root{color-scheme:light}
-*{box-sizing:border-box}
-body{margin:0 auto;max-width:960px;padding:28px 24px;background:#f8fafc;color:#0f172a;
+.qsi-grouping{color-scheme:light;box-sizing:border-box;margin:0 auto;max-width:960px;
+  padding:28px 24px;background:#f8fafc;color:#0f172a;line-height:1.4;
   font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}
-h1{font-size:20px;margin:0 0 2px}
-h2{font-size:15px;margin:26px 0 10px;color:#334155}
-.tagline{color:#475569;font-size:13.5px;margin:2px 0 8px}
-.legend{font-size:12px;color:#64748b;margin:0}
-.chip{display:inline-block;border:1.5px solid;border-radius:99px;padding:1px 9px;
-  font-size:11.5px}
-.chip.small{padding:0 7px;font-size:10.5px}
-.est-rail{display:flex;gap:14px;flex-wrap:wrap}
-.est{flex:1 1 280px;max-width:440px;border:2px solid;border-radius:10px;background:#fff;
-  overflow:hidden;transition:box-shadow .1s}
-.est-head{padding:8px 12px;font-size:13.5px;display:flex;align-items:center;gap:8px}
-.est-body{padding:8px 12px 10px}
-.badge{display:inline-flex;align-items:center;justify-content:center;width:20px;
-  height:20px;border:2px solid;border-radius:50%;font-weight:700;font-size:11px;
-  background:#fff;flex:none}
-.badge.inline{width:16px;height:16px;font-size:9.5px;vertical-align:-3px;margin:0 2px}
-.method{font-weight:600;font-size:12.5px;margin:0 0 3px}
-.explain{font-size:11.5px;color:#475569;margin:0 0 6px;line-height:1.45}
-.blips{display:flex;gap:8px;align-items:center;font-size:11.5px;font-weight:600;
-  background:#f1f5f9;border-radius:6px;padding:4px 10px;margin:0 0 6px;width:fit-content}
-.blips .vs{color:#64748b}
-.srcs{font-size:11px;color:#475569;margin:0 0 4px}
-.why{font-size:11px;margin:6px 0 0;line-height:1.45}
-.why code{font-size:10.5px;background:#f1f5f9;padding:0 3px;border-radius:3px;
-  color:inherit}
-.unused{font-weight:400;font-size:11px;color:#64748b}
-.output{background:#fff;border:1.5px solid #cbd5e1;border-radius:12px;margin:0 0 18px;
-  padding:0 0 6px;overflow:hidden}
-.out-head{background:#0f172a;color:#fff;padding:9px 14px;display:flex;gap:9px;
-  align-items:center}
-.out-name{font-weight:650;font-size:13px;font-family:ui-monospace,Menlo,monospace}
-.out-count{margin-left:auto;font-size:11.5px;color:#94a3b8}
-.out-why{padding:7px 14px 2px;color:#475569}
-.dgroup{margin:8px 12px;border:1px solid #e2e8f0;border-left:5px solid;border-radius:7px;
-  padding:7px 10px;background:#fcfdfe}
-.dg-head{font-size:12.5px;display:flex;gap:7px;align-items:baseline;flex-wrap:wrap}
-.dg-sig{color:#64748b;font-size:11.5px}
-.dg-corr{margin-left:auto;font-size:11.5px}
-.prov-word{font-size:10.5px}
-.losing{color:#94a3b8;font-size:10.5px}
-.nocorr{color:#b91c1c;font-weight:600}
-.pol{font-size:11px}
-.scan{display:flex;align-items:center;gap:7px;font-size:11.5px;padding:2.5px 0 0 20px}
-.scan code{background:none;color:#334155}
-.shells{color:#0e7490;font-size:10.5px;background:#ecfeff;border-radius:4px;padding:0 5px}
-.borrow{font-size:11.5px;color:#475569;margin:4px 14px;background:#f8fafc;
+.qsi-grouping *{box-sizing:border-box}
+.qsi-grouping code{font-family:ui-monospace,Menlo,monospace;color:inherit}
+.qsi-grouping h1{font-size:20px;font-weight:700;line-height:1.2;margin:0 0 2px}
+.qsi-grouping h2{font-size:15px;font-weight:700;line-height:1.2;margin:26px 0 10px;
+  color:#334155}
+.qsi-grouping .tagline{color:#475569;font-size:13.5px;margin:2px 0 8px}
+.qsi-grouping .legend{font-size:12px;color:#64748b;margin:0}
+.qsi-grouping .chip{display:inline-block;border:1.5px solid;border-radius:99px;
+  padding:1px 9px;font-size:11.5px}
+.qsi-grouping .chip.small{padding:0 7px;font-size:10.5px}
+.qsi-grouping .est-rail{display:flex;gap:14px;flex-wrap:wrap}
+.qsi-grouping .est{flex:1 1 280px;max-width:440px;border:2px solid;border-radius:10px;
+  background:#fff;overflow:hidden;transition:box-shadow .1s}
+.qsi-grouping .est-head{padding:8px 12px;font-size:13.5px;display:flex;
+  align-items:center;gap:8px}
+.qsi-grouping .est-body{padding:8px 12px 10px}
+.qsi-grouping .badge{display:inline-flex;align-items:center;justify-content:center;
+  width:20px;height:20px;padding:0;line-height:1;border:2px solid;border-radius:50%;
+  font-weight:700;font-size:11px;background:#fff;flex:none}
+.qsi-grouping .badge.inline{width:16px;height:16px;font-size:9.5px;
+  vertical-align:-3px;margin:0 2px}
+.qsi-grouping .method{font-weight:600;font-size:12.5px;margin:0 0 3px}
+.qsi-grouping .explain{font-size:11.5px;color:#475569;margin:0 0 6px;line-height:1.45}
+.qsi-grouping .blips{display:flex;gap:8px;align-items:center;font-size:11.5px;
+  font-weight:600;background:#f1f5f9;border-radius:6px;padding:4px 10px;margin:0 0 6px;
+  width:fit-content}
+.qsi-grouping .blips .vs{color:#64748b}
+.qsi-grouping .srcs{font-size:11px;color:#475569;margin:0 0 4px}
+.qsi-grouping .why{font-size:11px;margin:6px 0 0;line-height:1.45}
+.qsi-grouping .why code{font-size:10.5px;background:#f1f5f9;padding:0 3px;
+  border-radius:3px;color:inherit}
+.qsi-grouping .unused{font-weight:400;font-size:11px;color:#64748b}
+.qsi-grouping .output{background:#fff;border:1.5px solid #cbd5e1;border-radius:12px;
+  margin:0 0 18px;padding:0 0 6px;overflow:hidden}
+.qsi-grouping .out-head{background:#0f172a;color:#fff;padding:9px 14px;display:flex;
+  gap:9px;align-items:center}
+.qsi-grouping .out-name{font-weight:650;font-size:13px;
+  font-family:ui-monospace,Menlo,monospace}
+.qsi-grouping .out-count{margin-left:auto;font-size:11.5px;color:#94a3b8}
+.qsi-grouping .out-why{padding:7px 14px 2px;color:#475569}
+.qsi-grouping .dgroup{margin:8px 12px;border:1px solid #e2e8f0;border-left:5px solid;
+  border-radius:7px;padding:7px 10px;background:#fcfdfe}
+.qsi-grouping .dg-head{font-size:12.5px;display:flex;gap:7px;align-items:baseline;
+  flex-wrap:wrap}
+.qsi-grouping .dg-sig{color:#64748b;font-size:11.5px}
+.qsi-grouping .dg-corr{margin-left:auto;font-size:11.5px}
+.qsi-grouping .prov-word{font-size:10.5px}
+.qsi-grouping .losing{color:#94a3b8;font-size:10.5px}
+.qsi-grouping .nocorr{color:#b91c1c;font-weight:600}
+.qsi-grouping .pol{font-size:11px}
+.qsi-grouping .scan{display:flex;align-items:center;gap:7px;font-size:11.5px;
+  padding:2.5px 0 0 20px}
+.qsi-grouping .scan code{background:none;color:#334155}
+.qsi-grouping .shells{color:#0e7490;font-size:10.5px;background:#ecfeff;
+  border-radius:4px;padding:0 5px}
+.qsi-grouping .borrow{font-size:11.5px;color:#475569;margin:4px 14px;background:#f8fafc;
   border:1px dashed #cbd5e1;border-radius:7px;padding:6px 10px}
-.cunit{border:1.5px dashed #94a3b8;border-radius:9px;margin:8px 12px;padding:0 0 4px;
-  background:#f8fafc}
-.cunit .dgroup{margin:6px 10px;background:#fff}
-.cu-head{font-size:11px;color:#475569;padding:7px 12px 0}
-.cu-note{color:#94a3b8;margin-left:6px}
-.final-concat{font-size:11.5px;font-weight:600;color:#334155;margin:6px 14px 8px}
-.note{font-size:12px;border-radius:8px;padding:8px 12px;margin:0 0 8px;line-height:1.5}
-.note.warning{background:#fffbeb;border:1px solid #fcd34d}
-.note.error{background:#fef2f2;border:1px solid #fca5a5}
-.none{font-size:13px;color:#b91c1c}
-.hl{box-shadow:0 0 0 2.5px #0ea5e9}
-.tabs{display:flex;gap:2px;flex-wrap:wrap;margin:10px 12px 0;
-  border-bottom:1px solid #e2e8f0}
-.tab-btn{border:1px solid transparent;border-bottom:none;background:#f1f5f9;
-  color:#475569;padding:5px 12px;font-size:11.5px;cursor:pointer;
-  border-radius:7px 7px 0 0;font-weight:550}
-.tab-btn:hover{background:#e2e8f0}
-.tab-btn.on{background:#fff;color:#0f172a;border-color:#e2e8f0;margin-bottom:-1px}
-.tab-btn.scheme.on{color:#0369a1}
-.tab-btn.sel::after{content:'\\2022';margin-left:5px;color:#0ea5e9}
-.tab-panel{display:none;padding:10px 14px 6px}
-.tab-panel.on{display:block}
-.tab-desc{font-size:11.5px;color:#475569;margin:0 0 6px}
-.tab-panel ol{margin:6px 0 4px;padding-left:22px;line-height:1.55;color:#334155}
-.tab-panel li.issue{color:#b91c1c;list-style:none;margin-left:-14px}
-.scheme-missing{font-size:12px;color:#94a3b8;padding:6px 0}
+.qsi-grouping .cunit{border:1.5px dashed #94a3b8;border-radius:9px;margin:8px 12px;
+  padding:0 0 4px;background:#f8fafc}
+.qsi-grouping .cunit .dgroup{margin:6px 10px;background:#fff}
+.qsi-grouping .cu-head{font-size:11px;color:#475569;padding:7px 12px 0}
+.qsi-grouping .cu-note{color:#94a3b8;margin-left:6px}
+.qsi-grouping .final-concat{font-size:11.5px;font-weight:600;color:#334155;
+  margin:6px 14px 8px}
+.qsi-grouping .note{font-size:12px;border-radius:8px;padding:8px 12px;margin:0 0 8px;
+  line-height:1.5}
+.qsi-grouping .note.warning{background:#fffbeb;border:1px solid #fcd34d}
+.qsi-grouping .note.error{background:#fef2f2;border:1px solid #fca5a5}
+.qsi-grouping .none{font-size:13px;color:#b91c1c}
+.qsi-grouping .hl{box-shadow:0 0 0 2.5px #0ea5e9}
+.qsi-grouping .scheme-block{margin:10px 12px 0;padding:10px 2px 4px;
+  border-top:1px solid #e2e8f0}
+.qsi-grouping .scheme-label{font-size:11.5px;font-weight:600;color:#0369a1;margin:0 0 8px}
+.qsi-grouping .scheme-missing{font-size:12px;color:#94a3b8;padding:6px 0}
 """
 
-#: Hover an estimation card or letter chip -> highlight everything that
-#: estimation touches (its card, its chips, the groups it corrects).
+#: Everything is scoped to each `.qsi-grouping` root so the script is inert
+#: against the rest of the (Bootstrap) report page and stays correct if more
+#: than one grouping widget is ever inlined into a single document.
 _JS = """
-document.querySelectorAll('[data-est]').forEach(el => {
-  const eid = el.dataset.est;
-  el.addEventListener('mouseenter', () => {
-    document.querySelectorAll('[data-est]').forEach(other => {
-      if (other.dataset.est === eid) other.classList.add('hl');
+document.querySelectorAll('.qsi-grouping').forEach(root => {
+  // Hover an estimation card or letter chip -> highlight everything that
+  // estimation touches (its card, its chips, the groups it corrects).
+  root.querySelectorAll('[data-est]').forEach(el => {
+    const eid = el.dataset.est;
+    el.addEventListener('mouseenter', () => {
+      root.querySelectorAll('[data-est]').forEach(other => {
+        if (other.dataset.est === eid) other.classList.add('hl');
+      });
     });
-  });
-  el.addEventListener('mouseleave', () => {
-    document.querySelectorAll('.hl').forEach(other => other.classList.remove('hl'));
-  });
-});
-
-// Tabs: click a tab button to reveal its panel; scoped to each output box so
-// buttons in one box never switch another. The resize nudge lets a viewer that
-// was in a hidden tab lay out its canvas the first time it is shown.
-document.querySelectorAll('.output').forEach(box => {
-  box.querySelectorAll('.tab-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const key = btn.dataset.tab;
-      box.querySelectorAll('.tab-btn').forEach(
-        b => b.classList.toggle('on', b.dataset.tab === key));
-      box.querySelectorAll('.tab-panel').forEach(
-        p => p.classList.toggle('on', p.dataset.tab === key));
-      window.dispatchEvent(new Event('resize'));
+    el.addEventListener('mouseleave', () => {
+      root.querySelectorAll('.hl').forEach(other => other.classList.remove('hl'));
     });
   });
 });
@@ -254,7 +251,7 @@ def _badge(letter: str, stroke: str, eid: str, inline: bool = True) -> str:
     )
 
 
-def _header(grouping: DWIGrouping) -> list[str]:
+def _header(grouping: DWIGrouping, past: bool = False) -> list[str]:
     n_scans = len(grouping.dwi_files)
     n_out = len(grouping.concatenation_groups)
     n_est = len(grouping.estimations)
@@ -267,9 +264,10 @@ def _header(grouping: DWIGrouping) -> list[str]:
             ('from IntendedFor (deprecated)', _PROVENANCE_COLORS['intendedfor']),
         ]
     )
+    processed = 'processed' if past else 'will process'
     return [
         '<header>'
-        f'<h1>How QSIPrep will process sub-{_esc(grouping.subject_id)}&rsquo;s '
+        f'<h1>How QSIPrep {processed} sub-{_esc(grouping.subject_id)}&rsquo;s '
         'diffusion data</h1>',
         f'<p class="tagline">{n_scans} DWI scan{"s" if n_scans != 1 else ""} &rarr; '
         f'{n_out} preprocessed output file{"s" if n_out != 1 else ""}, using '
@@ -309,12 +307,16 @@ def _blip_diagram(grouping: DWIGrouping, estimation) -> list[str]:
     return parts
 
 
-def _estimation_cards(grouping: DWIGrouping, letters: dict[str, str]) -> list[str]:
-    parts = ['<section><h2>Step 1 &mdash; Fieldmaps: how distortion will be measured</h2>']
+def _estimation_cards(
+    grouping: DWIGrouping, letters: dict[str, str], past: bool = False
+) -> list[str]:
+    measured = 'was measured' if past else 'will be measured'
+    parts = [f'<section><h2>Step 1 &mdash; Fieldmaps: how distortion {measured}</h2>']
     if not grouping.estimations:
+        not_corrected = 'was NOT corrected' if past else 'will NOT be corrected'
         parts.append(
-            '<p class="none">No fieldmap estimations: susceptibility distortion '
-            'will NOT be corrected.</p></section>'
+            f'<p class="none">No fieldmap estimations: susceptibility distortion '
+            f'{not_corrected}.</p></section>'
         )
         return parts
 
@@ -396,20 +398,6 @@ def _scan_row(grouping: DWIGrouping, path: str, letters: dict[str, str]) -> str:
     return f'<div class="scan"><code>{_esc(_basename(path))}</code>{shell_span}{chips}</div>'
 
 
-def _preview_list(steps: list[str]) -> list[str]:
-    parts = ['<ol>']
-    for step in steps:
-        if step.startswith('!!'):
-            parts.append(f'<li class="issue">&#10060; {_esc(step.lstrip("! "))}</li>')
-        else:
-            parts.append(f'<li>{_esc(step)}</li>')
-    parts.append('</ol>')
-    return parts
-
-
-_BACKEND_TAB_LABELS = {'fsl': 'FSL', 'tortoise': 'TORTOISE', 'mixed': 'Mixed'}
-
-
 def _load_gradients(path: str):
     """``(bvals, bvecs)`` from a DWI's sidecars, or ``None`` if unreadable.
 
@@ -457,8 +445,8 @@ def _scheme_data(grouping: DWIGrouping, concat) -> dict | None:
     return scheme_payload(panels, meta, files, pes, b0_threshold=get_b0_threshold())
 
 
-def _scheme_tab(grouping: DWIGrouping, concat) -> str:
-    """The sampling-scheme tab body: the interactive viewer, or a notice."""
+def _scheme_view(grouping: DWIGrouping, concat) -> str:
+    """The sampling-scheme body: the interactive viewer, or a notice."""
     data = _scheme_data(grouping, concat)
     if data is None:
         return (
@@ -468,12 +456,9 @@ def _scheme_tab(grouping: DWIGrouping, concat) -> str:
     return scheme_div(data)
 
 
-def _output_boxes(grouping: DWIGrouping, letters: dict[str, str], backend: str) -> list[str]:
-    previews = {b: processing_steps(grouping, b) for b in BACKENDS}
-    parts = [
-        '<section><h2>Step 2 &mdash; Outputs: which scans are combined, '
-        'and how each is corrected</h2>'
-    ]
+def _output_boxes(grouping: DWIGrouping, letters: dict[str, str], past: bool = False) -> list[str]:
+    combined = 'were combined, and how each was' if past else 'are combined, and how each is'
+    parts = [f'<section><h2>Step 2 &mdash; Outputs: which scans {combined} corrected</h2>']
     for concat_key, concat in sorted(grouping.concatenation_groups.items()):
         cfill, cstroke = _PROVENANCE_COLORS[_prov_value(concat.provenance)]
         n_scans = len(concat.dwi_files)
@@ -521,51 +506,28 @@ def _output_boxes(grouping: DWIGrouping, letters: dict[str, str], backend: str) 
             if multi_unit:
                 parts.append('</div>')
         if multi_unit:
+            resampled = 'were' if past else 'are'
             parts.append(
                 f'<p class="final-concat">&#10515; The corrected results of these '
-                f'{len(units)} units are resampled onto one grid and combined into '
-                'this output file.</p>'
+                f'{len(units)} units {resampled} resampled onto one grid and combined '
+                'into this output file.</p>'
             )
 
         for eid, paths in sorted(grouping.borrowed_sources(concat_key).items()):
             _, stroke = _PROVENANCE_COLORS[_prov_value(grouping.estimations[eid].provenance)]
             names = ', '.join(f'<code>{_esc(_basename(path))}</code>' for path in paths)
+            borrows = 'borrowed' if past else 'also borrows'
             parts.append(
                 f'<p class="borrow">&#8618; fieldmap {_badge(letters[eid], stroke, eid)} '
-                f'also borrows b=0 volumes from {names} &mdash; those scans are '
+                f'{borrows} b=0 volumes from {names} &mdash; those scans are '
                 '<b>not</b> part of this output file.</p>'
             )
 
-        # Tabbed footer: the concatenated sampling scheme (shown by default),
-        # then one processing preview per backend. The backend selected on the
-        # command line is flagged with a dot.
-        parts.append('<div class="tabs">')
+        # The concatenated sampling scheme for this output.
         parts.append(
-            '<button class="tab-btn scheme on" data-tab="scheme">'
-            '&#9673; Sampling scheme</button>'
+            '<div class="scheme-block"><p class="scheme-label">&#9673; Sampling scheme</p>'
+            f'{_scheme_view(grouping, concat)}</div>'
         )
-        for name in BACKENDS:
-            if not previews[name].get(concat.output_name):
-                continue
-            sel = ' sel' if name == backend else ''
-            parts.append(
-                f'<button class="tab-btn{sel}" data-tab="{_esc(name)}">'
-                f'{_esc(_BACKEND_TAB_LABELS.get(name, name))}</button>'
-            )
-        parts.append('</div>')
-        parts.append(
-            '<div class="tab-panel scheme on" data-tab="scheme">'
-            f'{_scheme_tab(grouping, concat)}</div>'
-        )
-        for name in BACKENDS:
-            steps = previews[name].get(concat.output_name, [])
-            if not steps:
-                continue
-            parts.append(f'<div class="tab-panel" data-tab="{_esc(name)}">')
-            parts.append(f'<p class="tab-desc">{_esc(BACKEND_DESCRIPTIONS[name])}</p>')
-            parts.extend(_preview_list(steps))
-            parts.append('</div>')
-        parts.append('</div>')
     parts.append('</section>')
     return parts
 
@@ -584,29 +546,57 @@ def _issue_notes(grouping: DWIGrouping) -> list[str]:
     return parts
 
 
-def render_html(grouping: DWIGrouping, backend: str = 'fsl') -> str:
-    """Return a standalone explanatory HTML document for ``grouping``.
+def _body(grouping: DWIGrouping, letters: dict[str, str], past: bool) -> str:
+    """The grouping page's inner markup (no container, styles, or scripts)."""
+    parts = _header(grouping, past)
+    parts.extend(_estimation_cards(grouping, letters, past))
+    parts.extend(_output_boxes(grouping, letters, past))
+    parts.extend(_issue_notes(grouping))
+    return ''.join(parts)
 
-    Every output shows its concatenated sampling scheme by default; the
-    processing previews sit behind per-backend tabs. ``backend`` flags which
-    workflow the user selected on the command line.
+
+def _fragment(grouping: DWIGrouping, past: bool) -> str:
+    """The scoped, self-contained grouping widget: styles + markup + scripts.
+
+    Everything is scoped under :data:`ROOT_CLASS` and carried inline (the shared
+    q-space viewer's assets included), so the fragment drops straight into a host
+    page with no iframe: the host's styles do not reach in, and these do not leak
+    out. ``past`` picks report tense (a run that happened) vs plan tense (a run
+    that has not).
     """
     letters = {
         eid: chr(ord('A') + index) for index, eid in enumerate(sorted(grouping.estimations))
     }
-    parts = _header(grouping)
-    parts.extend(_estimation_cards(grouping, letters))
-    parts.extend(_output_boxes(grouping, letters, backend))
-    parts.extend(_issue_notes(grouping))
-    body = ''.join(parts)
     viewer_css, viewer_js = viewer_assets()
+    return (
+        f'<style>{_CSS}\n{viewer_css}</style>'
+        f'<div class="{ROOT_CLASS}">{_body(grouping, letters, past)}</div>'
+        f'<script>{viewer_js}</script>'
+        f'<script>{_JS}</script>'
+    )
+
+
+def render_report_segment(grouping: DWIGrouping) -> str:
+    """The grouping widget for inlining into the subject report (no iframe).
+
+    The report describes a run that already happened, so the wording is past
+    tense. See :func:`_fragment` for how the styles/scripts stay isolated.
+    """
+    return _fragment(grouping, past=True)
+
+
+def render_html(grouping: DWIGrouping) -> str:
+    """Return a standalone explanatory HTML document for ``grouping``.
+
+    Wraps the grouping fragment in a minimal page shell. Used by
+    ``qsiprep-group --html``, which previews a run that has not happened yet, so
+    the wording is future tense.
+    """
     return (
         '<!doctype html>\n'
         '<html lang="en"><head><meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
         f'<title>DWI grouping for sub-{_esc(grouping.subject_id)}</title>\n'
-        f'<style>{_CSS}\n{viewer_css}</style></head>\n'
-        f'<body>{body}\n'
-        f'<script>{viewer_js}</script>\n'
-        f'<script>{_JS}</script></body></html>'
+        '<style>body{margin:0}</style></head>\n'
+        f'<body>{_fragment(grouping, past=False)}</body></html>'
     )

--- a/qsiprep/grouping/interactive.py
+++ b/qsiprep/grouping/interactive.py
@@ -12,9 +12,9 @@ reads top to bottom as a story:
    hold the scan rows. Every scan appears exactly once; membership in a
    fieldmap estimation is a letter chip on the row, so identity is carried by
    letters (A, B, ...) while color stays dedicated to provenance. Borrowed
-   b=0 sources are called out in a sentence. Each output ends with the
-   plain-language processing steps for the chosen backend, with the other
-   backends collapsed underneath.
+   b=0 sources are called out in a sentence. Each output ends with tabs: an
+   interactive view of its concatenated sampling scheme (shown first) and a
+   plain-language processing preview per backend.
 3. **Notes** - the grouping's warnings and errors.
 
 The page works without JavaScript; a small inline script adds hover
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import html
 
+from ..viz.qspace import q_points, scheme_div, scheme_payload, viewer_assets
+from .metadata import get_b0_threshold, sibling_bval, sibling_bvec
 from .models import CorrectionMethod, DWIGrouping, Provenance
-from .report import processing_steps
-from .validation import BACKENDS
+from .report import processing_steps, shell_label
+from .validation import BACKEND_DESCRIPTIONS, BACKENDS
 
 #: Provenance value -> (fill, stroke).
 _PROVENANCE_COLORS = {
@@ -155,18 +157,26 @@ h2{font-size:15px;margin:26px 0 10px;color:#334155}
 .cu-head{font-size:11px;color:#475569;padding:7px 12px 0}
 .cu-note{color:#94a3b8;margin-left:6px}
 .final-concat{font-size:11.5px;font-weight:600;color:#334155;margin:6px 14px 8px}
-.preview{margin:8px 12px 6px;font-size:12px;background:#f1f5f9;border-radius:8px;
-  padding:7px 12px}
-.preview summary{cursor:pointer;color:#334155;font-size:12px}
-.preview ol{margin:8px 0 4px;padding-left:22px;line-height:1.55;color:#334155}
-.preview li.issue{color:#b91c1c;list-style:none;margin-left:-14px}
-.alt{margin:4px 0 4px 4px}
-.alt summary{font-size:11.5px;color:#64748b}
 .note{font-size:12px;border-radius:8px;padding:8px 12px;margin:0 0 8px;line-height:1.5}
 .note.warning{background:#fffbeb;border:1px solid #fcd34d}
 .note.error{background:#fef2f2;border:1px solid #fca5a5}
 .none{font-size:13px;color:#b91c1c}
 .hl{box-shadow:0 0 0 2.5px #0ea5e9}
+.tabs{display:flex;gap:2px;flex-wrap:wrap;margin:10px 12px 0;
+  border-bottom:1px solid #e2e8f0}
+.tab-btn{border:1px solid transparent;border-bottom:none;background:#f1f5f9;
+  color:#475569;padding:5px 12px;font-size:11.5px;cursor:pointer;
+  border-radius:7px 7px 0 0;font-weight:550}
+.tab-btn:hover{background:#e2e8f0}
+.tab-btn.on{background:#fff;color:#0f172a;border-color:#e2e8f0;margin-bottom:-1px}
+.tab-btn.scheme.on{color:#0369a1}
+.tab-btn.sel::after{content:'\\2022';margin-left:5px;color:#0ea5e9}
+.tab-panel{display:none;padding:10px 14px 6px}
+.tab-panel.on{display:block}
+.tab-desc{font-size:11.5px;color:#475569;margin:0 0 6px}
+.tab-panel ol{margin:6px 0 4px;padding-left:22px;line-height:1.55;color:#334155}
+.tab-panel li.issue{color:#b91c1c;list-style:none;margin-left:-14px}
+.scheme-missing{font-size:12px;color:#94a3b8;padding:6px 0}
 """
 
 #: Hover an estimation card or letter chip -> highlight everything that
@@ -181,6 +191,22 @@ document.querySelectorAll('[data-est]').forEach(el => {
   });
   el.addEventListener('mouseleave', () => {
     document.querySelectorAll('.hl').forEach(other => other.classList.remove('hl'));
+  });
+});
+
+// Tabs: click a tab button to reveal its panel; scoped to each output box so
+// buttons in one box never switch another. The resize nudge lets a viewer that
+// was in a hidden tab lay out its canvas the first time it is shown.
+document.querySelectorAll('.output').forEach(box => {
+  box.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.dataset.tab;
+      box.querySelectorAll('.tab-btn').forEach(
+        b => b.classList.toggle('on', b.dataset.tab === key));
+      box.querySelectorAll('.tab-panel').forEach(
+        p => p.classList.toggle('on', p.dataset.tab === key));
+      window.dispatchEvent(new Event('resize'));
+    });
   });
 });
 """
@@ -214,7 +240,7 @@ def _pe_phrase(pe_dir: str | None) -> str:
 
 def _shell_text(record) -> str:
     if record.shelled is True:
-        return 'b=' + '/'.join(str(int(centre)) for centre in record.shells)
+        return shell_label(record)
     if record.shelled is False:
         return 'non-shelled sampling'
     return ''
@@ -381,6 +407,67 @@ def _preview_list(steps: list[str]) -> list[str]:
     return parts
 
 
+_BACKEND_TAB_LABELS = {'fsl': 'FSL', 'tortoise': 'TORTOISE', 'mixed': 'Mixed'}
+
+
+def _load_gradients(path: str):
+    """``(bvals, bvecs)`` from a DWI's sidecars, or ``None`` if unreadable.
+
+    Uses :func:`dipy.io.read_bvals_bvecs` — the same reader the rest of the
+    pipeline uses — so the report's gradients are parsed identically. ``bvals``
+    is a list of floats and ``bvecs`` a list of ``(x, y, z)`` lists. Returning
+    ``None`` on a missing or malformed sidecar lets the report degrade to a
+    short notice instead of failing.
+    """
+    # Deferred: dipy has a slow import chain the report shouldn't pay for until
+    # a scheme actually needs drawing.
+    from dipy.io import read_bvals_bvecs
+
+    try:
+        bvals, bvecs = read_bvals_bvecs(sibling_bval(path), sibling_bvec(path))
+    except (OSError, ValueError):
+        return None
+    return bvals.tolist(), bvecs.tolist()
+
+
+def _scheme_data(grouping: DWIGrouping, concat) -> dict | None:
+    """Viewer payload for one output's concatenated sampling scheme.
+
+    Each volume becomes a q-space point ``sqrt(b) * bvec`` tagged with its
+    source file and phase-encoding direction, so the viewer can color by
+    either. Returns ``None`` when no member has readable gradients.
+    """
+    coords, meta, files, pes = [], [], [], []
+    for path in concat.dwi_files:
+        loaded = _load_gradients(path)
+        if loaded is None:
+            continue
+        bvals, bvecs = loaded
+        record = grouping.files.get(path)
+        pe = (record.signature.pe_dir if record else None) or 'unknown'
+        if pe not in pes:
+            pes.append(pe)
+        file_index = len(files)
+        files.append(_basename(path))
+        coords.extend(q_points(bvals, bvecs))
+        meta.extend({'b': int(round(bval)), 'file': file_index, 'pe': pe} for bval in bvals)
+    if not coords:
+        return None
+    panels = [{'title': concat.output_name, 'coords': coords}]
+    return scheme_payload(panels, meta, files, pes, b0_threshold=get_b0_threshold())
+
+
+def _scheme_tab(grouping: DWIGrouping, concat) -> str:
+    """The sampling-scheme tab body: the interactive viewer, or a notice."""
+    data = _scheme_data(grouping, concat)
+    if data is None:
+        return (
+            '<p class="scheme-missing">Sampling scheme unavailable '
+            '(no readable <code>.bval</code>/<code>.bvec</code>).</p>'
+        )
+    return scheme_div(data)
+
+
 def _output_boxes(grouping: DWIGrouping, letters: dict[str, str], backend: str) -> list[str]:
     previews = {b: processing_steps(grouping, b) for b in BACKENDS}
     parts = [
@@ -449,24 +536,35 @@ def _output_boxes(grouping: DWIGrouping, letters: dict[str, str], backend: str) 
                 '<b>not</b> part of this output file.</p>'
             )
 
-        steps = previews[backend].get(concat.output_name, [])
-        if steps:
+        # Tabbed footer: the concatenated sampling scheme (shown by default),
+        # then one processing preview per backend. The backend selected on the
+        # command line is flagged with a dot.
+        parts.append('<div class="tabs">')
+        parts.append(
+            '<button class="tab-btn scheme on" data-tab="scheme">'
+            '&#9673; Sampling scheme</button>'
+        )
+        for name in BACKENDS:
+            if not previews[name].get(concat.output_name):
+                continue
+            sel = ' sel' if name == backend else ''
             parts.append(
-                '<details class="preview" open><summary>What will happen to this data '
-                f'(<b>{_esc(backend)}</b> workflow)</summary>'
+                f'<button class="tab-btn{sel}" data-tab="{_esc(name)}">'
+                f'{_esc(_BACKEND_TAB_LABELS.get(name, name))}</button>'
             )
+        parts.append('</div>')
+        parts.append(
+            '<div class="tab-panel scheme on" data-tab="scheme">'
+            f'{_scheme_tab(grouping, concat)}</div>'
+        )
+        for name in BACKENDS:
+            steps = previews[name].get(concat.output_name, [])
+            if not steps:
+                continue
+            parts.append(f'<div class="tab-panel" data-tab="{_esc(name)}">')
+            parts.append(f'<p class="tab-desc">{_esc(BACKEND_DESCRIPTIONS[name])}</p>')
             parts.extend(_preview_list(steps))
-            for other in BACKENDS:
-                other_steps = previews[other].get(concat.output_name, [])
-                if other == backend or not other_steps:
-                    continue
-                parts.append(
-                    f'<details class="alt"><summary>if run with the {_esc(other)} '
-                    'workflow instead&hellip;</summary>'
-                )
-                parts.extend(_preview_list(other_steps))
-                parts.append('</details>')
-            parts.append('</details>')
+            parts.append('</div>')
         parts.append('</div>')
     parts.append('</section>')
     return parts
@@ -489,8 +587,9 @@ def _issue_notes(grouping: DWIGrouping) -> list[str]:
 def render_html(grouping: DWIGrouping, backend: str = 'fsl') -> str:
     """Return a standalone explanatory HTML document for ``grouping``.
 
-    ``backend`` selects which workflow's processing preview is expanded on
-    each output; the other backends are collapsed underneath it.
+    Every output shows its concatenated sampling scheme by default; the
+    processing previews sit behind per-backend tabs. ``backend`` flags which
+    workflow the user selected on the command line.
     """
     letters = {
         eid: chr(ord('A') + index) for index, eid in enumerate(sorted(grouping.estimations))
@@ -500,11 +599,14 @@ def render_html(grouping: DWIGrouping, backend: str = 'fsl') -> str:
     parts.extend(_output_boxes(grouping, letters, backend))
     parts.extend(_issue_notes(grouping))
     body = ''.join(parts)
+    viewer_css, viewer_js = viewer_assets()
     return (
         '<!doctype html>\n'
         '<html lang="en"><head><meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width,initial-scale=1">\n'
         f'<title>DWI grouping for sub-{_esc(grouping.subject_id)}</title>\n'
-        f'<style>{_CSS}</style></head>\n'
-        f'<body>{body}<script>{_JS}</script></body></html>'
+        f'<style>{_CSS}\n{viewer_css}</style></head>\n'
+        f'<body>{body}\n'
+        f'<script>{viewer_js}</script>\n'
+        f'<script>{_JS}</script></body></html>'
     )

--- a/qsiprep/grouping/metadata.py
+++ b/qsiprep/grouping/metadata.py
@@ -43,21 +43,45 @@ FMAP_SUFFIXES = (
     'magnitude2',
 )
 
-#: b-values below this are b=0 (qsiprep's convention, cf. interfaces/eddy.py).
+#: Fallback b=0 threshold, used only when the runtime config is not loaded
+#: (e.g. the ``qsiprep-group`` preview CLI). Matches the ``--b0-threshold``
+#: default; prefer :func:`get_b0_threshold`.
 B0_THRESHOLD = 100.0
+
+
+def get_b0_threshold() -> float:
+    """The active b=0 threshold.
+
+    Uses ``config.workflow.b0_threshold`` (the ``--b0-threshold`` value) when
+    the config is loaded, falling back to :data:`B0_THRESHOLD` otherwise.
+    Diffusion-weighting at or below this is treated as b=0.
+    """
+    from qsiprep import config
+
+    configured = config.workflow.b0_threshold
+    return B0_THRESHOLD if configured is None else float(configured)
+
+
+def _sibling(nii_file: str, ext: str) -> str:
+    for nii_ext in ('.nii.gz', '.nii'):
+        if nii_file.endswith(nii_ext):
+            return nii_file[: -len(nii_ext)] + ext
+    return op.splitext(nii_file)[0] + ext
 
 
 def sibling_bval(nii_file: str) -> str:
     """The FSL ``.bval`` sibling path for a BIDS DWI nii."""
-    for ext in ('.nii.gz', '.nii'):
-        if nii_file.endswith(ext):
-            return nii_file[: -len(ext)] + '.bval'
-    return op.splitext(nii_file)[0] + '.bval'
+    return _sibling(nii_file, '.bval')
+
+
+def sibling_bvec(nii_file: str) -> str:
+    """The FSL ``.bvec`` sibling path for a BIDS DWI nii."""
+    return _sibling(nii_file, '.bvec')
 
 
 def evaluate_shells(
     bvals,
-    b0_threshold: float = B0_THRESHOLD,
+    b0_threshold: float | None = None,
     tol: float = 100.0,
     min_shell_dirs: int = 6,
     max_shells: int = 7,
@@ -82,6 +106,8 @@ def evaluate_shells(
     ``shelled`` is ``None`` (undetermined) when there are no diffusion-weighted
     volumes to classify.
     """
+    if b0_threshold is None:
+        b0_threshold = get_b0_threshold()
     non_b0 = np.asarray(bvals, dtype=float).reshape(-1)
     non_b0 = non_b0[non_b0 >= b0_threshold]
     if non_b0.size == 0:

--- a/qsiprep/grouping/report.py
+++ b/qsiprep/grouping/report.py
@@ -45,11 +45,25 @@ def _basename(path: str) -> str:
     return op.basename(path)
 
 
+def round_bval(bval) -> int:
+    """A b-value rounded to the nearest 100 for display.
+
+    Small acquisition deviations (e.g. 1585, 4985) should not read as distinct
+    shells. The JS viewer (``qsiprep/data/qspace_viewer.js`` ``roundB``) applies
+    the same rule, so every b-value shown to a reader is rounded consistently.
+    """
+    return int((bval + 50) // 100) * 100
+
+
+def shell_label(record) -> str:
+    """``b=<v>/<v>...`` of a shelled record's centres, rounded for display."""
+    return 'b=' + '/'.join(dict.fromkeys(str(round_bval(c)) for c in record.shells))
+
+
 def _shell_tag(record) -> str:
     """Bracketed sampling-scheme annotation for a DWI file line."""
     if record.shelled is True:
-        shells = '/'.join(str(int(centre)) for centre in record.shells)
-        return f' [shelled: b={shells}]'
+        return f' [shelled: {shell_label(record)}]'
     if record.shelled is False:
         return ' [non-shelled q-space sampling]'
     return ''

--- a/qsiprep/interfaces/__init__.py
+++ b/qsiprep/interfaces/__init__.py
@@ -5,7 +5,7 @@ from .confounds import DMRISummary, GatherConfounds
 from .fmap import FieldToHz, FieldToRadS, Phasediff2Fieldmap, Phases2Fieldmap
 from .freesurfer import StructuralReference
 from .images import Conform, ConformDwi, IntraModalMerge, ValidateImage
-from .reports import AboutSummary, SubjectSummary
+from .reports import AboutSummary, InteractiveReport, SubjectSummary
 from .utils import AddTSVHeader, ConcatAffines
 
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
     'StructuralReference',
     'ValidateImage',
     'AboutSummary',
+    'InteractiveReport',
     'SubjectSummary',
     'AddTSVHeader',
     'ConcatAffines',

--- a/qsiprep/interfaces/reports.py
+++ b/qsiprep/interfaces/reports.py
@@ -13,13 +13,9 @@ import re
 import time
 from collections import defaultdict
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import nibabel as nb
 import numpy as np
 import pandas as pd
-import seaborn as sns
-from matplotlib import animation
 from nilearn.maskers import NiftiLabelsMasker
 from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
@@ -297,6 +293,10 @@ class GradientPlotInputSpec(BaseInterfaceInputSpec):
         File(exists=True), mandatory=True, desc='bvals from DWISplit'
     )
     source_files = traits.List(desc='source file for each gradient')
+    source_pe_dirs = traits.Dict(
+        desc='map from source file path to PhaseEncodingDirection, so the viewer '
+        'can color by phase encoding as well as by source file'
+    )
     final_bvec_file = File(exists=True, desc='bval file')
 
 
@@ -309,103 +309,51 @@ class GradientPlot(SummaryInterface):
     output_spec = GradientPlotOutputSpec
 
     def _run_interface(self, runtime):
-        outfile = os.path.join(runtime.cwd, 'bvec_plot.gif')
-        sns.set_style('whitegrid')
-        sns.set_context('paper', font_scale=0.8)
+        from ..grouping.metadata import get_b0_threshold
+        from ..viz.qspace import q_points, scheme_iframe, scheme_payload
 
+        outfile = os.path.join(runtime.cwd, 'sampling_scheme.html')
         orig_bvecs = concatenate_bvecs(self.inputs.orig_bvec_files)
         bvals = concatenate_bvals(self.inputs.orig_bval_files, None)
-        if isdefined(self.inputs.source_files):
-            file_array = np.array(self.inputs.source_files)
-            _, filenums = np.unique(file_array, return_inverse=True)
-        else:
-            filenums = np.ones_like(bvals)
 
-        # Account for the possibility that this is a PE Pair average
+        # One color category per source file, plus each file's phase-encoding
+        # direction, so the viewer can color by either.
+        if isdefined(self.inputs.source_files):
+            labels, filenums = np.unique(np.array(self.inputs.source_files), return_inverse=True)
+            files = [op.basename(label) for label in labels]
+        else:
+            labels = np.array(['dwi'])
+            filenums = np.zeros(len(bvals), dtype=int)
+            files = ['dwi']
+        # A PE-pair average carries two source files per volume; keep the first.
         if len(filenums) == len(bvals) * 2:
             filenums = filenums[: len(bvals)]
 
-        # Plot the final bvecs if provided
-        final_bvecs = None
-        if isdefined(self.inputs.final_bvec_file):
-            final_bvecs = np.loadtxt(self.inputs.final_bvec_file).T
+        pe_map = self.inputs.source_pe_dirs if isdefined(self.inputs.source_pe_dirs) else {}
+        file_pes = [pe_map.get(str(label)) or 'unknown' for label in labels]
+        pes = list(dict.fromkeys(file_pes))
 
-        plot_gradients(bvals, orig_bvecs, filenums, outfile, final_bvecs)
+        panels = [
+            {'title': 'Acquired (original b-vectors)', 'coords': q_points(bvals, orig_bvecs)}
+        ]
+        if isdefined(self.inputs.final_bvec_file):
+            final_bvecs = concatenate_bvecs([self.inputs.final_bvec_file])
+            panels.append(
+                {
+                    'title': 'After preprocessing (rotated b-vectors)',
+                    'coords': q_points(bvals, final_bvecs),
+                }
+            )
+
+        meta = [
+            {'b': int(round(float(bval))), 'file': int(filenum), 'pe': file_pes[filenum]}
+            for bval, filenum in zip(bvals, filenums, strict=True)
+        ]
+        data = scheme_payload(panels, meta, list(files), pes=pes, b0_threshold=get_b0_threshold())
+        with open(outfile, 'w') as fobj:
+            fobj.write(scheme_iframe(data))
         self._results['plot_file'] = outfile
         return runtime
-
-
-def plot_gradients(bvals, orig_bvecs, source_filenums, output_fname, final_bvecs=None, frames=60):
-    qrads = np.sqrt(bvals)
-    qvecs = qrads[:, np.newaxis] * orig_bvecs
-    qx, qy, qz = qvecs.T
-    maxvals = qvecs.max(0)
-    minvals = qvecs.min(0)
-    total_max = max(np.abs(maxvals).max(), np.abs(minvals).max())
-
-    def force_scaling(ax):
-        # trick to force equal aspect on all 3 axes
-        for direction in (-1, 1):
-            for point in np.diag(direction * total_max * np.array([1, 1, 1])):
-                ax.plot([point[0]], [point[1]], [point[2]], 'w')
-
-    def add_lines(ax):
-        labels = ['L', 'P', 'S']
-        for axnum in range(3):
-            minvec = np.zeros(3)
-            maxvec = np.zeros(3)
-            minvec[axnum] = minvals[axnum]
-            maxvec[axnum] = maxvals[axnum]
-            x, y, z = np.column_stack([minvec, maxvec])
-            ax.plot(x, y, z, color='k')
-            txt_pos = maxvec + 5
-            ax.text(txt_pos[0], txt_pos[1], txt_pos[2], labels[axnum], size=8, zorder=1, color='k')
-
-    if final_bvecs is not None:
-        if final_bvecs.shape[0] == 3:
-            final_bvecs = final_bvecs.T
-        fqx, fqy, fqz = (qrads[:, np.newaxis] * final_bvecs).T
-        fig, axes = plt.subplots(
-            nrows=1, ncols=2, figsize=(10, 5), subplot_kw={'projection': '3d'}
-        )
-        orig_ax = axes[0]
-        final_ax = axes[1]
-        axes_list = [orig_ax, final_ax]
-        final_ax.scatter(fqx, fqy, fqz, c=source_filenums, marker='+')
-        orig_ax.scatter(qx, qy, qz, c=source_filenums, marker='+')
-        final_ax.axis('off')
-        add_lines(final_ax)
-        final_ax.set_title('After Preprocessing')
-    else:
-        fig, orig_ax = plt.subplots(
-            nrows=1, ncols=1, figsize=(10, 5), subplot_kw={'aspect': 'equal', 'projection': '3d'}
-        )
-        axes_list = [orig_ax]
-        orig_ax.scatter(qx, qy, qz, c=source_filenums, marker='+')
-
-    fig.tight_layout()
-    orig_ax.axis('off')
-    orig_ax.set_title('Original Scheme')
-    add_lines(orig_ax)
-    force_scaling(orig_ax)
-    # Animate rotating the axes
-    rotate_amount = np.ones(frames) * 180 / frames
-    stay_put = np.zeros_like(rotate_amount)
-    rotate_azim = np.concatenate([rotate_amount, stay_put, -rotate_amount, stay_put])
-    rotate_elev = np.concatenate([stay_put, rotate_amount, stay_put, -rotate_amount])
-    plt.tight_layout()
-
-    def rotate(i):
-        for ax in axes_list:
-            ax.azim += rotate_azim[i]
-            ax.elev += rotate_elev[i]
-        return tuple(axes_list)
-
-    anim = animation.FuncAnimation(fig, rotate, frames=frames * 4, interval=20, blit=False)
-    anim.save(output_fname, writer='imagemagick', fps=32)
-
-    plt.close(fig)
-    fig = None
 
 
 def topup_selection_to_report(
@@ -702,15 +650,3 @@ def calculate_motion_summary(confounds_tsv):
         'max_rel_rotation': compare_series('max_rel_rotation', max),
         'max_rel_translation': compare_series('max_rel_translation', max),
     }
-
-
-def _filename_to_colors(labels_column, colormap='rainbow'):
-    cmap = mpl.cm.get_cmap(colormap)
-    labels, _ = pd.factorize(labels_column)
-    n_samples = labels.shape[0]
-    max_label = labels.max()
-    if max_label == 0:
-        return [(1.0, 0.0, 0.0)] * n_samples
-    labels = labels / max_label
-    colors = np.array([cmap(label) for label in labels])
-    return colors.tolist()

--- a/qsiprep/interfaces/reports.py
+++ b/qsiprep/interfaces/reports.py
@@ -331,7 +331,7 @@ class GradientPlot(SummaryInterface):
 
     def _run_interface(self, runtime):
         from ..grouping.metadata import get_b0_threshold
-        from ..viz.qspace import q_points, scheme_iframe, scheme_payload
+        from ..viz.qspace import q_points, scheme_fragment, scheme_payload
 
         outfile = os.path.join(runtime.cwd, 'sampling_scheme.html')
         orig_bvecs = concatenate_bvecs(self.inputs.orig_bvec_files)
@@ -372,7 +372,7 @@ class GradientPlot(SummaryInterface):
         ]
         data = scheme_payload(panels, meta, list(files), pes=pes, b0_threshold=get_b0_threshold())
         with open(outfile, 'w') as fobj:
-            fobj.write(scheme_iframe(data))
+            fobj.write(scheme_fragment(data))
         self._results['plot_file'] = outfile
         return runtime
 

--- a/qsiprep/interfaces/reports.py
+++ b/qsiprep/interfaces/reports.py
@@ -285,6 +285,27 @@ class TopupSummary(SummaryInterface):
         return TOPUP_TEMPLATE.format(summary=self.inputs.summary)
 
 
+class InteractiveReportInputSpec(BaseInterfaceInputSpec):
+    segment = Str(mandatory=True, desc='pre-rendered HTML segment to write as a reportlet')
+
+
+class InteractiveReport(SummaryInterface):
+    """Write a pre-rendered, self-contained HTML segment as a reportlet.
+
+    The segment is a scoped fragment (its own inline ``<style>``/``<script>``,
+    e.g. the DWI grouping widget) that nireports inlines directly into the
+    report. Unlike the other summaries, the HTML is assembled by the caller (the
+    grouping page is built from a rich Python object at workflow-construction
+    time) and passed straight through, so it can be sunk with the standard
+    :class:`~qsiprep.interfaces.bids.DerivativesDataSink` provenance.
+    """
+
+    input_spec = InteractiveReportInputSpec
+
+    def _generate_segment(self):
+        return self.inputs.segment
+
+
 class GradientPlotInputSpec(BaseInterfaceInputSpec):
     orig_bvec_files = InputMultiObject(
         File(exists=True), mandatory=True, desc='bvecs from DWISplit'

--- a/qsiprep/tests/test_grouping_viz.py
+++ b/qsiprep/tests/test_grouping_viz.py
@@ -45,17 +45,35 @@ def test_render_html_shows_each_scan_once_per_output(tmp_path, scenario):
     assert page.count('class="scan"') == expected
 
 
-def test_render_html_previews_every_backend(tmp_path):
+def test_grouping_display_omits_workflow_processing_previews(tmp_path):
+    """The step-by-step processing narrative lives in a separate workflow
+    display, not the grouping page: no backend tabs and no per-backend step
+    text, but the concatenated sampling scheme stays."""
     grouping = load_scenario('hcp_style', tmp_path, strict=False)
-    page = render_html(grouping, backend='tortoise')
-    # The sampling scheme is the default tab; each backend has its own preview
-    # tab, and the one selected on the command line is flagged.
-    assert 'data-tab="scheme"' in page
-    for backend in ('fsl', 'tortoise', 'mixed'):
-        assert f'data-tab="{backend}"' in page
-    assert 'class="tab-btn sel" data-tab="tortoise"' in page
-    assert 'DRBUDDI' in page
-    assert 'TOPUP' in page
+    page = render_html(grouping)
+    assert 'tab-btn' not in page
+    assert 'data-tab=' not in page
+    assert 'TOPUP estimates' not in page
+    assert 'eddy corrects' not in page
+    # The sampling scheme is still shown, directly (no tab).
+    assert 'scheme-block' in page
+    assert 'qspace-viewer' in page
+
+
+def test_report_is_past_tense_and_plan_is_future_tense(tmp_path):
+    """The report describes a run that happened (past tense); the CLI plan page
+    previews one that has not yet (future tense). Same markup, different wording."""
+    from qsiprep.grouping import render_report_segment
+
+    grouping = load_scenario('hcp_style', tmp_path, strict=False)
+    plan = render_html(grouping)
+    report = render_report_segment(grouping)
+    assert 'How QSIPrep will process' in plan
+    assert 'how distortion will be measured' in plan
+    assert 'How QSIPrep processed' in report
+    assert 'how distortion was measured' in report
+    assert 'were combined, and how each was corrected' in report
+    assert 'will process' not in report
 
 
 def test_render_html_marks_borrowed_sources(tmp_path):
@@ -73,6 +91,49 @@ def test_render_html_is_self_contained(tmp_path):
     page = render_html(grouping)
     assert 'src="http' not in page
     assert 'href="http' not in page
+
+
+def test_render_report_segment_inlines_scoped_and_self_contained(tmp_path):
+    """The report fragment inlines natively (no iframe, no document wrapper),
+    carries its own assets, and scopes every style rule under the container so
+    it neither restyles the host report nor leaks in."""
+    import re
+
+    from qsiprep.grouping import render_report_segment
+    from qsiprep.grouping.interactive import ROOT_CLASS
+
+    grouping = load_scenario('hcp_style', tmp_path, strict=False)
+    segment = render_report_segment(grouping)
+
+    # Inlines directly: no iframe and no full-document wrapper.
+    assert '<iframe' not in segment
+    lowered = segment.lower()
+    assert '<!doctype' not in lowered
+    assert '<body' not in lowered
+    # One scoping container holds the whole widget.
+    assert f'<div class="{ROOT_CLASS}">' in segment
+    # Self-contained: no external assets.
+    assert 'src="http' not in segment
+    assert 'href="http' not in segment
+
+    # Every grouping rule is scoped: no bare body/h1/h2/.badge selector that
+    # would reach out into (or be reached by) the report's Bootstrap CSS.
+    style = re.search(r'<style>(.*?)</style>', segment, re.S).group(1)
+    grouping_css = style.split('.qspace-viewer', 1)[0]  # drop the shared viewer CSS
+    for bare in ('\nbody{', '\nh1{', '\nh2{', '\n.badge{', '\n.output{', '\n*{'):
+        assert bare not in grouping_css, bare
+    assert f'.{ROOT_CLASS} .badge{{' in grouping_css
+    assert f'.{ROOT_CLASS} .output{{' in grouping_css
+
+
+def test_render_html_wraps_the_report_segment(tmp_path):
+    """The standalone page is the inline fragment inside a minimal page shell."""
+    from qsiprep.grouping.interactive import ROOT_CLASS
+
+    grouping = load_scenario('hcp_style', tmp_path, strict=False)
+    page = render_html(grouping)
+    assert page.startswith('<!doctype html>')
+    assert f'<div class="{ROOT_CLASS}">' in page
 
 
 @pytest.mark.parametrize('scenario', SCENARIOS)
@@ -137,9 +198,9 @@ def test_scheme_tab_builds_viewer_from_gradients(tmp_path):
     distinct = {tuple(round(value, 6) for value in point) for point in coords}
     assert len(distinct) == 4
 
-    tab = interactive._scheme_tab(grouping, concat)
-    assert tab.startswith('<div class="qspace-viewer">')
-    payload = tab.split('application/json">', 1)[1].split('</script>', 1)[0]
+    view = interactive._scheme_view(grouping, concat)
+    assert view.startswith('<div class="qspace-viewer">')
+    payload = view.split('application/json">', 1)[1].split('</script>', 1)[0]
     assert json.loads(payload)['files'] == data['files']
 
 
@@ -155,4 +216,4 @@ def test_scheme_tab_degrades_without_gradients(tmp_path):
     grouping = types.SimpleNamespace(files={str(nii): record})
     concat = types.SimpleNamespace(dwi_files=[str(nii)], output_name='sub-01_desc-preproc_dwi')
     assert interactive._scheme_data(grouping, concat) is None
-    assert 'scheme-missing' in interactive._scheme_tab(grouping, concat)
+    assert 'scheme-missing' in interactive._scheme_view(grouping, concat)

--- a/qsiprep/tests/test_grouping_viz.py
+++ b/qsiprep/tests/test_grouping_viz.py
@@ -48,10 +48,12 @@ def test_render_html_shows_each_scan_once_per_output(tmp_path, scenario):
 def test_render_html_previews_every_backend(tmp_path):
     grouping = load_scenario('hcp_style', tmp_path, strict=False)
     page = render_html(grouping, backend='tortoise')
-    # The chosen backend is the expanded preview; the others are alternates.
-    assert '(<b>tortoise</b> workflow)' in page
-    assert 'if run with the fsl workflow instead' in page
-    assert 'if run with the mixed workflow instead' in page
+    # The sampling scheme is the default tab; each backend has its own preview
+    # tab, and the one selected on the command line is flagged.
+    assert 'data-tab="scheme"' in page
+    for backend in ('fsl', 'tortoise', 'mixed'):
+        assert f'data-tab="{backend}"' in page
+    assert 'class="tab-btn sel" data-tab="tortoise"' in page
     assert 'DRBUDDI' in page
     assert 'TOPUP' in page
 
@@ -87,3 +89,70 @@ def test_render_html_shows_correction_units(tmp_path, scenario):
     expected_units = sum(len(c.correction_units) for c in multi_unit_outputs)
     assert page.count('class="cunit"') == expected_units
     assert page.count('class="final-concat"') == len(multi_unit_outputs)
+
+
+def _write_series(directory, stem, bvals, bvecs, pe):
+    """Write a touch-only nii plus its .bval/.bvec; return (path, record)."""
+    import types
+
+    nii = directory / f'{stem}.nii.gz'
+    nii.touch()
+    (directory / f'{stem}.bval').write_text(' '.join(str(b) for b in bvals))
+    (directory / f'{stem}.bvec').write_text(
+        '\n'.join(' '.join(str(v) for v in row) for row in bvecs)
+    )
+    record = types.SimpleNamespace(signature=types.SimpleNamespace(pe_dir=pe))
+    return str(nii), record
+
+
+def test_scheme_tab_builds_viewer_from_gradients(tmp_path):
+    """The sampling-scheme tab embeds a viewer payload built from the sibling
+    .bval/.bvec, one point per volume tagged by source file and PE direction,
+    with the b0 threshold carried through."""
+    import json
+    import types
+
+    from qsiprep.grouping import interactive
+
+    bvals = [0, 1000, 1000, 2000]
+    # x, y, z rows over four volumes (b=0 has no direction). Non-square so the
+    # reader can orient it unambiguously.
+    bvecs = [[0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+    ap, ap_rec = _write_series(tmp_path, 'sub-01_dir-AP_dwi', bvals, bvecs, 'j-')
+    pa, pa_rec = _write_series(tmp_path, 'sub-01_dir-PA_dwi', bvals, bvecs, 'j')
+    grouping = types.SimpleNamespace(files={ap: ap_rec, pa: pa_rec})
+    concat = types.SimpleNamespace(dwi_files=[ap, pa], output_name='sub-01_desc-preproc_dwi')
+
+    data = interactive._scheme_data(grouping, concat)
+    assert data['files'] == [
+        'sub-01_dir-AP_dwi.nii.gz',
+        'sub-01_dir-PA_dwi.nii.gz',
+    ]
+    assert data['pes'] == ['j-', 'j']
+    assert len(data['meta']) == 8  # four volumes per series
+    assert data['b0Threshold'] == 100.0
+    # AP and PA sample the same directions, so their points coincide: one shared
+    # origin (the two b=0s) plus the three shared directions = four coordinates.
+    coords = data['panels'][0]['coords']
+    distinct = {tuple(round(value, 6) for value in point) for point in coords}
+    assert len(distinct) == 4
+
+    tab = interactive._scheme_tab(grouping, concat)
+    assert tab.startswith('<div class="qspace-viewer">')
+    payload = tab.split('application/json">', 1)[1].split('</script>', 1)[0]
+    assert json.loads(payload)['files'] == data['files']
+
+
+def test_scheme_tab_degrades_without_gradients(tmp_path):
+    """A DWI with no readable .bval/.bvec yields a notice, not an error."""
+    import types
+
+    from qsiprep.grouping import interactive
+
+    nii = tmp_path / 'sub-01_dwi.nii.gz'
+    nii.touch()
+    record = types.SimpleNamespace(signature=types.SimpleNamespace(pe_dir='j'))
+    grouping = types.SimpleNamespace(files={str(nii): record})
+    concat = types.SimpleNamespace(dwi_files=[str(nii)], output_name='sub-01_desc-preproc_dwi')
+    assert interactive._scheme_data(grouping, concat) is None
+    assert 'scheme-missing' in interactive._scheme_tab(grouping, concat)

--- a/qsiprep/tests/test_interfaces_diffprep.py
+++ b/qsiprep/tests/test_interfaces_diffprep.py
@@ -603,13 +603,13 @@ def test_diffprep_split_outputs_deobliques_gradients(tmp_path):
     deobliqued = np.array([np.loadtxt(f) for f in deob_files])
     raw = np.array([np.loadtxt(f) for f in raw_files])
 
-    assert np.allclose(emitted, deobliqued, atol=1e-5), (
-        f'gradients are not the mrtrix RAS+ ones:\n{emitted}\nvs\n{deobliqued}'
-    )
+    assert np.allclose(
+        emitted, deobliqued, atol=1e-5
+    ), f'gradients are not the mrtrix RAS+ ones:\n{emitted}\nvs\n{deobliqued}'
     # And on this grid that is a real difference, so the assertion has teeth.
-    assert not np.allclose(deobliqued, raw, atol=1e-3), (
-        'oblique fixture failed to distinguish the two conversions'
-    )
+    assert not np.allclose(
+        deobliqued, raw, atol=1e-3
+    ), 'oblique fixture failed to distinguish the two conversions'
 
 
 def _make_original_with_sidecar(tmp_path, name, pe_dir):

--- a/qsiprep/tests/test_interfaces_diffprep.py
+++ b/qsiprep/tests/test_interfaces_diffprep.py
@@ -603,13 +603,13 @@ def test_diffprep_split_outputs_deobliques_gradients(tmp_path):
     deobliqued = np.array([np.loadtxt(f) for f in deob_files])
     raw = np.array([np.loadtxt(f) for f in raw_files])
 
-    assert np.allclose(
-        emitted, deobliqued, atol=1e-5
-    ), f'gradients are not the mrtrix RAS+ ones:\n{emitted}\nvs\n{deobliqued}'
+    assert np.allclose(emitted, deobliqued, atol=1e-5), (
+        f'gradients are not the mrtrix RAS+ ones:\n{emitted}\nvs\n{deobliqued}'
+    )
     # And on this grid that is a real difference, so the assertion has teeth.
-    assert not np.allclose(
-        deobliqued, raw, atol=1e-3
-    ), 'oblique fixture failed to distinguish the two conversions'
+    assert not np.allclose(deobliqued, raw, atol=1e-3), (
+        'oblique fixture failed to distinguish the two conversions'
+    )
 
 
 def _make_original_with_sidecar(tmp_path, name, pe_dir):

--- a/qsiprep/tests/test_n4_robustness.py
+++ b/qsiprep/tests/test_n4_robustness.py
@@ -199,9 +199,9 @@ def test_anatomical_n4_estimates_on_truncated_but_corrects_the_original(tmp_path
         # and it is apply_bias, not n4_correct, that feeds downstream
         consumers = [k[1] for k in edges if k[0] == 'apply_bias']
         assert consumers, 'apply_bias output goes nowhere'
-        assert not any(k[0] == 'n4_correct' and k[1] != 'apply_bias' for k in edges), (
-            'the N4 output image still reaches something downstream'
-        )
+        assert not any(
+            k[0] == 'n4_correct' and k[1] != 'apply_bias' for k in edges
+        ), 'the N4 output image still reaches something downstream'
 
         assert nodes['n4_correct'].interface.inputs.save_bias is True
         trunc = nodes['truncate_intensity'].interface.inputs

--- a/qsiprep/tests/test_n4_robustness.py
+++ b/qsiprep/tests/test_n4_robustness.py
@@ -199,9 +199,9 @@ def test_anatomical_n4_estimates_on_truncated_but_corrects_the_original(tmp_path
         # and it is apply_bias, not n4_correct, that feeds downstream
         consumers = [k[1] for k in edges if k[0] == 'apply_bias']
         assert consumers, 'apply_bias output goes nowhere'
-        assert not any(
-            k[0] == 'n4_correct' and k[1] != 'apply_bias' for k in edges
-        ), 'the N4 output image still reaches something downstream'
+        assert not any(k[0] == 'n4_correct' and k[1] != 'apply_bias' for k in edges), (
+            'the N4 output image still reaches something downstream'
+        )
 
         assert nodes['n4_correct'].interface.inputs.save_bias is True
         trunc = nodes['truncate_intensity'].interface.inputs

--- a/qsiprep/tests/test_reports.py
+++ b/qsiprep/tests/test_reports.py
@@ -270,11 +270,10 @@ def test_anat_spatial_normalization_reportlet_allows_template_cohort(tmp_path):
         )
 
 
-def test_gradient_plot_emits_interactive_iframe(tmp_path, monkeypatch):
-    """GradientPlot writes a self-contained ``<iframe srcdoc>`` sampling-scheme
-    reportlet with before/after panels, colored by source file, in a form that
-    is charset-independent (pure ASCII)."""
-    import html as html_lib
+def test_gradient_plot_emits_inline_scheme(tmp_path, monkeypatch):
+    """GradientPlot writes a self-contained inline sampling-scheme reportlet
+    (no iframe, so it flows in the report instead of scrolling in a fixed frame)
+    with before/after panels, colored by source file."""
     import json
     import re
 
@@ -302,11 +301,11 @@ def test_gradient_plot_emits_interactive_iframe(tmp_path, monkeypatch):
     out = Path(result.outputs.plot_file)
     assert out.suffix == '.html'
     markup = out.read_text()
-    assert markup.startswith('<iframe')
-    assert markup.isascii()  # decodes correctly under any host-page charset
+    # Inlines directly into the report: no iframe, so no fixed-height scroll frame.
+    assert '<iframe' not in markup
+    assert 'class="qspace-viewer"' in markup
 
-    document = html_lib.unescape(re.search(r'srcdoc="(.*?)"\s', markup, re.S).group(1))
-    payload = re.search(r'application/json">(\{.*?\})</script>', document, re.S).group(1)
+    payload = re.search(r'application/json">(\{.*?\})</script>', markup, re.S).group(1)
     data = json.loads(payload.replace('<\\/', '</'))
     assert [panel['title'] for panel in data['panels']] == [
         'Acquired (original b-vectors)',

--- a/qsiprep/tests/test_reports.py
+++ b/qsiprep/tests/test_reports.py
@@ -29,7 +29,7 @@ def test_subject_summary_counts_inputs_uniquely():
     assert 'inputs 2, outputs 2' in segment
 
 
-@pytest.fixture()
+@pytest.fixture
 def collect_reports(monkeypatch):
     """Replace run_reports with a recorder of the report directories and filenames."""
     from qsiprep.reports import core

--- a/qsiprep/tests/test_reports.py
+++ b/qsiprep/tests/test_reports.py
@@ -242,6 +242,7 @@ def test_anat_spatial_normalization_reportlet_allows_template_cohort(tmp_path):
         )
 
     html_reportlets = [
+        figures_dir / 'sub-01_desc-grouping_T1w.html',
         figures_dir / 'sub-01_desc-summary_T1w.html',
         figures_dir / 'sub-01_desc-conform_T1w.html',
         figures_dir / 'sub-01_desc-about_T1w.html',

--- a/qsiprep/tests/test_reports.py
+++ b/qsiprep/tests/test_reports.py
@@ -29,7 +29,7 @@ def test_subject_summary_counts_inputs_uniquely():
     assert 'inputs 2, outputs 2' in segment
 
 
-@pytest.fixture
+@pytest.fixture()
 def collect_reports(monkeypatch):
     """Replace run_reports with a recorder of the report directories and filenames."""
     from qsiprep.reports import core
@@ -267,3 +267,51 @@ def test_anat_spatial_normalization_reportlet_allows_template_cohort(tmp_path):
         assert (
             reportlet.name in report_html or reportlet.read_text(encoding='utf-8') in report_html
         )
+
+
+def test_gradient_plot_emits_interactive_iframe(tmp_path, monkeypatch):
+    """GradientPlot writes a self-contained ``<iframe srcdoc>`` sampling-scheme
+    reportlet with before/after panels, colored by source file, in a form that
+    is charset-independent (pure ASCII)."""
+    import html as html_lib
+    import json
+    import re
+
+    import numpy as np
+
+    from qsiprep.interfaces.reports import GradientPlot
+
+    # Two DIPY-style (N, 3) split series that sample the same directions.
+    dirs = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+    bvals = [0, 1000, 1000, 2000]
+    for name in ('ap', 'pa'):
+        np.savetxt(tmp_path / f'{name}.bvec', dirs)
+        (tmp_path / f'{name}.bval').write_text(' '.join(str(b) for b in bvals))
+    np.savetxt(tmp_path / 'final.bvec', np.vstack([dirs, dirs]))
+
+    monkeypatch.chdir(tmp_path)
+    result = GradientPlot(
+        orig_bvec_files=[str(tmp_path / 'ap.bvec'), str(tmp_path / 'pa.bvec')],
+        orig_bval_files=[str(tmp_path / 'ap.bval'), str(tmp_path / 'pa.bval')],
+        source_files=['sub-01_dir-AP_dwi.nii.gz'] * 4 + ['sub-01_dir-PA_dwi.nii.gz'] * 4,
+        source_pe_dirs={'sub-01_dir-AP_dwi.nii.gz': 'j-', 'sub-01_dir-PA_dwi.nii.gz': 'j'},
+        final_bvec_file=str(tmp_path / 'final.bvec'),
+    ).run()
+
+    out = Path(result.outputs.plot_file)
+    assert out.suffix == '.html'
+    markup = out.read_text()
+    assert markup.startswith('<iframe')
+    assert markup.isascii()  # decodes correctly under any host-page charset
+
+    document = html_lib.unescape(re.search(r'srcdoc="(.*?)"\s', markup, re.S).group(1))
+    payload = re.search(r'application/json">(\{.*?\})</script>', document, re.S).group(1)
+    data = json.loads(payload.replace('<\\/', '</'))
+    assert [panel['title'] for panel in data['panels']] == [
+        'Acquired (original b-vectors)',
+        'After preprocessing (rotated b-vectors)',
+    ]
+    assert data['files'] == ['sub-01_dir-AP_dwi.nii.gz', 'sub-01_dir-PA_dwi.nii.gz']
+    assert data['pes'] == ['j-', 'j']  # colorable by phase encoding
+    assert {point['pe'] for point in data['meta']} == {'j-', 'j'}
+    assert len(data['meta']) == 8

--- a/qsiprep/viz/qspace.py
+++ b/qsiprep/viz/qspace.py
@@ -87,6 +87,25 @@ def viewer_assets():
     )
 
 
+def document_iframe(document, title='embedded document', height=440):
+    """Wrap a complete HTML document in a self-contained ``<iframe srcdoc>``.
+
+    The frame fully isolates ``document``'s CSS and scripts from the host page,
+    so a full standalone page (its own ``body``/``h1`` styles and all) can be
+    dropped into a report without leaking style. ``height`` is the frame's
+    starting height in pixels; a same-origin document may grow itself past it
+    (see the resize script in :mod:`qsiprep.grouping.interactive`).
+    """
+    # The browser decodes ``srcdoc`` using the *host* page's charset, so make
+    # the value pure ASCII (non-ASCII as numeric entities) to stay correct
+    # regardless of how the surrounding report is served.
+    srcdoc = html.escape(document, quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii')
+    return (
+        f'<iframe title="{html.escape(title, quote=True)}" srcdoc="{srcdoc}" '
+        f'style="width:100%;height:{height}px;border:0" loading="lazy"></iframe>'
+    )
+
+
 def scheme_iframe(data, height=440):
     """A self-contained ``<iframe srcdoc>`` with the viewer and its assets inlined.
 
@@ -100,11 +119,4 @@ def scheme_iframe(data, height=440):
         f'{scheme_div(data)}'
         f'<script>{js}</script>'
     )
-    # The browser decodes ``srcdoc`` using the *host* page's charset, so make
-    # the value pure ASCII (non-ASCII as numeric entities) to stay correct
-    # regardless of how the surrounding report is served.
-    srcdoc = html.escape(document, quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii')
-    return (
-        f'<iframe title="DWI sampling scheme" srcdoc="{srcdoc}" '
-        f'style="width:100%;height:{height}px;border:0" loading="lazy"></iframe>'
-    )
+    return document_iframe(document, title='DWI sampling scheme', height=height)

--- a/qsiprep/viz/qspace.py
+++ b/qsiprep/viz/qspace.py
@@ -1,0 +1,110 @@
+"""Build the interactive q-space sampling-scheme viewer.
+
+Shared by the group report (:mod:`qsiprep.grouping.interactive`) and the subject
+report (:class:`qsiprep.interfaces.reports.GradientPlot`) so gradient schemes
+are depicted identically in both. The self-contained JS/CSS assets live in
+``qsiprep/data/qspace_viewer.{js,css}``.
+
+Two embedding styles are offered:
+
+- :func:`scheme_div` - a bare ``.qspace-viewer`` element for a host page that
+  loads the assets once (via :func:`viewer_assets`) and may hold several viewers.
+- :func:`scheme_iframe` - a self-contained ``<iframe srcdoc>`` that inlines the
+  assets, for isolated contexts such as a nireports reportlet.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import math
+
+from ..data import load
+
+#: Default b=0 threshold for display. Matches ``grouping.metadata.B0_THRESHOLD``
+#: (qsiprep's convention); callers may pass their context's own threshold.
+DEFAULT_B0_THRESHOLD = 100.0
+
+_AXIS_LABELS = ['L', 'P', 'S']
+_AXIS_LABELS_NEG = ['R', 'A', 'I']
+
+#: Minimal reset for the isolated iframe document (the host page has its own).
+_FRAME_CSS = (
+    'html,body{margin:0;padding:0}'
+    "body{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,"
+    'sans-serif;color:#0f172a;background:#fff;padding:6px 8px}'
+)
+
+
+def q_points(bvals, bvecs):
+    """q-space points ``sqrt(b) * bvec`` (b=0 lands at the origin).
+
+    ``bvecs`` is any ``(N, 3)`` sequence (rows are gradient directions).
+    Returns a list of ``[x, y, z]`` Python floats, ready for JSON.
+    """
+    points = []
+    for bval, bvec in zip(bvals, bvecs, strict=True):
+        radius = math.sqrt(bval) if bval > 0 else 0.0
+        points.append([float(radius * bvec[0]), float(radius * bvec[1]), float(radius * bvec[2])])
+    return points
+
+
+def scheme_payload(panels, meta, files, pes, b0_threshold=DEFAULT_B0_THRESHOLD):
+    """Assemble the viewer's JSON payload.
+
+    ``panels`` is ``[{'title': str, 'coords': [[x, y, z], ...]}, ...]`` and
+    ``meta`` is one ``{'b', 'file', 'pe'}`` dict per point, shared across panels.
+    """
+    return {
+        'panels': panels,
+        'meta': meta,
+        'files': files,
+        'pes': pes,
+        'axisLabels': _AXIS_LABELS,
+        'axisLabelsNeg': _AXIS_LABELS_NEG,
+        'b0Threshold': b0_threshold,
+    }
+
+
+def _embedded_json(data):
+    # Escape ``</`` so an unlucky string cannot close the surrounding <script>.
+    return json.dumps(data).replace('</', '<\\/')
+
+
+def scheme_div(data):
+    """A bare ``.qspace-viewer`` element. The host page supplies the JS/CSS once."""
+    return (
+        '<div class="qspace-viewer">'
+        f'<script type="application/json">{_embedded_json(data)}</script></div>'
+    )
+
+
+def viewer_assets():
+    """The viewer ``(css, js)`` text, for a page that embeds the viewer inline."""
+    return (
+        load.readable('qspace_viewer.css').read_text(),
+        load.readable('qspace_viewer.js').read_text(),
+    )
+
+
+def scheme_iframe(data, height=440):
+    """A self-contained ``<iframe srcdoc>`` with the viewer and its assets inlined.
+
+    For isolated contexts (a nireports reportlet) where each widget carries its
+    own copy of the code and cannot rely on the host page's scripts.
+    """
+    css, js = viewer_assets()
+    document = (
+        '<!doctype html><meta charset="utf-8">'
+        f'<style>{_FRAME_CSS}{css}</style>'
+        f'{scheme_div(data)}'
+        f'<script>{js}</script>'
+    )
+    # The browser decodes ``srcdoc`` using the *host* page's charset, so make
+    # the value pure ASCII (non-ASCII as numeric entities) to stay correct
+    # regardless of how the surrounding report is served.
+    srcdoc = html.escape(document, quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii')
+    return (
+        f'<iframe title="DWI sampling scheme" srcdoc="{srcdoc}" '
+        f'style="width:100%;height:{height}px;border:0" loading="lazy"></iframe>'
+    )

--- a/qsiprep/viz/qspace.py
+++ b/qsiprep/viz/qspace.py
@@ -9,13 +9,13 @@ Two embedding styles are offered:
 
 - :func:`scheme_div` - a bare ``.qspace-viewer`` element for a host page that
   loads the assets once (via :func:`viewer_assets`) and may hold several viewers.
-- :func:`scheme_iframe` - a self-contained ``<iframe srcdoc>`` that inlines the
-  assets, for isolated contexts such as a nireports reportlet.
+- :func:`scheme_fragment` - a self-contained inline fragment (the viewer plus
+  its assets) that nireports drops straight into the report, so the widget flows
+  in the page instead of scrolling inside a fixed-height iframe.
 """
 
 from __future__ import annotations
 
-import html
 import json
 import math
 
@@ -27,13 +27,6 @@ DEFAULT_B0_THRESHOLD = 100.0
 
 _AXIS_LABELS = ['L', 'P', 'S']
 _AXIS_LABELS_NEG = ['R', 'A', 'I']
-
-#: Minimal reset for the isolated iframe document (the host page has its own).
-_FRAME_CSS = (
-    'html,body{margin:0;padding:0}'
-    "body{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,"
-    'sans-serif;color:#0f172a;background:#fff;padding:6px 8px}'
-)
 
 
 def q_points(bvals, bvecs):
@@ -87,36 +80,14 @@ def viewer_assets():
     )
 
 
-def document_iframe(document, title='embedded document', height=440):
-    """Wrap a complete HTML document in a self-contained ``<iframe srcdoc>``.
+def scheme_fragment(data):
+    """A self-contained inline fragment: the viewer, its assets, and one scheme.
 
-    The frame fully isolates ``document``'s CSS and scripts from the host page,
-    so a full standalone page (its own ``body``/``h1`` styles and all) can be
-    dropped into a report without leaking style. ``height`` is the frame's
-    starting height in pixels; a same-origin document may grow itself past it
-    (see the resize script in :mod:`qsiprep.grouping.interactive`).
-    """
-    # The browser decodes ``srcdoc`` using the *host* page's charset, so make
-    # the value pure ASCII (non-ASCII as numeric entities) to stay correct
-    # regardless of how the surrounding report is served.
-    srcdoc = html.escape(document, quote=True).encode('ascii', 'xmlcharrefreplace').decode('ascii')
-    return (
-        f'<iframe title="{html.escape(title, quote=True)}" srcdoc="{srcdoc}" '
-        f'style="width:100%;height:{height}px;border:0" loading="lazy"></iframe>'
-    )
-
-
-def scheme_iframe(data, height=440):
-    """A self-contained ``<iframe srcdoc>`` with the viewer and its assets inlined.
-
-    For isolated contexts (a nireports reportlet) where each widget carries its
-    own copy of the code and cannot rely on the host page's scripts.
+    For a nireports reportlet that inlines directly into the host report (no
+    iframe), so the widget flows in the page instead of scrolling inside a
+    fixed-height frame. The viewer's ``.qspace-viewer``/``.qs-*`` CSS is
+    host-agnostic (no bare-element rules that could leak), and its JS boots
+    idempotently, so several fragments can coexist in one report.
     """
     css, js = viewer_assets()
-    document = (
-        '<!doctype html><meta charset="utf-8">'
-        f'<style>{_FRAME_CSS}{css}</style>'
-        f'{scheme_div(data)}'
-        f'<script>{js}</script>'
-    )
-    return document_iframe(document, title='DWI sampling scheme', height=height)
+    return f'<style>{css}</style>{scheme_div(data)}<script>{js}</script>'

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -49,6 +49,7 @@ from ..grouping import (
     build_dwi_grouping,
     check_backend,
     describe_processing,
+    render_report_segment,
     report_text,
     to_preproc_units,
 )
@@ -60,6 +61,7 @@ from ..interfaces import (
     BIDSDataGrabber,
     BIDSInfo,
     DerivativesDataSink,
+    InteractiveReport,
     SubjectSummary,
 )
 from ..utils.bids import collect_data
@@ -398,6 +400,37 @@ to workflows in *QSIPrep*'s documentation]\
             f'The DWI grouping for sub-{subject_id} has {len(grouping_errors)} '
             f'unresolvable problem(s):\n{rendered}'
         )
+
+    # Embed the grouping decision page (fieldmap estimations, which scans combine
+    # into each output, and how each is corrected) at the top of the subject
+    # report. Rendered here because it is built from the DWIGrouping object,
+    # which only exists at workflow-construction time. The segment's styles are
+    # scoped so it inlines natively into the report (no iframe).
+    grouping_report = pe.Node(
+        InteractiveReport(segment=render_report_segment(grouping)),
+        name='grouping_report',
+        run_without_submitting=True,
+    )
+    ds_report_grouping = pe.Node(
+        DerivativesDataSink(
+            base_directory=config.execution.output_dir,
+            datatype='figures',
+            desc='grouping',
+            suffix=report_suffix,
+        ),
+        name='ds_report_grouping',
+        run_without_submitting=True,
+    )
+    workflow.connect([
+        (bidssrc, ds_report_grouping, [
+            ((info_modality,
+              fix_multi_source_name,
+              config.workflow.subject_anatomical_reference == 'sessionwise',
+              config.workflow.anat_modality),
+             'source_file'),
+        ]),
+        (grouping_report, ds_report_grouping, [('out_report', 'in_file')]),
+    ])  # fmt:skip
 
     # Each PreprocUnit is one HMC+SDC run. concatenation_scheme maps each
     # unit's preprocessed result to the final output it is combined into. The

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -365,6 +365,10 @@ def init_dwi_finalize_wf(
     btab_t1 = pe.Node(DSIStudioBTable(bvec_convention='DIPY'), name='btab_t1')
     t1_dice_calc = init_mask_overlap_wf(name='t1_dice_calc')
     gradient_plot = pe.Node(GradientPlot(), name='gradient_plot', run_without_submitting=True)
+    gradient_plot.inputs.source_pe_dirs = {
+        path: overrides['PhaseEncodingDirection']
+        for path, overrides in unit.sidecar_overrides().items()
+    }
     ds_report_gradients = pe.Node(
         DerivativesDataSink(
             datatype='figures',


### PR DESCRIPTION
There has historically been a matplotlib-based rotating gif of the sampling scheme. It's a big file and the image quality has always been low. This PR introduces a javascript-based q-space viewer that lets you see where each coordinate came from (which nifti file and which distortion group) and rotate the scheme yourself.