### PR TITLE
Enforce fixed FOV in figures with context manager

### DIFF
--- a/qsiprep/interfaces/fmap.py
+++ b/qsiprep/interfaces/fmap.py
@@ -48,6 +48,7 @@ from niworkflows.viz.utils import (
 from svgutils.transform import SVGFigure
 
 from ..utils.bids import load_sidecar
+from ..viz.utils import fixed_field_of_view
 from .epi_fmap import (
     _merge_metadata,
     acqp_lines,
@@ -1049,8 +1050,6 @@ class PEPOLARReport(SimpleInterface):
         uncorrected_fa = image.math_img('(a+b)/2', a=fa_up_img, b=fa_down_img)
         corrected_fa = image.math_img('(a+b)/2', a=fa_up_corrected_img, b=fa_down_corrected_img)
 
-        _, crop_offset = image.crop_img(uncorrected_fa, return_offset=True)
-
         compose_view(
             plot_fa_reg(
                 corrected_fa,
@@ -1135,8 +1134,9 @@ def plot_pepolar(
 
         # Generate nilearn figure
         display = plotting.plot_anat(zeros_bg_img, **plot_params)
-        display.add_overlay(blip_up_img, cmap='gray', **image_plot_params)
-        display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
+        with fixed_field_of_view(display):
+            display.add_overlay(blip_up_img, cmap='gray', **image_plot_params)
+            display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
 
         svg = extract_svg(display, compress=compress)
         display.close()
@@ -1166,8 +1166,10 @@ def plot_pepolar(
 
         # Generate nilearn figure
         display = plotting.plot_anat(zeros_bg_img, **blip_down_plot_params)
-        display.add_overlay(blip_down_img, cmap='gray', **image_blip_down_plot_params)
-        display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
+        with fixed_field_of_view(display):
+            display.add_overlay(blip_down_img, cmap='gray', **image_blip_down_plot_params)
+            display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
+
         svg = extract_svg(display, compress=compress)
         display.close()
 
@@ -1229,8 +1231,9 @@ def plot_fa_reg(
 
         # Generate nilearn figure
         display = plotting.plot_anat(zeros_bg_img, **plot_params)
-        display.add_overlay(fa_img, **image_plot_params)
-        # display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
+        with fixed_field_of_view(display):
+            display.add_overlay(fa_img, **image_plot_params)
+            # display.add_contours(seg_contour_img, colors='b', linewidths=0.5)
 
         svg = extract_svg(display, compress=compress)
         display.close()

--- a/qsiprep/tests/test_viz.py
+++ b/qsiprep/tests/test_viz.py
@@ -1,0 +1,146 @@
+"""Tests for the reportlet plotting functions.
+
+Reportlets that show a "before" and an "after" image must display both with the
+same field of view, otherwise the two frames of the flicker animation are not
+comparable.
+"""
+
+import matplotlib as mpl
+import nibabel as nb
+import numpy as np
+import pytest
+
+mpl.use('Agg')
+
+from qsiprep.interfaces import fmap  # noqa: E402
+from qsiprep.viz import utils as viz_utils  # noqa: E402
+
+
+def _grid_img(data, resolution, origin=None):
+    """Build a Nifti1Image on an isotropic RAS-ish grid."""
+    affine = np.diag([resolution, resolution, resolution, 1.0])
+    if origin is None:
+        origin = [-(n * resolution) / 2 for n in data.shape]
+    affine[:3, 3] = origin
+    return nb.Nifti1Image(data.astype('float32'), affine)
+
+
+@pytest.fixture
+def fov_mismatch():
+    """A segmentation plus "before"/"after" images sampled on different grids.
+
+    This mimics DRBUDDI, which writes its corrected images onto a finer grid with
+    a larger field of view than the images it was given.
+    """
+    seg_data = np.zeros((60, 60, 60))
+    seg_data[20:40, 20:40, 20:40] = 1
+    seg = _grid_img(seg_data, 2.0)
+
+    rng = np.random.default_rng(42)
+    # "Before": coarse grid, smaller FOV
+    before = _grid_img(rng.uniform(1, 100, size=(24, 24, 24)), 5.0)
+    # "After": fine grid, larger FOV
+    after = _grid_img(rng.uniform(1, 100, size=(70, 70, 70)), 2.0)
+    return seg, before, after
+
+
+def _capture_axis_limits(monkeypatch, module):
+    """Record the axis limits of every display right before it is rasterized."""
+    captured = []
+    real_extract_svg = module.extract_svg
+
+    def spy(display, compress='auto'):
+        captured.append(
+            {
+                name: (tuple(ax.ax.get_xlim()), tuple(ax.ax.get_ylim()))
+                for name, ax in display.axes.items()
+            }
+        )
+        return real_extract_svg(display, compress=compress)
+
+    monkeypatch.setattr(module, 'extract_svg', spy)
+    return captured
+
+
+def test_plot_pepolar_fov_is_independent_of_the_plotted_image(monkeypatch, fov_mismatch):
+    """The before and after panels share a field of view despite differing grids."""
+    seg, before, after = fov_mismatch
+    from nilearn.image import crop_img
+
+    _, crop_offset = crop_img(seg, return_offset=True)
+    cuts = {'z': [-10.0, 0.0, 10.0], 'x': [-10.0, 0.0, 10.0], 'y': [-10.0, 0.0, 10.0]}
+    captured = _capture_axis_limits(monkeypatch, fmap)
+
+    for img, div_id in ((before, 'moving-image'), (after, 'fixed-image')):
+        fmap.plot_pepolar(
+            img,
+            img,
+            seg,
+            div_id,
+            estimate_brightness=True,
+            cuts=cuts,
+            crop_offset=crop_offset,
+            label='Test',
+            compress=False,
+        )
+
+    # Six panels per call (three orientations x blip up/down), twelve in total.
+    assert len(captured) == 12
+    assert all(limits == captured[0] for limits in captured)
+
+
+def test_plot_fa_reg_fov_is_independent_of_the_plotted_image(monkeypatch, fov_mismatch):
+    """The FA before and after panels share a field of view despite differing grids."""
+    seg, before, after = fov_mismatch
+    from nilearn.image import crop_img
+
+    _, crop_offset = crop_img(seg, return_offset=True)
+    cuts = {'z': [-10.0, 0.0, 10.0], 'x': [-10.0, 0.0, 10.0], 'y': [-10.0, 0.0, 10.0]}
+    captured = _capture_axis_limits(monkeypatch, fmap)
+
+    for img, div_id in ((before, 'moving-image'), (after, 'fixed-image')):
+        fmap.plot_fa_reg(
+            img,
+            seg,
+            div_id,
+            cuts=cuts,
+            crop_offset=crop_offset,
+            label='Test',
+            compress=False,
+        )
+
+    assert len(captured) == 6
+    assert all(limits == captured[0] for limits in captured)
+
+
+def test_plot_denoise_honors_the_crop(monkeypatch, fov_mismatch):
+    """Contours drawn from an uncropped image do not undo the requested crop."""
+    seg, _, _ = fov_mismatch
+    from nilearn.image import crop_img
+
+    cropped_seg, crop_offset = crop_img(seg, return_offset=True)
+    rng = np.random.default_rng(0)
+    # A difference image that is non-zero over the whole, uncropped field of view.
+    contour = _grid_img(rng.normal(size=seg.shape), 2.0)
+    cuts = {'z': [-10.0, 0.0, 10.0], 'x': [-10.0, 0.0, 10.0], 'y': [-10.0, 0.0, 10.0]}
+    captured = _capture_axis_limits(monkeypatch, viz_utils)
+
+    viz_utils.plot_denoise(
+        seg,
+        seg,
+        'moving-image',
+        estimate_brightness=True,
+        cuts=cuts,
+        crop_offset=crop_offset,
+        label='Test',
+        lowb_contour=contour,
+        highb_contour=contour,
+        compress=False,
+    )
+
+    # The plotted extent must match the cropped image, not the full field of view.
+    span = max(cropped_seg.shape) * 2.0
+    for limits in captured:
+        for xlim, ylim in limits.values():
+            assert abs(xlim[1] - xlim[0]) <= span
+            assert abs(ylim[1] - ylim[0]) <= span

--- a/qsiprep/viz/utils.py
+++ b/qsiprep/viz/utils.py
@@ -1,9 +1,34 @@
 """Visualization utilities."""
 
+from contextlib import contextmanager
+
 from lxml import etree
 from nilearn import plotting
 from niworkflows.viz.utils import SVGNS, extract_svg, robust_set_limits, uuid4
 from svgutils.transform import SVGFigure
+
+
+@contextmanager
+def fixed_field_of_view(display):
+    """Keep a nilearn display's field of view fixed while objects are added to it.
+
+    Nilearn grows a display's axes to fit the union of everything drawn on them, so an
+    overlay or contour taken from an image with a larger field of view than the
+    background silently undoes any cropping of the background. When the "before" and
+    "after" images of a reportlet sit on different grids, that leaves the two frames
+    zoomed relative to one another.
+
+    Restoring the limits that the background image established keeps both frames on the
+    same field of view.
+    """
+    limits = {name: (ax.ax.get_xlim(), ax.ax.get_ylim()) for name, ax in display.axes.items()}
+    try:
+        yield display
+    finally:
+        for name, ax in display.axes.items():
+            xlim, ylim = limits[name]
+            ax.ax.set_xlim(*xlim)
+            ax.ax.set_ylim(*ylim)
 
 
 def plot_denoise(
@@ -58,8 +83,9 @@ def plot_denoise(
 
         # Generate nilearn figure
         display = plotting.plot_anat(lowb_nii_cropped, **plot_params)
-        if lowb_contour is not None:
-            display.add_contours(lowb_contour, linewidths=1)
+        with fixed_field_of_view(display):
+            if lowb_contour is not None:
+                display.add_contours(lowb_contour, linewidths=1)
 
         svg = extract_svg(display, compress=compress)
         display.close()
@@ -90,8 +116,9 @@ def plot_denoise(
 
         # Generate nilearn figure
         display = plotting.plot_anat(highb_nii_cropped, **highb_plot_params)
-        if highb_contour is not None:
-            display.add_contours(highb_contour, linewidths=1)
+        with fixed_field_of_view(display):
+            if highb_contour is not None:
+                display.add_contours(highb_contour, linewidths=1)
 
         svg = extract_svg(display, compress=compress)
         display.close()


### PR DESCRIPTION
This should actually fix the issue I was trying to fix in #1100.

It looks like adding an overlay to a nilearn plot overrides the fixed FOV of the underlay, which (for some reason) had different effects in the before and after images for some figures. This adds a context manager to enforce the fixed FOV.
