### PR TITLE
Stop DWI summary reportlet duplication

### DIFF
--- a/qsiprep/data/reports-spec.yml
+++ b/qsiprep/data/reports-spec.yml
@@ -9,7 +9,7 @@ sections:
 
 - name: Summary
   reportlets:
-  - bids: {datatype: figures, desc: summary, suffix: [T1w, T2w, dwi]}
+  - bids: {datatype: figures, desc: summary, suffix: [T1w, T2w]}
 
 - name: Anatomical
   reportlets:


### PR DESCRIPTION
With ``--anat-modality none`` there is no anatomical image, so the subject summary is written with a ``dwi`` suffix and shows up at the top of the Diffusion section rather than at the top of the report.
