### PR TITLE
Ignore graphify outputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,4 @@ Dockerfile*    text eol=lf
 *.jpg      binary
 *.nii.gz   binary
 *.gpg      binary
+graphify-out/graph.json merge=graphify

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+graphify-out
+
 .cursor/.cursorenv
 
 # Test data


### PR DESCRIPTION
Just updates the gitignore to ignore graphify outputs.