### PR TITLE
Consolidate `--shoreline-iters`, `--shoreline-model`, `--hmc-transform` under `--shoreline-config`

### DIFF
--- a/docs/notebooks/grouping_tutorial.md
+++ b/docs/notebooks/grouping_tutorial.md
@@ -428,8 +428,8 @@ The grouping describes your *data*. How processing consumes it is a separate
 decision with **two axes**, matching the CLI:
 
 - **`--hmc-method`** picks the head-motion/eddy-current correction: `eddy`
-  (FSL), `tortoise` (TORTOISE's DIFFPREP), or `shoreline` (with
-  `--shoreline-model` naming its signal model).
+  (FSL), `tortoise` (TORTOISE's DIFFPREP), or `shoreline` (with a
+  `--shoreline-config` JSON whose `"model"` names its signal model).
 - **`--sdc-method`** picks the PEPOLAR susceptibility-correction tool chain:
   `topup`, `drbuddi`, or `topup+drbuddi` (TOPUP first, refined by DRBUDDI).
   The `topup` chains require `--hmc-method eddy`, which consumes TOPUP's

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -963,9 +963,9 @@ signal image and its vector is rotated accordingly. A new model is fit on the
 transformed images and their rotated vectors. The leave-one-out procedure is
 then repeated on this updated DWI and gradient set.
 
-If ``"none"`` is specified as the hmc_model, then only the b0 images are used
-and the non-b0 images are transformed based on their nearest b0 image. This
-is probably not a great idea.
+If ``"model": "none"`` is set in ``--shoreline-config``, then only the b0
+images are used and the non-b0 images are transformed based on their nearest
+b0 image. This is probably not a great idea.
 
 Susceptibility distortion correction is run as part of this pipeline to be
 consistent with the ``TOPUP``/``eddy`` workflow.
@@ -1003,6 +1003,40 @@ are saved for each slice for display in a carpet plot-like thing.
         name='qsiprep_hmcsdc_wf',
         dwi_metadata={},
     )
+
+.. _configure_shoreline:
+
+Configuring SHORELine
+^^^^^^^^^^^^^^^^^^^^^
+
+SHORELine's settings are passed to *QSIPrep* as a JSON file with the
+``--shoreline-config`` option, which is only valid with
+``--hmc-method shoreline``. Every key is optional: missing keys take the
+defaults below, and unknown keys or invalid values are an error.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key
+     - Allowed values
+     - Default
+     - Meaning
+   * - ``model``
+     - ``"3dshore"``, ``"tensor"``, ``"none"``
+     - ``"3dshore"``
+     - Signal model used to predict each left-out image. ``"none"`` skips the
+       model and gives each b>0 image the transform of its nearest b=0 image.
+   * - ``iters``
+     - An integer of at least 1 (ignored when ``model`` is ``"none"``)
+     - ``2``
+     - Number of SHORELine iterations.
+   * - ``transform``
+     - ``"Affine"``, ``"Rigid"``
+     - ``"Affine"``
+     - Transformation optimized during head motion correction.
+
+The default configuration can be viewed or downloaded `here
+<https://github.com/PennLINC/qsiprep/blob/main/qsiprep/data/shoreline_params.json>`__.
 
 
 .. _dwi_sdc:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -138,16 +138,29 @@ Head motion correction is selected with ``--hmc-method``, which takes
 ``eddy``, ``shoreline`` or ``tortoise``. (The deprecated ``--hmc-model``
 values map onto these: ``eddy`` is ``--hmc-method eddy``, ``tortoise`` is
 ``--hmc-method tortoise``, and ``3dSHORE``/``tensor``/``none`` are
-``--hmc-method shoreline`` with the matching ``--shoreline-model``.)
+``--hmc-method shoreline`` with the matching SHORELine ``"model"``.)
 
 Choosing ``eddy`` (the default) runs FSL's ``eddy`` for head motion correction
 and eddy current correction. This will work for single-shell and multi-shell
 sampling schemes. The ``shoreline`` option (SHORELine) works for multi-shell,
-Cartesian grid sampling (DSI) and random q-space sampling (CS-DSI); its
-signal model is chosen with ``--shoreline-model``, either ``3dshore`` (the
-default) or ``tensor``.
+Cartesian grid sampling (DSI) and random q-space sampling (CS-DSI). Its
+settings are passed as a JSON file with ``--shoreline-config``, for example:
 
-``--shoreline-model none`` will register all the b=0 images to one another
+.. code-block:: json
+
+   {
+     "model": "tensor",
+     "iters": 2,
+     "transform": "Rigid"
+   }
+
+``"model"`` is the signal model, either ``"3dshore"`` (the default) or
+``"tensor"``; ``"iters"`` is the number of SHORELine iterations (default 2);
+and ``"transform"`` is the transformation optimized during head motion
+correction, ``"Affine"`` (the default) or ``"Rigid"``. Every key is optional.
+See :ref:`configure_shoreline` for details.
+
+Setting ``"model": "none"`` will register all the b=0 images to one another
 and the b>0 images will have the transform from the nearest b=0 image
 applied. This is not recommended. Between ``eddy`` and ``shoreline``, all
 sampling schemes can be motion corrected, though eddy-current correction for

--- a/docs/superpowers/plans/2026-09-11-shoreline-config.md
+++ b/docs/superpowers/plans/2026-09-11-shoreline-config.md
@@ -1,0 +1,1483 @@
+# `--shoreline-config` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` with a single `--shoreline-config` JSON file (issue #1132). Along the way, fix the long-standing bug where the SHORELine iteration count never reached the workflow, and the SHORELine methods text that misreports the model and transform.
+
+**Architecture:** The parser loads and validates the JSON once, in `DeprecationForwardingParser.parse_known_args`, through a new `load_shoreline_config()` in `qsiprep/utils/misc.py`. It writes the resolved values onto the existing internal names `shoreline_model`, `shoreline_iters` and `hmc_transform`, which workflow builders, `utils/plan.py` and QSIPlan's `selection_from_namespace` already read. `parse_args` assigns the SHORELine block to `config.workflow` directly, so the command line stays authoritative on `--config-file` reloads.
+
+**Tech Stack:** Python 3.11, argparse, Nipype workflows, pytest, ruff, Sphinx (reStructuredText).
+
+**Spec:** `docs/superpowers/specs/2026-09-11-shoreline-config-design.md`. Read it before starting; this plan follows it.
+
+## Global Constraints
+
+- Repo root: `/mnt/c/Users/tsalo/Documents/linc/qsiprep`. Branch: `shoreline-config`. The package directory is `qsiprep/` under the root.
+- Python environment: `micromamba run -n linc311 ...`. Never use `lincapps`, `pip install` into any environment, conda, or venv.
+- **QSIPlan version for tests:** `linc311` has an editable development checkout of QSIPlan installed, which makes four tests in `test_plan_cli_spec.py` fail. qsiprep pins `qsiplan >= 0.4.0, < 0.5`, so every test command in this plan runs against released qsiplan 0.4.0 on `PYTHONPATH`, through the helper script from Task 0. `S` below is the scratchpad: `/tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad`. Every test command is written out in full.
+- **Git:**
+  - never run `git stash`;
+  - never `git add -A` or `git add .`; stage files by name;
+  - never edit `docs/changes.md`;
+  - end every commit message with:
+    ```
+    Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+    Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+    ```
+- Style: ruff line length 99, single quotes. Match the surrounding comment density.
+- JSON keys: exactly `model` (`3dshore` | `tensor` | `none`), `iters` (int ≥ 1, any int when `model` is `none`, bools rejected), `transform` (`Affine` | `Rigid`). Shipped defaults: `{"model": "3dshore", "iters": 2, "transform": "Affine"}`.
+- `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` are removed outright, with no deprecation shims.
+- Do **not** file the QSIPlan issue. Its text is drafted for the user in Task 6.
+- Integration tests (`-m integration`) need Docker data and are **not** run locally. Only collection is checked.
+
+## File Map
+
+| File | Responsibility | Task |
+|---|---|---|
+| `qsiprep/data/shoreline_params.json` (create) | Shipped SHORELine defaults | 1 |
+| `qsiprep/utils/misc.py` | `SHORELINE_MODELS`, `SHORELINE_TRANSFORMS`, `load_shoreline_config()` | 1 |
+| `qsiprep/tests/test_cli.py` | Loader unit tests (Task 1); integration flags (Task 4) | 1, 4 |
+| `qsiprep/cli/parser.py` | Flags, resolution, command-line-authoritative config assignment | 2 |
+| `qsiprep/config.py` | `workflow.shoreline_config`, `_paths`, docstrings | 2 |
+| `qsiprep/data/tests/config.toml` | Drop stale SHORELine keys from the eddy fixture | 2 |
+| `qsiprep/tests/test_cli_run.py` | Parser, reload and round-trip tests | 2 |
+| `qsiprep/tests/test_plan_cli_spec.py` | Conformance exemption, selection tests | 2 |
+| `qsiprep/workflows/dwi/hmc_sdc.py` | Pass `shoreline_iters` through (bug fix) | 3 |
+| `qsiprep/workflows/dwi/hmc.py` | Methods-text fixes | 3 |
+| `qsiprep/workflows/dwi/base.py` | Drop the dead check; gate the summary transform | 3 |
+| `qsiprep/interfaces/reports.py` | Optional "HMC Transform" line | 3 |
+| `qsiprep/tests/test_workflows_gradwarp.py`, `test_reports.py`, `test_template_registration_settings.py` | Consumer tests | 3 |
+| `qsiprep/tests/data/shoreline_{none,tensor,rigid}_config.json` (create) | Integration configs | 4 |
+| `docs/quickstart.rst`, `docs/preprocessing.rst`, `docs/notebooks/grouping_tutorial.md` | User docs | 5 |
+
+---
+
+### Task 0: Environment and baseline
+
+**Files:** none in the repo. Creates `S/qsiplan040/` and `S/pytest040.sh`.
+
+- [ ] **Step 1: Confirm the branch and a clean tree**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git branch --show-current && git status --short`
+Expected: `shoreline-config` and no output from `git status --short`.
+
+- [ ] **Step 2: Install qsiplan 0.4.0 into the scratchpad (not into the environment)**
+
+Run:
+```bash
+micromamba run -n linc311 python -m pip install -q --no-deps --target /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/qsiplan040 "qsiplan==0.4.0"
+```
+Expected: exit 0. Skip this step if `S/qsiplan040/qsiplan/__init__.py` already exists.
+
+- [ ] **Step 3: Write the test helper script**
+
+Create `S/pytest040.sh` with this content:
+```bash
+#!/usr/bin/env bash
+# Run qsiprep's pytest in linc311 against released qsiplan 0.4.0.
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep || exit 1
+PYTHONPATH=/tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/qsiplan040 \
+    exec micromamba run -n linc311 pytest -p no:cacheprovider "$@"
+```
+
+- [ ] **Step 4: Verify the helper resolves qsiplan 0.4.0**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_plan_cli_spec.py -q`
+Expected: `8 passed`.
+
+- [ ] **Step 5: Record the unit-suite baseline**
+
+Run:
+```bash
+bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests -q -n 4 2>&1 | grep -E "^FAILED|^ERROR|passed|failed" > /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/baseline_unit.txt
+```
+Expected: the file ends with a `N passed` summary line. Any `FAILED` or `ERROR` lines are pre-existing failures that Task 6 compares against. This takes several minutes; use a generous timeout. Skip it if `baseline_unit.txt` already exists and was produced on this branch's base commit.
+
+---
+
+### Task 1: Shipped defaults and `load_shoreline_config`
+
+**Files:**
+- Create: `qsiprep/data/shoreline_params.json`
+- Modify: `qsiprep/utils/misc.py`: insert after `validate_diffprep_config` (it ends with `    return` just before `def validate_gradient_flags`)
+- Test: `qsiprep/tests/test_cli.py`: insert after `test_validate_diffprep_config_accepts_each_correction_mode`
+
+**Interfaces:**
+- Produces: `qsiprep.utils.misc.load_shoreline_config(path=None, model=None) -> dict` returns exactly `{'model': str, 'iters': int, 'transform': str}` and raises `ValueError` on any invalid input. `path` is `str | os.PathLike | None`. `model` is `'3dshore' | 'tensor' | 'none' | None`: a legacy override that conflicts with a `"model"` key in the file. Also `SHORELINE_MODELS = ('3dshore', 'tensor', 'none')` and `SHORELINE_TRANSFORMS = ('Affine', 'Rigid')`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Insert into `qsiprep/tests/test_cli.py` after `test_validate_diffprep_config_accepts_each_correction_mode`:
+
+```python
+_SHORELINE_DEFAULTS = {'model': '3dshore', 'iters': 2, 'transform': 'Affine'}
+
+
+def test_load_shoreline_config_defaults_match_the_shipped_file():
+    import json
+
+    from qsiprep.data import load as load_data
+    from qsiprep.utils.misc import load_shoreline_config
+
+    shipped = load_data('shoreline_params.json')
+    assert json.loads(shipped.read_text()) == _SHORELINE_DEFAULTS
+    assert load_shoreline_config(None) == _SHORELINE_DEFAULTS
+    assert load_shoreline_config(str(shipped)) == _SHORELINE_DEFAULTS
+
+
+def test_load_shoreline_config_merges_a_partial_file(tmp_path):
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'tensor.json'
+    cfg.write_text(json.dumps({'model': 'tensor'}))
+    assert load_shoreline_config(str(cfg)) == {**_SHORELINE_DEFAULTS, 'model': 'tensor'}
+
+
+def test_load_shoreline_config_missing(tmp_path):
+    from qsiprep.utils.misc import load_shoreline_config
+
+    with pytest.raises(ValueError, match='does not exist'):
+        load_shoreline_config(str(tmp_path / 'nope.json'))
+
+
+@pytest.mark.parametrize(
+    ('contents', 'match'),
+    [
+        ('[1, 2]', 'must contain a JSON object'),
+        ('{"model": ', 'not valid JSON'),
+        # A typo must fail loudly rather than silently fall back to a default.
+        ('{"iter": 3}', 'unknown key'),
+        # Values are case-sensitive: the legacy --hmc-model spelling is not accepted.
+        ('{"model": "3dSHORE"}', 'model='),
+        ('{"transform": "affine"}', 'transform='),
+        ('{"iters": 0}', 'iters='),
+        ('{"iters": true}', 'iters='),
+        ('{"iters": "2"}', 'iters='),
+        ('{"iters": 1.5}', 'iters='),
+    ],
+)
+def test_load_shoreline_config_rejects_bad_files(tmp_path, contents, match):
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'bad.json'
+    cfg.write_text(contents)
+    with pytest.raises(ValueError, match=match):
+        load_shoreline_config(str(cfg))
+
+
+def test_load_shoreline_config_model_none_ignores_iters(tmp_path):
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'none.json'
+    cfg.write_text(json.dumps({'model': 'none', 'iters': 0}))
+    assert load_shoreline_config(str(cfg)) == {**_SHORELINE_DEFAULTS, 'model': 'none', 'iters': 0}
+
+
+def test_load_shoreline_config_legacy_model_override(tmp_path):
+    """The deprecated --hmc-model alias supplies the model; the file may still set the rest."""
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    assert load_shoreline_config(None, model='tensor') == {
+        **_SHORELINE_DEFAULTS,
+        'model': 'tensor',
+    }
+
+    iters_only = tmp_path / 'iters.json'
+    iters_only.write_text(json.dumps({'iters': 3}))
+    assert load_shoreline_config(str(iters_only), model='none') == {
+        **_SHORELINE_DEFAULTS,
+        'model': 'none',
+        'iters': 3,
+    }
+
+    with_model = tmp_path / 'with_model.json'
+    with_model.write_text(json.dumps({'model': '3dshore'}))
+    with pytest.raises(ValueError, match='conflicts'):
+        load_shoreline_config(str(with_model), model='tensor')
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_cli.py -q -k load_shoreline_config`
+Expected: every selected test FAILS, with `ImportError: cannot import name 'load_shoreline_config'` (or `FileNotFoundError`/`KeyError` for the missing `shoreline_params.json`).
+
+- [ ] **Step 3: Create the shipped defaults**
+
+Create `qsiprep/data/shoreline_params.json`:
+```json
+{
+  "model": "3dshore",
+  "iters": 2,
+  "transform": "Affine"
+}
+```
+
+- [ ] **Step 4: Implement the loader**
+
+In `qsiprep/utils/misc.py`, insert this after `validate_diffprep_config` (after its final `    return` and the two blank lines), before `def validate_gradient_flags`:
+
+```python
+SHORELINE_MODELS = ('3dshore', 'tensor', 'none')
+"""Signal models SHORELine can use to predict motion-correction targets."""
+
+SHORELINE_TRANSFORMS = ('Affine', 'Rigid')
+"""Transformations SHORELine can optimize during head motion correction."""
+
+
+def load_shoreline_config(path=None, model=None):
+    """Load a ``--shoreline-config`` JSON file, merged over the shipped defaults.
+
+    Parameters
+    ----------
+    path : str, os.PathLike or None
+        The SHORELine configuration JSON file. ``None`` uses the defaults in
+        ``qsiprep/data/shoreline_params.json``.
+    model : str or None
+        A SHORELine model from the deprecated ``--hmc-model`` alias (``3dshore``,
+        ``tensor`` or ``none``). It replaces the default model, and conflicts with
+        a ``model`` key in the file.
+
+    Returns
+    -------
+    dict
+        Exactly the keys ``model``, ``iters`` and ``transform``.
+
+    Raises
+    ------
+    ValueError
+        If the file does not exist, is not a JSON object, has an unknown key or an
+        invalid value, or sets ``model`` while ``model`` is also given.
+    """
+    import json
+    import os
+
+    from ..data import load as load_data
+
+    cfg = json.loads(load_data('shoreline_params.json').read_text())
+    source = 'The default SHORELine configuration'
+    if path is not None:
+        source = f'SHORELine configuration file {path}'
+        if not os.path.exists(path):
+            raise ValueError(f'{source} does not exist.')
+        with open(path) as f:
+            try:
+                user_cfg = json.load(f)
+            except json.JSONDecodeError as err:
+                raise ValueError(f'{source} is not valid JSON: {err}') from err
+        if not isinstance(user_cfg, dict):
+            raise ValueError(f'{source} must contain a JSON object.')
+        # Unknown keys are errors so a typo cannot silently fall back to a default.
+        unknown = sorted(set(user_cfg) - set(cfg))
+        if unknown:
+            raise ValueError(
+                f'{source} has unknown key(s) {", ".join(unknown)}; '
+                f'valid keys are {", ".join(sorted(cfg))}.'
+            )
+        if model is not None and 'model' in user_cfg:
+            raise ValueError(f'--hmc-model conflicts with "model" in --shoreline-config {path}.')
+        cfg.update(user_cfg)
+    if model is not None:
+        cfg['model'] = model
+
+    if cfg['model'] not in SHORELINE_MODELS:
+        raise ValueError(
+            f'{source} sets model={cfg["model"]!r}; must be one of '
+            f'{", ".join(SHORELINE_MODELS)}.'
+        )
+    if cfg['transform'] not in SHORELINE_TRANSFORMS:
+        raise ValueError(
+            f'{source} sets transform={cfg["transform"]!r}; must be one of '
+            f'{", ".join(SHORELINE_TRANSFORMS)}.'
+        )
+    iters = cfg['iters']
+    # bool is a subclass of int, so "iters": true has to be rejected explicitly.
+    if (
+        isinstance(iters, bool)
+        or not isinstance(iters, int)
+        or (iters < 1 and cfg['model'] != 'none')
+    ):
+        raise ValueError(
+            f'{source} sets iters={iters!r}; must be an integer >= 1 '
+            '(any integer when model is "none").'
+        )
+    return cfg
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_cli.py -q -k "load_shoreline_config or validate_diffprep"`
+Expected: all pass (15 loader cases plus the 4 existing DIFFPREP validator tests).
+
+- [ ] **Step 6: Lint**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 ruff check qsiprep/utils/misc.py qsiprep/tests/test_cli.py && micromamba run -n linc311 ruff format --check qsiprep/utils/misc.py qsiprep/tests/test_cli.py`
+Expected: `All checks passed!` and no files that would be reformatted. If the format check fails, run `ruff format` on those two files and re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git add qsiprep/data/shoreline_params.json qsiprep/utils/misc.py qsiprep/tests/test_cli.py && git commit -q -F - <<'EOF'
+Add load_shoreline_config and shipped SHORELine defaults
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+EOF
+```
+
+---
+
+### Task 2: `--shoreline-config` in the parser and config
+
+**Files:**
+- Modify: `qsiprep/cli/parser.py`, in these places:
+  - line 31 (import);
+  - lines 74-78 (the `--hmc-model` entry in `deprecations`);
+  - lines 193-208 (the SHORELine branch of `parse_known_args`);
+  - lines 865-871 (`--hmc-transform`);
+  - lines 879-885 and 899-902 (help texts);
+  - lines 904-913 (`--shoreline-model`);
+  - lines 951-957 (`--shoreline-iters`);
+  - line ~1175 (`config.from_dict` in `parse_args`).
+- Modify: `qsiprep/config.py`, in `workflow`: the `hmc_transform`, `shoreline_iters` and `shoreline_model` docstrings; a new `shoreline_config`; and `_paths` at line 708.
+- Modify: `qsiprep/data/tests/config.toml`: remove `hmc_transform = "Affine"` and `shoreline_iters = 2`.
+- Test: `qsiprep/tests/test_cli_run.py`, `qsiprep/tests/test_plan_cli_spec.py`
+
+**Interfaces:**
+- Consumes: `load_shoreline_config(path=None, model=None)` from Task 1.
+- Produces:
+  - the parsed namespace always has `shoreline_config` (absolute `pathlib.Path` or `None`), `shoreline_model` (`'3dshore' | 'tensor' | 'none' | None`), `shoreline_iters` (`int | None`) and `hmc_transform` (`'Affine' | 'Rigid' | None`), with non-`None` values only when `hmc_method == 'shoreline'`;
+  - `hmc_model` is still derived as before;
+  - `config.workflow.shoreline_config` exists and is listed in `workflow._paths`;
+  - after `parse_args`, the four `config.workflow` SHORELine fields equal the namespace values exactly, `None` included.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+In `qsiprep/tests/test_cli_run.py`:
+
+(a) In `test_method_axis_defaults`, after `assert opts.shoreline_model is None`, add:
+```python
+    assert opts.shoreline_config is None
+    assert opts.shoreline_iters is None
+    assert opts.hmc_transform is None
+```
+
+(b) In `test_hmc_method_shoreline_gets_model_and_drbuddi`, after `assert opts.shoreline_model == '3dshore'`, add:
+```python
+    assert opts.shoreline_iters == 2
+    assert opts.hmc_transform == 'Affine'
+```
+
+(c) Delete `test_shoreline_model_requires_shoreline_method` entirely and put this in its place:
+
+```python
+def _shoreline_json(tmp_path, name='shoreline.json', **settings):
+    import json
+
+    path = tmp_path / name
+    path.write_text(json.dumps(settings))
+    return str(path)
+
+
+def test_shoreline_config_values_reach_the_namespace(minimal_args, tmp_path):
+    from pathlib import Path
+
+    cfg = _shoreline_json(tmp_path, model='tensor', iters=3, transform='Rigid')
+    opts = _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    assert opts.shoreline_config == Path(cfg).absolute()
+    assert opts.shoreline_model == 'tensor'
+    assert opts.shoreline_iters == 3
+    assert opts.hmc_transform == 'Rigid'
+    assert opts.hmc_model == 'tensor'
+
+
+@pytest.mark.parametrize('method_args', [[], ['--hmc-method', 'eddy'], ['--hmc-method', 'tortoise']])
+def test_shoreline_config_requires_shoreline_method(minimal_args, tmp_path, capsys, method_args):
+    cfg = _shoreline_json(tmp_path, model='tensor')
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, *method_args, '--shoreline-config', cfg)
+    assert '--shoreline-config requires --hmc-method shoreline' in capsys.readouterr().err
+
+
+def test_invalid_shoreline_config_is_a_parse_error(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, iter=3)
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    assert 'unknown key' in capsys.readouterr().err
+
+
+def test_hmc_model_alias_merges_with_shoreline_config(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, iters=3)
+    opts = _parse(minimal_args, '--hmc-model', 'tensor', '--shoreline-config', cfg)
+    assert 'deprecated' in capsys.readouterr().err
+    assert opts.hmc_method == 'shoreline'
+    assert opts.shoreline_model == 'tensor'
+    assert opts.shoreline_iters == 3
+    assert opts.hmc_model == 'tensor'
+
+
+def test_hmc_model_alias_conflicts_with_shoreline_config_model(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, model='3dshore')
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-model', 'tensor', '--shoreline-config', cfg)
+    assert 'conflicts' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ('flag', 'value'),
+    [('--shoreline-model', 'tensor'), ('--shoreline-iters', '3'), ('--hmc-transform', 'Rigid')],
+)
+def test_removed_shoreline_flags_are_rejected(minimal_args, capsys, flag, value):
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-method', 'shoreline', flag, value)
+    assert 'unrecognized arguments' in capsys.readouterr().err
+
+
+_SHORELINE_KEYS = ('shoreline_config', 'shoreline_model', 'shoreline_iters', 'hmc_transform')
+
+
+@pytest.fixture
+def restore_shoreline_config():
+    """Yield qsiprep.config, restoring the SHORELine block that parse_args writes."""
+    from qsiprep import config
+
+    saved = {key: getattr(config.workflow, key) for key in _SHORELINE_KEYS}
+    yield config
+    for key, value in saved.items():
+        setattr(config.workflow, key, value)
+
+
+def test_shoreline_config_survives_a_config_round_trip(
+    minimal_args, tmp_path, restore_shoreline_config
+):
+    """A Path must be written as a path string, not the literal "PosixPath('...')"."""
+    from pathlib import Path
+
+    import toml
+
+    config = restore_shoreline_config
+    cfg = _shoreline_json(tmp_path, model='tensor')
+    opts = _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    config.workflow.load({'shoreline_config': opts.shoreline_config}, init=False)
+    dumped = toml.dumps({'workflow': config.workflow.get()})
+    assert 'PosixPath(' not in dumped
+    config.workflow.shoreline_config = None
+    config.workflow.load(toml.loads(dumped)['workflow'], init=False)
+    assert config.workflow.shoreline_config == Path(cfg).absolute()
+
+
+def _parse_with_config_file(tmp_path, toml_text, *extra):
+    """Run the real parse_args, loading ``toml_text`` as a --config-file."""
+    from qsiprep import config
+    from qsiprep.cli.parser import parse_args
+
+    bids_dir = tmp_path / 'bids'
+    generate_bids_skeleton(str(bids_dir), long)
+    work_dir = tmp_path / 'work'
+    config_file = tmp_path / 'previous.toml'
+    config_file.write_text(toml_text)
+    config.from_dict({'bids_dir': str(bids_dir), 'work_dir': str(work_dir)}, init=True)
+    parse_args(
+        [
+            str(bids_dir),
+            str(tmp_path / 'out'),
+            'participant',
+            '--participant-label',
+            '01',
+            '--output-resolution',
+            '2',
+            '--work-dir',
+            str(work_dir),
+            '--skip-bids-validation',
+            '--config-file',
+            str(config_file),
+            *extra,
+        ]
+    )
+    return config
+
+
+def test_config_file_reload_drops_stale_shoreline_settings(tmp_path, restore_shoreline_config):
+    """An old eddy config.toml carried hmc_transform/shoreline_iters; they must not survive."""
+    config = _parse_with_config_file(
+        tmp_path,
+        '[workflow]\nhmc_model = "eddy"\nhmc_transform = "Affine"\nshoreline_iters = 2\n',
+    )
+    for key in _SHORELINE_KEYS:
+        assert getattr(config.workflow, key) is None, key
+
+
+def _previous_shoreline_toml(tmp_path):
+    old_json = _shoreline_json(tmp_path, name='old.json', model='tensor', iters=5)
+    return (
+        '[workflow]\n'
+        f'shoreline_config = "{old_json}"\n'
+        'shoreline_model = "tensor"\n'
+        'shoreline_iters = 5\n'
+        'hmc_transform = "Rigid"\n'
+    )
+
+
+def test_config_file_reload_uses_command_line_shoreline_defaults(
+    tmp_path, restore_shoreline_config
+):
+    config = _parse_with_config_file(
+        tmp_path, _previous_shoreline_toml(tmp_path), '--hmc-method', 'shoreline'
+    )
+    assert config.workflow.shoreline_config is None
+    assert config.workflow.shoreline_model == '3dshore'
+    assert config.workflow.shoreline_iters == 2
+    assert config.workflow.hmc_transform == 'Affine'
+
+
+def test_config_file_reload_uses_command_line_shoreline_config(
+    tmp_path, restore_shoreline_config
+):
+    from pathlib import Path
+
+    new_json = _shoreline_json(tmp_path, name='new.json', iters=3, transform='Rigid')
+    config = _parse_with_config_file(
+        tmp_path,
+        _previous_shoreline_toml(tmp_path),
+        '--hmc-method',
+        'shoreline',
+        '--shoreline-config',
+        new_json,
+    )
+    assert config.workflow.shoreline_config == Path(new_json).absolute()
+    assert config.workflow.shoreline_model == '3dshore'
+    assert config.workflow.shoreline_iters == 3
+    assert config.workflow.hmc_transform == 'Rigid'
+```
+
+- [ ] **Step 2: Write the failing QSIPlan conformance changes**
+
+In `qsiprep/tests/test_plan_cli_spec.py`:
+
+(a) Change the imports at the top to:
+```python
+import argparse
+import json
+
+import pytest
+from qsiplan import cli_spec
+
+from qsiprep.cli.parser import _build_parser
+```
+
+(b) After the imports, add:
+```python
+# QSIPlan still lists --shoreline-model as a qsiprep flag, but qsiprep takes the
+# SHORELine model from --shoreline-config (a JSON "model" key) and fills the same
+# ``shoreline_model`` dest that selection_from_namespace reads. Remove this, and
+# bump the qsiplan pin, once QSIPlan stops listing the flag (QSIPlan issue:
+# "Replace --shoreline-model with qsiprep's --shoreline-config").
+_NOT_A_QSIPREP_FLAG = frozenset({'--shoreline-model'})
+```
+
+(c) Replace `test_parser_realizes_every_implemented_plan_option` and `test_planned_options_are_the_only_gaps` with:
+```python
+def test_parser_realizes_every_implemented_plan_option():
+    actions = _actions()
+    for option in cli_spec.PLAN_OPTIONS:
+        if option.planned or option.flag in _NOT_A_QSIPREP_FLAG:
+            continue
+        action = actions.get(option.flag)
+        assert action is not None, f'qsiprep parser is missing {option.flag}'
+        missing = set(option.owned_choices()) - set(action.choices or ())
+        assert not missing, f'{option.flag}: qsiprep is missing choices {sorted(missing)}'
+
+
+def test_planned_options_are_the_only_gaps():
+    actions = _actions()
+    absent = sorted(
+        o.flag
+        for o in cli_spec.PLAN_OPTIONS
+        if o.flag not in actions and o.flag not in _NOT_A_QSIPREP_FLAG
+    )
+    planned = sorted(o.flag for o in cli_spec.PLAN_OPTIONS if o.planned)
+    assert absent == planned  # today: []
+    # The exemption must not outlive the flag in QSIPlan's spec.
+    assert _NOT_A_QSIPREP_FLAG <= {o.flag for o in cli_spec.PLAN_OPTIONS}
+```
+
+(d) Append at the end of the file:
+```python
+@pytest.mark.parametrize('model', ['3dshore', 'tensor', 'none'])
+def test_shoreline_config_model_reaches_the_method_selection(tmp_path, model):
+    cfg = tmp_path / 'shoreline.json'
+    cfg.write_text(json.dumps({'model': model}))
+    namespace = _parse_minimal(tmp_path, '--hmc-method', 'shoreline', '--shoreline-config', str(cfg))
+    selection = cli_spec.selection_from_namespace(namespace)
+    assert selection.hmc.value == 'shoreline'
+    assert selection.shoreline_model == model
+
+
+def test_eddy_namespace_has_no_shoreline_model(tmp_path):
+    namespace = _parse_minimal(tmp_path, '--hmc-method', 'eddy')
+    assert namespace.shoreline_model is None
+    assert cli_spec.selection_from_namespace(namespace).hmc.value == 'eddy'
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_cli_run.py qsiprep/tests/test_plan_cli_spec.py -q`
+Expected: the new tests FAIL, for example `unrecognized arguments: --shoreline-config` or `AttributeError: 'Namespace' object has no attribute 'shoreline_config'`. `test_removed_shoreline_flags_are_rejected` fails for all three flags because they still parse. The two rewritten conformance tests pass, since the flag still exists.
+
+- [ ] **Step 4: Update `qsiprep/config.py`**
+
+(a) Replace the `hmc_transform` field and docstring:
+```python
+    hmc_transform = None
+    """Transformation SHORELine optimizes during head motion correction: Affine or
+    Rigid. Derived from ``--shoreline-config``; None unless ``hmc_method`` is
+    shoreline."""
+```
+
+(b) Replace the `shoreline_iters` and `shoreline_model` fields and docstrings (they sit between `separate_all_dwis` and `tortoise_gpu_cpu_ratio`) with:
+```python
+    shoreline_config = None
+    """Configuration JSON for SHORELine (``--shoreline-config``)."""
+    shoreline_iters = None
+    """How many iterations to run SHORELine. Derived from ``--shoreline-config``;
+    None unless ``hmc_method`` is shoreline."""
+    shoreline_model = None
+    """Signal model SHORELine uses to predict motion-correction targets:
+    3dshore, tensor or none. Derived from ``--shoreline-config``; None unless
+    ``hmc_method`` is shoreline."""
+```
+
+(c) At the end of `class workflow`, change `_paths = ('gradient_file',)` to:
+```python
+    _paths = ('gradient_file', 'shoreline_config')
+```
+
+- [ ] **Step 5: Update `qsiprep/cli/parser.py`**
+
+(a) Line 31: replace `from ..utils.misc import parse_denoise_method` with:
+```python
+from ..utils.misc import load_shoreline_config, parse_denoise_method
+```
+
+(b) In `deprecations`, replace the `'--hmc-model'` entry with:
+```python
+        '--hmc-model': (
+            '27.0.0',
+            'Use `--hmc-method` instead (with a `--shoreline-config` "model" for the '
+            'SHORELine signal model).',
+        ),
+```
+
+(c) In `DeprecationForwardingParser.parse_known_args`, replace this block:
+```python
+            if legacy_hmc is not None:
+                if namespace.shoreline_model is not None:
+                    self.error(
+                        '--shoreline-model requires --hmc-method shoreline '
+                        '(not the deprecated --hmc-model)'
+                    )
+                namespace.hmc_method = hmc_model_to_method[legacy_hmc]
+                namespace.shoreline_model = hmc_model_to_shoreline_model.get(legacy_hmc)
+            if namespace.hmc_method is None:
+                namespace.hmc_method = 'eddy'
+            if namespace.shoreline_model is not None and namespace.hmc_method != 'shoreline':
+                self.error('--shoreline-model requires --hmc-method shoreline')
+            if namespace.hmc_method == 'shoreline':
+                if namespace.shoreline_model is None:
+                    namespace.shoreline_model = '3dshore'
+                print(
+```
+with:
+```python
+            legacy_shoreline_model = None
+            if legacy_hmc is not None:
+                namespace.hmc_method = hmc_model_to_method[legacy_hmc]
+                legacy_shoreline_model = hmc_model_to_shoreline_model.get(legacy_hmc)
+            if namespace.hmc_method is None:
+                namespace.hmc_method = 'eddy'
+            if namespace.shoreline_config is not None and namespace.hmc_method != 'shoreline':
+                self.error('--shoreline-config requires --hmc-method shoreline')
+            # SHORELine settings come from --shoreline-config (or the shipped
+            # defaults). Config and the workflow builders read only these resolved
+            # values, which stay None for the other methods.
+            namespace.shoreline_model = None
+            namespace.shoreline_iters = None
+            namespace.hmc_transform = None
+            if namespace.hmc_method == 'shoreline':
+                try:
+                    shoreline = load_shoreline_config(
+                        namespace.shoreline_config, model=legacy_shoreline_model
+                    )
+                except ValueError as err:
+                    self.error(str(err))
+                namespace.shoreline_model = shoreline['model']
+                namespace.shoreline_iters = shoreline['iters']
+                namespace.hmc_transform = shoreline['transform']
+                print(
+```
+The `print(...)` removal notice and everything after it stay as they are. That includes `namespace.hmc_model = shoreline_model_to_hmc_model[namespace.shoreline_model]`.
+
+(d) Delete the whole `--hmc-transform` argument:
+```python
+    g_moco.add_argument(
+        '--hmc-transform',
+        action='store',
+        default='Affine',
+        choices=['Affine', 'Rigid'],
+        help='transformation to be optimized during head motion correction (default: affine)',
+    )
+```
+
+(e) In the `--hmc-method` help, replace:
+```python
+        'sampling; see --shoreline-model and --shoreline-iters; scheduled '
+```
+with:
+```python
+        'sampling; configured with --shoreline-config; scheduled '
+```
+
+(f) Replace the `--hmc-model` help with:
+```python
+        help='DEPRECATED: use --hmc-method (and --shoreline-config) instead. '
+        '"eddy" means `--hmc-method eddy`; "tortoise" means `--hmc-method '
+        'tortoise`; "3dSHORE", "tensor" and "none" mean `--hmc-method '
+        'shoreline` with the matching --shoreline-config "model".',
+```
+
+(g) Replace the whole `--shoreline-model` argument with:
+```python
+    g_moco.add_argument(
+        '--shoreline-config',
+        action='store',
+        type=IsFile,
+        default=None,
+        help='path to a JSON file with settings for SHORELine (only valid with '
+        '--hmc-method shoreline). Every key is optional: "model" is the signal model '
+        'used to predict motion-correction targets ("3dshore", the default; "tensor"; '
+        'or "none", which warps each non-b=0 image with the transform of its nearest '
+        'b=0 image), "iters" is the number of SHORELine iterations (default: 2), and '
+        '"transform" is the transformation optimized during head motion correction '
+        '("Affine", the default, or "Rigid"). Unknown keys are an error. The current '
+        'default can be found here: '
+        'https://github.com/PennLINC/qsiprep/blob/main/qsiprep/data/shoreline_params.json',
+    )
+```
+
+(h) Delete the whole `--shoreline-iters` argument:
+```python
+    g_moco.add_argument(
+        '--shoreline-iters',
+        action='store',
+        type=int,
+        default=2,
+        help='number of SHORELine iterations. (default: 2)',
+    )
+```
+
+(i) In `parse_args`, replace:
+```python
+    config.from_dict(vars(opts), init=['nipype'])
+```
+with:
+```python
+    config.from_dict(vars(opts), init=['nipype'])
+    # The command line is authoritative for SHORELine settings, as it already is
+    # for hmc_method. from_dict skips None values, so without this a --config-file
+    # could leave a stale shoreline_config, hmc_transform or shoreline_iters behind.
+    for key in ('shoreline_config', 'shoreline_model', 'shoreline_iters', 'hmc_transform'):
+        setattr(config.workflow, key, getattr(opts, key))
+```
+
+- [ ] **Step 6: Update the eddy config fixture**
+
+In `qsiprep/data/tests/config.toml`, delete these two lines from `[workflow]`:
+```
+hmc_transform = "Affine"
+```
+```
+shoreline_iters = 2
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_cli_run.py qsiprep/tests/test_plan_cli_spec.py qsiprep/tests/test_cli.py qsiprep/tests/test_method_selection.py -q`
+Expected: all pass. `test_cli.py` runs only non-integration tests by default.
+
+- [ ] **Step 8: Lint**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 ruff check qsiprep/cli/parser.py qsiprep/config.py qsiprep/tests/test_cli_run.py qsiprep/tests/test_plan_cli_spec.py && micromamba run -n linc311 ruff format --check qsiprep/cli/parser.py qsiprep/config.py qsiprep/tests/test_cli_run.py qsiprep/tests/test_plan_cli_spec.py`
+Expected: clean. Run `ruff format` on any file it flags, then re-run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git add qsiprep/cli/parser.py qsiprep/config.py qsiprep/data/tests/config.toml qsiprep/tests/test_cli_run.py qsiprep/tests/test_plan_cli_spec.py && git commit -q -F - <<'EOF'
+Replace SHORELine flags with --shoreline-config
+
+Remove --shoreline-model, --shoreline-iters and --hmc-transform. The
+parser resolves --shoreline-config (or the shipped defaults) into the
+existing shoreline_model/shoreline_iters/hmc_transform values, and the
+command line stays authoritative for them on --config-file reloads.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+EOF
+```
+
+---
+
+### Task 3: Workflow consumers, summary and methods text
+
+**Files:**
+- Modify: `qsiprep/workflows/dwi/hmc_sdc.py:140`
+- Modify: `qsiprep/workflows/dwi/hmc.py`: add a module constant after `DEFAULT_MEMORY_MIN_GB`; the iterative desc at ~386-389; the model-HMC `__desc__` at ~717-723
+- Modify: `qsiprep/workflows/dwi/base.py:257-262` and the `summary` node at ~485-495
+- Modify: `qsiprep/interfaces/reports.py`: `DIFFUSION_TEMPLATE`, `DiffusionSummaryInputSpec.hmc_transform`, `DiffusionSummary._generate_segment`
+- Test: `qsiprep/tests/test_workflows_gradwarp.py`, `qsiprep/tests/test_reports.py`, `qsiprep/tests/test_template_registration_settings.py`
+
+**Interfaces:**
+- Consumes: the resolved `config.workflow.shoreline_iters` and `hmc_transform` from Task 2, and `config.workflow.hmc_model`, which the parser still derives (`'3dSHORE' | 'tensor' | 'none' | 'eddy' | 'tortoise'`).
+- Produces: `DiffusionSummaryInputSpec.hmc_transform` is optional, and the "HMC Transform" line renders only when it is defined.
+
+- [ ] **Step 1: Write the failing workflow tests**
+
+Append to `qsiprep/tests/test_workflows_gradwarp.py`, after `test_shoreline_dis3d_does_not_gradwarp_sdc_inputs`:
+
+```python
+def test_shoreline_iters_sets_the_model_iteration_count(tmp_path):
+    """Regression: --shoreline-iters never reached init_dwi_hmc_wf (always 2)."""
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.shoreline_iters = 3
+    wf = _shoreline_wf(tmp_path, _rpe_unit(tmp_path))
+    model_wf = wf.get_node('dwi_hmc_wf.dwi_model_hmc_wf')
+    assert model_wf.get_node('shoreline_iteration002') is not None
+    assert model_wf.get_node('shoreline_iteration003') is None
+    assert model_wf.get_node('summarize_iterations') is not None
+    assert 'A total of 3 iterations' in model_wf.__desc__
+
+
+def test_single_shoreline_iteration_skips_the_iteration_summary(tmp_path):
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.shoreline_iters = 1
+    wf = _shoreline_wf(tmp_path, _rpe_unit(tmp_path))
+    model_wf = wf.get_node('dwi_hmc_wf.dwi_model_hmc_wf')
+    assert model_wf.get_node('initial_model_iteration') is not None
+    assert model_wf.get_node('shoreline_iteration001') is None
+    assert model_wf.get_node('summarize_iterations') is None
+    assert 'A total of 1 iterations' in model_wf.__desc__
+
+
+@pytest.mark.parametrize(
+    ('hmc_model', 'expected', 'unexpected'),
+    [
+        ('tensor', 'using a tensor model', '3dSHORE'),
+        ('3dSHORE', 'using 3dSHORE [@merlet3dshore]', 'tensor model'),
+    ],
+)
+def test_shoreline_methods_text_names_the_model_and_transform(
+    tmp_path, hmc_model, expected, unexpected
+):
+    from qsiprep.workflows.dwi.hmc import init_dwi_model_hmc_wf
+
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.hmc_model = hmc_model
+    config.workflow.hmc_transform = 'Rigid'
+    wf = init_dwi_model_hmc_wf(num_iters=2)
+    assert expected in wf.__desc__
+    assert unexpected not in wf.__desc__
+    assert 'using a Rigid transform' in wf.__desc__
+
+
+def test_eddy_summary_leaves_hmc_transform_undefined(tmp_path):
+    """A stale hmc_transform (e.g. from a reloaded config) must not reach an eddy summary."""
+    from nipype.interfaces.base import isdefined
+
+    wf = _preproc_wf(tmp_path)
+    # _dwi_preproc_cfg sets this, standing in for a stale value.
+    assert config.workflow.hmc_transform == 'Affine'
+    assert not isdefined(wf.get_node('summary').inputs.hmc_transform)
+```
+
+Append to `qsiprep/tests/test_reports.py`, after `test_diffusion_summary_renders_gradient_correction`:
+
+```python
+def _diffusion_summary(**overrides):
+    from qsiprep.interfaces.reports import DiffusionSummary
+
+    inputs = {
+        'distortion_correction': 'TOPUP',
+        'pe_direction': 'j',
+        'hmc_model': 'eddy',
+        'b0_to_anat_transform': 'Rigid',
+        'denoise_method': 'dwidenoise',
+        'dwi_denoise_window': 5,
+    }
+    inputs.update(overrides)
+    return DiffusionSummary(**inputs)
+
+
+def test_diffusion_summary_omits_hmc_transform_when_undefined():
+    segment = _diffusion_summary()._generate_segment()
+    assert 'HMC Transform' not in segment
+    assert 'HMC Model: eddy' in segment
+
+
+def test_diffusion_summary_shows_hmc_transform_when_given():
+    segment = _diffusion_summary(hmc_model='3dSHORE', hmc_transform='Rigid')._generate_segment()
+    assert '<li>HMC Transform: Rigid</li>' in segment
+    assert 'HMC Model: 3dSHORE' in segment
+```
+
+Append to `qsiprep/tests/test_template_registration_settings.py`, after `test_within_scan_hmc_still_uses_shoreline`:
+
+```python
+def test_iterative_b0_description_names_the_transform(tmp_path):
+    """The methods text named hmc_model ("tortoise registrations") instead of the transform."""
+    from qsiprep.workflows.dwi.hmc import init_b0_hmc_wf
+
+    _config().execution.output_dir = str(tmp_path)
+    wf = init_b0_hmc_wf(align_to='iterative', transform='Rigid')
+    assert 'iterations of Rigid registrations' in wf.__desc__
+    assert 'tortoise' not in wf.__desc__
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_workflows_gradwarp.py qsiprep/tests/test_reports.py qsiprep/tests/test_template_registration_settings.py -q -k "shoreline_iter or methods_text or eddy_summary or hmc_transform or iterative_b0_description"`
+Expected FAILs:
+- `test_shoreline_iters_sets_the_model_iteration_count`: `shoreline_iteration002` is `None`.
+- `test_single_shoreline_iteration_skips_the_iteration_summary`: `shoreline_iteration001` is not `None`.
+- The tensor case of `test_shoreline_methods_text_names_the_model_and_transform`: "3dSHORE" is present.
+- `test_eddy_summary_leaves_hmc_transform_undefined`: it is `'Affine'`.
+- `test_diffusion_summary_omits_hmc_transform_when_undefined`: renders `HMC Transform: <undefined>`.
+- `test_iterative_b0_description_names_the_transform`: says "tortoise registrations".
+
+`test_diffusion_summary_shows_hmc_transform_when_given` and the `3dSHORE` methods-text case may already pass.
+
+- [ ] **Step 3: Pass the iteration count through (`qsiprep/workflows/dwi/hmc_sdc.py`)**
+
+Replace:
+```python
+    dwi_hmc_wf = init_dwi_hmc_wf(source_file=source_file)
+```
+with:
+```python
+    dwi_hmc_wf = init_dwi_hmc_wf(
+        source_file=source_file,
+        num_model_iterations=config.workflow.shoreline_iters,
+    )
+```
+
+- [ ] **Step 4: Fix the methods text (`qsiprep/workflows/dwi/hmc.py`)**
+
+(a) After `DEFAULT_MEMORY_MIN_GB = 0.01`, add:
+```python
+
+# Methods-text names for the SHORELine signal models, keyed by the hmc_model value
+# SignalPrediction reads. "none" never builds the model-based workflow.
+_SHORELINE_MODEL_DESCRIPTIONS = {
+    '3dSHORE': '3dSHORE [@merlet3dshore]',
+    'tensor': 'a tensor model',
+}
+```
+
+(b) In `init_b0_hmc_wf`, iterative branch, replace:
+```python
+            f'of {config.workflow.hmc_model} registrations. '
+```
+with:
+```python
+            f'of {transform} registrations. '
+```
+
+(c) In `init_dwi_model_hmc_wf`, replace:
+```python
+    workflow.__desc__ = (
+        'The SHORELine method was used to estimate head motion in b>0 '
+        'images. This entails leaving out each b>0 image and reconstructing '
+        'the others using 3dSHORE [@merlet3dshore]. The signal for the left-'
+        f'out image serves as the registration target. A total of {num_iters} '
+        f'iterations were run using a {config.workflow.hmc_transform} transform. '
+    )
+```
+with:
+```python
+    model_description = _SHORELINE_MODEL_DESCRIPTIONS.get(
+        config.workflow.hmc_model, config.workflow.hmc_model
+    )
+    workflow.__desc__ = (
+        'The SHORELine method was used to estimate head motion in b>0 '
+        'images. This entails leaving out each b>0 image and reconstructing '
+        f'the others using {model_description}. The signal for the left-'
+        f'out image serves as the registration target. A total of {num_iters} '
+        f'iterations were run using a {config.workflow.hmc_transform} transform. '
+    )
+```
+
+- [ ] **Step 5: Update `qsiprep/workflows/dwi/base.py`**
+
+(a) Replace:
+```python
+    if hmc_tool == 'shoreline':
+        if config.workflow.shoreline_model != 'none' and config.workflow.shoreline_iters < 1:
+            raise Exception(
+                '--shoreline-iters must be > 0 when --shoreline-model is '
+                f'{config.workflow.shoreline_model}'
+            )
+        hmc_wf = init_qsiprep_hmcsdc_wf(
+```
+with:
+```python
+    if hmc_tool == 'shoreline':
+        hmc_wf = init_qsiprep_hmcsdc_wf(
+```
+
+(b) In the `summary = pe.Node(DiffusionSummary(...), ...)` call, delete the line:
+```python
+            hmc_transform=config.workflow.hmc_transform,
+```
+and immediately after the closing `)` of that `summary = pe.Node(...)` statement, add:
+```python
+    if hmc_tool == 'shoreline':
+        # Only SHORELine optimizes a selectable transform. Gating on the resolved
+        # method, not the value, keeps a stale hmc_transform out of eddy and
+        # TORTOISE summaries.
+        summary.inputs.hmc_transform = config.workflow.hmc_transform
+```
+`hmc_tool` is `unit.run.hmc_stage.tool`, set earlier in the same function (`base.py:256`).
+
+- [ ] **Step 6: Make the summary line optional (`qsiprep/interfaces/reports.py`)**
+
+(a) In `DIFFUSION_TEMPLATE`, replace:
+```
+\t\t\t<li>HMC Transform: {hmc_transform}</li>
+\t\t\t<li>HMC Model: {hmc_model}</li>
+```
+with:
+```
+{hmc_transform_line}\t\t\t<li>HMC Model: {hmc_model}</li>
+```
+
+(b) In `DiffusionSummaryInputSpec`, replace:
+```python
+    hmc_transform = traits.Str(mandatory=True, desc='transform used during HMC')
+```
+with:
+```python
+    hmc_transform = traits.Str(desc='transform optimized during HMC (SHORELine runs only)')
+```
+
+(c) In `DiffusionSummary._generate_segment`, just before `return DIFFUSION_TEMPLATE.format(`, add:
+```python
+        hmc_transform_line = ''
+        if isdefined(self.inputs.hmc_transform):
+            hmc_transform_line = f'\t\t\t<li>HMC Transform: {self.inputs.hmc_transform}</li>\n'
+
+```
+and in the `.format(...)` call, replace `hmc_transform=self.inputs.hmc_transform,` with:
+```python
+            hmc_transform_line=hmc_transform_line,
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_workflows_gradwarp.py qsiprep/tests/test_reports.py qsiprep/tests/test_template_registration_settings.py qsiprep/tests/test_workflows_native.py qsiprep/tests/test_intramodal_template.py -q`
+Expected: all pass. That includes the existing SHORELine gradwarp tests, which run at the fixture's `shoreline_iters = 2`.
+
+- [ ] **Step 8: Lint**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 ruff check qsiprep/workflows/dwi/hmc_sdc.py qsiprep/workflows/dwi/hmc.py qsiprep/workflows/dwi/base.py qsiprep/interfaces/reports.py qsiprep/tests/test_workflows_gradwarp.py qsiprep/tests/test_reports.py qsiprep/tests/test_template_registration_settings.py && micromamba run -n linc311 ruff format --check qsiprep/workflows/dwi/hmc_sdc.py qsiprep/workflows/dwi/hmc.py qsiprep/workflows/dwi/base.py qsiprep/interfaces/reports.py qsiprep/tests/test_workflows_gradwarp.py qsiprep/tests/test_reports.py qsiprep/tests/test_template_registration_settings.py`
+Expected: clean. Run `ruff format` on any file it flags, then re-run.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git add qsiprep/workflows/dwi/hmc_sdc.py qsiprep/workflows/dwi/hmc.py qsiprep/workflows/dwi/base.py qsiprep/interfaces/reports.py qsiprep/tests/test_workflows_gradwarp.py qsiprep/tests/test_reports.py qsiprep/tests/test_template_registration_settings.py && git commit -q -F - <<'EOF'
+Honor SHORELine iterations and report its settings accurately
+
+Pass shoreline_iters to init_dwi_hmc_wf, which always ran two model
+iterations. Name the actual SHORELine model and transform in the methods
+text, and show "HMC Transform" in the summary only for SHORELine runs.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+EOF
+```
+
+---
+
+### Task 4: Integration test configurations
+
+**Files:**
+- Create: `qsiprep/tests/data/shoreline_none_config.json`, `qsiprep/tests/data/shoreline_tensor_config.json`, `qsiprep/tests/data/shoreline_rigid_config.json`
+- Modify: `qsiprep/tests/test_cli.py`: the four integration tests that pass the removed flags (`drbuddi_shoreline_epi`, `test_drbuddi_tensorline_epi`, `test_dscsdsi`, `intramodal_template`)
+
+**Interfaces:**
+- Consumes: `--shoreline-config` from Task 2; `get_test_data_path()` is already imported in `test_cli.py`.
+
+- [ ] **Step 1: Create the three JSON files**
+
+`qsiprep/tests/data/shoreline_none_config.json`:
+```json
+{
+  "model": "none",
+  "iters": 1
+}
+```
+`qsiprep/tests/data/shoreline_tensor_config.json`:
+```json
+{
+  "model": "tensor",
+  "iters": 1
+}
+```
+`qsiprep/tests/data/shoreline_rigid_config.json`:
+```json
+{
+  "transform": "Rigid",
+  "iters": 1
+}
+```
+
+- [ ] **Step 2: Update the `drbuddi_shoreline_epi` test (the one with `--shoreline-model=none` and `--sdc-method=drbuddi`)**
+
+Just before its `parameters = [`, add:
+```python
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_none_config.json')
+```
+In its `parameters`, replace:
+```python
+        '--hmc-method=shoreline',
+        '--shoreline-model=none',
+        '--sdc-method=drbuddi',
+        '--output-resolution=2',
+        '--shoreline-iters=1',
+```
+with:
+```python
+        '--hmc-method=shoreline',
+        f'--shoreline-config={shoreline_config}',
+        '--sdc-method=drbuddi',
+        '--output-resolution=2',
+```
+
+- [ ] **Step 3: Update `test_drbuddi_tensorline_epi`**
+
+Just before its `parameters = [`, add:
+```python
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_tensor_config.json')
+```
+Replace:
+```python
+        '--hmc-method=shoreline',
+        '--shoreline-model=tensor',
+        '--sdc-method=drbuddi',
+        '--output-resolution=5',
+        '--shoreline-iters=1',
+```
+with:
+```python
+        '--hmc-method=shoreline',
+        f'--shoreline-config={shoreline_config}',
+        '--sdc-method=drbuddi',
+        '--output-resolution=5',
+```
+
+- [ ] **Step 4: Update `test_dscsdsi`**
+
+Just before its `parameters = [`, add:
+```python
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_rigid_config.json')
+```
+Replace:
+```python
+        '--hmc-method=shoreline',
+        '--hmc-transform=Rigid',
+        '--output-resolution=5',
+        '--shoreline-iters=1',
+```
+with:
+```python
+        '--hmc-method=shoreline',
+        f'--shoreline-config={shoreline_config}',
+        '--output-resolution=5',
+```
+
+- [ ] **Step 5: Update the `intramodal_template` test**
+
+Just before its `parameters = [`, add:
+```python
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_none_config.json')
+```
+Replace:
+```python
+        '--hmc-method=shoreline',
+        '--shoreline-model=none',
+        '--b0-motion-corr-to=first',
+```
+with:
+```python
+        '--hmc-method=shoreline',
+        f'--shoreline-config={shoreline_config}',
+        '--b0-motion-corr-to=first',
+```
+
+- [ ] **Step 6: Verify: no removed flags remain, the files validate, and collection works**
+
+Run:
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && ! grep -n -- "--shoreline-model\|--shoreline-iters\|--hmc-transform" qsiprep/tests/test_cli.py && micromamba run -n linc311 python -c "
+import os, qsiprep.tests.test_cli as t
+from qsiprep.utils.misc import load_shoreline_config
+d = t.get_test_data_path()
+for name in ('none', 'tensor', 'rigid'):
+    print(name, load_shoreline_config(os.path.join(d, f'shoreline_{name}_config.json')))
+"
+```
+Expected: the grep prints nothing. The loader prints `{'model': 'none', 'iters': 1, 'transform': 'Affine'}`, `{'model': 'tensor', 'iters': 1, 'transform': 'Affine'}` and `{'model': '3dshore', 'iters': 1, 'transform': 'Rigid'}`.
+
+Then run: `bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests/test_cli.py -m integration --collect-only -q 2>&1 | tail -3`
+Expected: collection succeeds with no errors. Integration tests are not run locally.
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 ruff check qsiprep/tests/test_cli.py && micromamba run -n linc311 ruff format --check qsiprep/tests/test_cli.py`
+Expected: clean.
+
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git add qsiprep/tests/data/shoreline_none_config.json qsiprep/tests/data/shoreline_tensor_config.json qsiprep/tests/data/shoreline_rigid_config.json qsiprep/tests/test_cli.py && git commit -q -F - <<'EOF'
+Use --shoreline-config in SHORELine integration tests
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+EOF
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `docs/quickstart.rst` ("Head motion correction method", about lines 136-155)
+- Modify: `docs/preprocessing.rst` (the SHORELine section, about lines 939-1007)
+- Modify: `docs/notebooks/grouping_tutorial.md` (about lines 430-432)
+
+`docs/usage.rst` is generated by sphinx-argparse from the parser, so it needs no edit. Do not touch `docs/changes.md`, or the stale `.. workflow::` directives in `preprocessing.rst`.
+
+- [ ] **Step 1: `docs/quickstart.rst`**
+
+Replace:
+```rst
+Head motion correction is selected with ``--hmc-method``, which takes
+``eddy``, ``shoreline`` or ``tortoise``. (The deprecated ``--hmc-model``
+values map onto these: ``eddy`` is ``--hmc-method eddy``, ``tortoise`` is
+``--hmc-method tortoise``, and ``3dSHORE``/``tensor``/``none`` are
+``--hmc-method shoreline`` with the matching ``--shoreline-model``.)
+
+Choosing ``eddy`` (the default) runs FSL's ``eddy`` for head motion correction
+and eddy current correction. This will work for single-shell and multi-shell
+sampling schemes. The ``shoreline`` option (SHORELine) works for multi-shell,
+Cartesian grid sampling (DSI) and random q-space sampling (CS-DSI); its
+signal model is chosen with ``--shoreline-model``, either ``3dshore`` (the
+default) or ``tensor``.
+
+``--shoreline-model none`` will register all the b=0 images to one another
+and the b>0 images will have the transform from the nearest b=0 image
+applied. This is not recommended. Between ``eddy`` and ``shoreline``, all
+```
+with:
+```rst
+Head motion correction is selected with ``--hmc-method``, which takes
+``eddy``, ``shoreline`` or ``tortoise``. (The deprecated ``--hmc-model``
+values map onto these: ``eddy`` is ``--hmc-method eddy``, ``tortoise`` is
+``--hmc-method tortoise``, and ``3dSHORE``/``tensor``/``none`` are
+``--hmc-method shoreline`` with the matching SHORELine ``"model"``.)
+
+Choosing ``eddy`` (the default) runs FSL's ``eddy`` for head motion correction
+and eddy current correction. This will work for single-shell and multi-shell
+sampling schemes. The ``shoreline`` option (SHORELine) works for multi-shell,
+Cartesian grid sampling (DSI) and random q-space sampling (CS-DSI). Its
+settings are passed as a JSON file with ``--shoreline-config``, for example:
+
+.. code-block:: json
+
+   {
+     "model": "tensor",
+     "iters": 2,
+     "transform": "Rigid"
+   }
+
+``"model"`` is the signal model, either ``"3dshore"`` (the default) or
+``"tensor"``; ``"iters"`` is the number of SHORELine iterations (default 2);
+and ``"transform"`` is the transformation optimized during head motion
+correction, ``"Affine"`` (the default) or ``"Rigid"``. Every key is optional.
+See :ref:`configure_shoreline` for details.
+
+Setting ``"model": "none"`` will register all the b=0 images to one another
+and the b>0 images will have the transform from the nearest b=0 image
+applied. This is not recommended. Between ``eddy`` and ``shoreline``, all
+```
+
+- [ ] **Step 2: `docs/preprocessing.rst`, the "none" paragraph**
+
+Replace:
+```rst
+If ``"none"`` is specified as the hmc_model, then only the b0 images are used
+and the non-b0 images are transformed based on their nearest b0 image. This
+is probably not a great idea.
+```
+with:
+```rst
+If ``"model": "none"`` is set in ``--shoreline-config``, then only the b0
+images are used and the non-b0 images are transformed based on their nearest
+b0 image. This is probably not a great idea.
+```
+
+- [ ] **Step 3: `docs/preprocessing.rst`, the new subsection**
+
+At the end of the SHORELine section, after the `.. workflow::` block that ends with `        dwi_metadata={},` and `    )`, and before the blank lines and `.. _dwi_sdc:`, insert:
+```rst
+
+.. _configure_shoreline:
+
+Configuring SHORELine
+^^^^^^^^^^^^^^^^^^^^^
+
+SHORELine's settings are passed to *QSIPrep* as a JSON file with the
+``--shoreline-config`` option, which is only valid with
+``--hmc-method shoreline``. Every key is optional: missing keys take the
+defaults below, and unknown keys or invalid values are an error.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key
+     - Allowed values
+     - Default
+     - Meaning
+   * - ``model``
+     - ``"3dshore"``, ``"tensor"``, ``"none"``
+     - ``"3dshore"``
+     - Signal model used to predict each left-out image. ``"none"`` skips the
+       model and gives each b>0 image the transform of its nearest b=0 image.
+   * - ``iters``
+     - An integer of at least 1 (ignored when ``model`` is ``"none"``)
+     - ``2``
+     - Number of SHORELine iterations.
+   * - ``transform``
+     - ``"Affine"``, ``"Rigid"``
+     - ``"Affine"``
+     - Transformation optimized during head motion correction.
+
+The default configuration can be viewed or downloaded `here
+<https://github.com/PennLINC/qsiprep/blob/main/qsiprep/data/shoreline_params.json>`__.
+```
+
+- [ ] **Step 4: `docs/notebooks/grouping_tutorial.md`**
+
+Replace:
+```markdown
+  (FSL), `tortoise` (TORTOISE's DIFFPREP), or `shoreline` (with
+  `--shoreline-model` naming its signal model).
+```
+with:
+```markdown
+  (FSL), `tortoise` (TORTOISE's DIFFPREP), or `shoreline` (with a
+  `--shoreline-config` JSON whose `"model"` names its signal model).
+```
+
+- [ ] **Step 5: Verify no user-facing references to the removed flags remain**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && grep -rn -- "--shoreline-model\|--shoreline-iters\|--hmc-transform\|shoreline-model" docs qsiprep --include=*.rst --include=*.md --include=*.py | grep -v "docs/changes.md\|docs/superpowers/\|docs/_build/\|tests/pytests/\|tests/test_data/"`
+Expected: only these hits:
+- the `_NOT_A_QSIPREP_FLAG` constant and its comment in `qsiprep/tests/test_plan_cli_spec.py`;
+- the `test_removed_shoreline_flags_are_rejected` parametrization in `qsiprep/tests/test_cli_run.py`.
+
+Any other hit must be fixed.
+
+- [ ] **Step 6: Check the reST syntax of the edited sections**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 python -c "
+import docutils.core, docutils.utils
+for path in ('docs/quickstart.rst',):
+    docutils.core.publish_doctree(open(path).read(), settings_overrides={'report_level': 2, 'halt_level': 5})
+print('ok')
+" 2>&1 | grep -v 'Unknown interpreted text role\|No role entry\|Unknown directive type\|No directive entry\|Trying\|:ref:\|workflow::\|^$' | tail -15`
+Expected: `ok`, with no warnings about the new code block or list. Sphinx-only roles and directives such as `:ref:` and `.. workflow::` are filtered out. Then inspect the `preprocessing.rst` diff by eye (`git diff docs/preprocessing.rst`). `list-table` rows need consistent `* -` / `  -` indentation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git add docs/quickstart.rst docs/preprocessing.rst docs/notebooks/grouping_tutorial.md && git commit -q -F - <<'EOF'
+Document --shoreline-config
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01Fw6LUSiixwJEwerwhYxH5R
+EOF
+```
+
+---
+
+### Task 6: Final verification and handoff
+
+**Files:** none modified, unless verification finds a problem.
+
+- [ ] **Step 1: Full unit suite against the baseline**
+
+Run:
+```bash
+bash /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/pytest040.sh qsiprep/tests -q -n 4 2>&1 | grep -E "^FAILED|^ERROR|passed|failed" > /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/final_unit.txt; diff <(grep -E "^FAILED|^ERROR" /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/baseline_unit.txt | sort) <(grep -E "^FAILED|^ERROR" /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/final_unit.txt | sort); tail -1 /tmp/claude-1000/-mnt-c-Users-tsalo-Documents-linc-qsiprep-qsiprep/69542bb0-c883-4df4-a123-46e41d78a10d/scratchpad/final_unit.txt
+```
+Expected: no line starting with `>`, meaning no new failures. Lines starting with `<` are baseline failures that now pass, which is fine. The passed count is higher than the baseline's by the number of new tests. Investigate any new failure with superpowers:systematic-debugging before continuing.
+
+- [ ] **Step 2: Lint the whole change**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && git diff --name-only main...HEAD -- '*.py' | xargs micromamba run -n linc311 ruff check && git diff --name-only main...HEAD -- '*.py' | xargs micromamba run -n linc311 ruff format --check`
+Expected: clean.
+
+- [ ] **Step 3: Confirm the parser help renders**
+
+Run: `cd /mnt/c/Users/tsalo/Documents/linc/qsiprep && micromamba run -n linc311 python -c "from qsiprep.cli.parser import _build_parser; _build_parser().print_help()" | grep -A12 -- "--shoreline-config"`
+Expected: the `--shoreline-config` help text. `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` appear nowhere in `print_help()` output (check with `| grep -c -- "--shoreline-model\|--shoreline-iters\|--hmc-transform"`, which should print `0`).
+
+- [ ] **Step 4: Draft the QSIPlan issue for the user (do not file it)**
+
+Present this text to the user in chat and wait for approval before filing it with `gh issue create -R PennLINC/QSIPlan`:
+
+```markdown
+Title: Replace --shoreline-model with qsiprep's --shoreline-config
+
+qsiprep (PennLINC/qsiprep#1132) is replacing `--shoreline-model`, `--shoreline-iters`
+and `--hmc-transform` with a single `--shoreline-config` JSON file whose `"model"` key
+(`3dshore`, `tensor` or `none`) selects the SHORELine signal model. qsiprep still fills
+the `shoreline_model` namespace dest, so `selection_from_namespace` keeps working.
+
+Needed in QSIPlan:
+- Drop `--shoreline-model` from `cli_spec.PLAN_OPTIONS`, or mark it as not exposed by
+  qsiprep.
+- `MethodSelection.cli_phrase()` should stop suggesting `--shoreline-model <model>` and
+  instead mention a `--shoreline-config` file with `"model": "<model>"`. qsiprep shows
+  this phrase in its workflow log and in the grouping report embedded in every subject
+  report.
+- Update the explorer (`interactive.py`) and tests (`test_cli_spec.py`,
+  `test_explorer.py`, `test_serve.py`).
+
+qsiprep's plan-CLI conformance test exempts `--shoreline-model` until this is released
+and qsiprep's `qsiplan` pin is bumped. That must happen before the next qsiprep release.
+```
+
+If the user approves and the issue is filed, add its URL to the `_NOT_A_QSIPREP_FLAG` comment in `qsiprep/tests/test_plan_cli_spec.py` and commit.
+
+- [ ] **Step 5: PR body notes (for when the user asks for a PR)**
+
+The PR body, not `docs/changes.md`, must state:
+- **Breaking:** `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` are removed; use `--shoreline-config` (show the example JSON). 26.0.0 command lines that use `--shoreline-iters` or `--hmc-transform` now fail with "unrecognized arguments".
+- **Behavior change:** the iteration count is now honored. Before, SHORELine always ran 2 model iterations regardless of `--shoreline-iters`, including in 26.0.0.
+- **Release gate:** the QSIPlan follow-up (issue link) must be released, qsiprep's pin bumped and the conformance exemption removed before the next qsiprep release.
+- The summary shows "HMC Transform" only for SHORELine runs, and the SHORELine methods text now names the actual model and transform.

--- a/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
+++ b/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
@@ -166,10 +166,10 @@ also give the SHORELine settings different reload behavior from `hmc_method`.
 |---|---|
 | `workflows/dwi/hmc_sdc.py:140` | Pass `num_model_iterations=config.workflow.shoreline_iters` to `init_dwi_hmc_wf`. This is the bug fix; see "Effects of the iteration fix" below. |
 | `workflows/dwi/base.py:257-262` | Delete the runtime check that `iters` is at least 1; the loader enforces it. |
-| `workflows/dwi/base.py:~491` | Pass `hmc_transform` to `DiffusionSummary` only when `config.workflow.hmc_method == 'shoreline'`. Gating on the method rather than on the value means a stale value could never reach an eddy or TORTOISE summary. |
+| `workflows/dwi/base.py:~491` | Pass `hmc_transform` to `DiffusionSummary` only when the resolved HMC method is SHORELine: `hmc_tool == 'shoreline'`, where `hmc_tool = unit.run.hmc_stage.tool` is set at `base.py:256` in the same function. This is the resolved form of `hmc_method`, and it also covers configs that carry only the legacy `hmc_model`. Gating on the method rather than on the value means a stale value could never reach an eddy or TORTOISE summary. |
 | `interfaces/reports.py` | Make `DiffusionSummaryInputSpec.hmc_transform` optional (no longer `mandatory=True`). Render the "HMC Transform" `<li>` only when it is defined. The other lines are unchanged. |
 | `workflows/dwi/hmc.py:~389` (`init_b0_hmc_wf`, iterative branch) | The methods text says "iterations of `{config.workflow.hmc_model}` registrations"; change it to the local `transform` (Affine or Rigid), which is what actually selects the ANTs settings (`hmc.py:~271`). The `first` branch already does this. It also corrects the anatomical merge and intramodal template text, which pass their own `transform`. |
-| `workflows/dwi/hmc.py:~717-722` (`init_dwi_model_hmc_wf`) | The methods text always says "reconstructing the others using 3dSHORE [@merlet3dshore]". Name the model from `config.workflow.shoreline_model`: "3dSHORE [@merlet3dshore]" for `3dshore` and "a tensor model" for `tensor`. `none` never reaches this function, because `init_dwi_hmc_wf` returns early (`hmc.py:~162`). |
+| `workflows/dwi/hmc.py:~717-722` (`init_dwi_model_hmc_wf`) | The methods text always says "reconstructing the others using 3dSHORE [@merlet3dshore]". Name the model from `config.workflow.hmc_model`, the value `SignalPrediction` actually reads (`hmc.py:~585`): "3dSHORE [@merlet3dshore]" for `3dSHORE` and "a tensor model" for `tensor`. `none` never reaches this function, because `init_dwi_hmc_wf` returns early (`hmc.py:~162`). |
 | `workflows/dwi/hmc.py` (lines 357, 583), `workflows/dwi/derivatives.py:89`, `utils/plan.py` | No change. They read the resolved fields. |
 
 ### Effects of the iteration fix
@@ -284,7 +284,7 @@ This is the regression test for the bug fix. On the current code both builds con
 
 **Methods text:**
 
-- building `init_dwi_model_hmc_wf` with `shoreline_model = 'tensor'` and
+- building `init_dwi_model_hmc_wf` with `hmc_model = 'tensor'` and
   `hmc_transform = 'Rigid'` gives a `__desc__` that mentions a tensor model and a Rigid
   transform, and does not contain "3dSHORE";
 - with `3dshore`, it contains "3dSHORE [@merlet3dshore]";
@@ -366,7 +366,7 @@ A Codex adversarial review of the first draft (task `task-mtx37zjc-sadktc`) rais
 
 - **`--config-file` ordering (high):** fixed by making the command line authoritative for
   the SHORELine block (section 1, "Interaction with `--config-file`") and by gating the
-  summary on `hmc_method`. Tests added.
+  summary on the resolved HMC method. Tests added.
 - **QSIPlan's `cli_phrase()` appears in qsiprep's own workflow log and embedded grouping
   report (high):** handled in section 5.
 - **The iteration fix has observable effects beyond node count (medium):** documented in

--- a/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
+++ b/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
@@ -1,0 +1,261 @@
+# `--shoreline-config` design
+
+Issue: [PennLINC/qsiprep#1132](https://github.com/PennLINC/qsiprep/issues/1132)
+Branch: `shoreline-config`
+
+## Goal
+
+Replace `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` with a single
+`--shoreline-config` JSON file, following the pattern of `--eddy-config` and
+`--diffprep-config`.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Retiring the old flags | Remove all three outright. `--shoreline-model` was never released. `--shoreline-iters` and `--hmc-transform` shipped in 26.0.0 but are removed without a deprecation cycle. SHORELine itself is proposed for removal in 27.0.0 (#1086). |
+| JSON schema | Short keys `model`, `iters`, `transform`, all optional. Validation is strict: unknown keys and bad values are errors. |
+| Non-SHORELine runs | `--shoreline-config` without `--hmc-method shoreline` is a parse error. SHORELine settings are resolved only for SHORELine runs. The HTML summary drops the "HMC Transform" line for eddy and TORTOISE. |
+| QSIPlan coupling | Change qsiprep only. Exempt `--shoreline-model` in the plan-CLI conformance tests and open a follow-up issue in QSIPlan. |
+
+## Background
+
+- `hmc_transform` only matters for SHORELine. `init_b0_hmc_wf` falls back to it only when
+  called without `transform=`. The anatomical merge (`workflows/anatomical/volume.py`) and
+  the intramodal template (`workflows/dwi/intramodal_template.py`) both pass their own
+  transform. Its other use is the diffusion summary, which currently prints
+  "HMC Transform: Affine" even for eddy and TORTOISE runs.
+- The SHORELine model must be known at parse time. `DeprecationForwardingParser.parse_known_args`
+  derives the legacy `hmc_model` from it, and `utils/plan.py` and QSIPlan's
+  `selection_from_namespace` read the `shoreline_model` dest.
+- `config.load` skips keys a config class doesn't have, so old `config.toml` files stay
+  loadable either way.
+- **Existing bug:** `--shoreline-iters` never reaches the workflow.
+  `workflows/dwi/hmc_sdc.py` calls `init_dwi_hmc_wf(source_file=source_file)`, so
+  `num_model_iterations` is always its default of 2. This was already true in 26.0.0.
+  The value is read only by a validity check in `base.py` and by `derivatives.py`, which
+  uses it to decide whether to write `hmcOptimization`.
+
+## Approach
+
+The parser resolves the config once. It loads and validates the JSON, then writes three
+resolved internal values onto the namespace: `shoreline_model`, `shoreline_iters` and
+`hmc_transform`. These are derived config fields with no flags, like `hmc_model` today.
+Consumers keep reading the same names.
+
+Rejected alternatives:
+
+- **Path only, like `--diffprep-config`:** the parser would still have to load the file to
+  derive the model, so the JSON would be read in two places and seven consumers would change.
+- **Nested dict in config:** every consumer would change, and it adds a nested TOML table
+  that no other config field uses.
+
+## 1. CLI and resolution
+
+### Flags
+
+- **Add** `--shoreline-config PATH` to the motion-correction group, with `type=IsFile`.
+  Its help text lists the keys and links to the shipped default:
+  https://github.com/PennLINC/qsiprep/blob/main/qsiprep/data/shoreline_params.json
+- **Remove** `--shoreline-model`, `--shoreline-iters` and `--hmc-transform`. A command line
+  that uses them fails with argparse's "unrecognized arguments" error.
+- **Update help text:**
+  - `--hmc-method` points to `--shoreline-config` instead of the removed flags;
+  - the `--hmc-model` help and its `deprecations` entry say "with a `--shoreline-config`
+    `model`" instead of "with `--shoreline-model`".
+
+### Shipped default
+
+New file `qsiprep/data/shoreline_params.json`:
+
+```json
+{
+  "model": "3dshore",
+  "iters": 2,
+  "transform": "Affine"
+}
+```
+
+### Loader
+
+New `load_shoreline_config(path, model=None)` in `qsiprep/utils/misc.py`, next to
+`validate_diffprep_config`.
+
+- **Input:** `path` is a config file, or `None`, which uses the defaults. `model` is an
+  optional override from the deprecated `--hmc-model` alias (`3dshore`, `tensor` or `none`).
+- **Returns:** a dict with exactly `model`, `iters` and `transform`: the user file merged
+  over the shipped defaults, then `model` applied if given.
+- **Raises `ValueError`** with a message naming the file and the offending key or value if:
+  - the file does not exist, or is not valid JSON;
+  - the top level is not a JSON object;
+  - there is a key other than `model`, `iters` or `transform`;
+  - `model` is not `3dshore`, `tensor` or `none`;
+  - `transform` is not `Affine` or `Rigid`;
+  - `iters` is not an `int`, or is a `bool`;
+  - `iters < 1`, unless the resolved `model` is `none`, which ignores `iters`;
+  - `model` is given and the user file also sets `"model"`. The message is:
+    `--hmc-model conflicts with "model" in --shoreline-config <path>`.
+
+### Where resolution happens
+
+In `DeprecationForwardingParser.parse_known_args`, where the method axes are already
+normalized:
+
+1. Resolve `hmc_method` as today, including the deprecated `--hmc-model` alias.
+2. If `shoreline_config` is set and `hmc_method != 'shoreline'`, call
+   `self.error('--shoreline-config requires --hmc-method shoreline')`.
+3. If `hmc_method == 'shoreline'`, call
+   `load_shoreline_config(namespace.shoreline_config, model=legacy_model)` and turn any
+   `ValueError` into `self.error(str(exc))`. `legacy_model` is the lowercased SHORELine
+   model from `--hmc-model 3dSHORE|tensor|none` (through the existing
+   `hmc_model_to_shoreline_model` map), or `None` when `--hmc-method` was used. The loader
+   handles the legacy/`"model"` conflict, so `iters` and `transform` can still come from
+   the file alongside a legacy model.
+   - Set `namespace.shoreline_model`, `namespace.shoreline_iters` and
+     `namespace.hmc_transform` from the resolved dict.
+4. Otherwise set all three to `None`.
+5. Derive `hmc_model` from `shoreline_model` as today.
+
+The existing SHORELine removal notice printed to stderr is unchanged.
+
+### Config storage
+
+- `config.workflow.shoreline_config = None`, documented as "Configuration JSON for SHORELine."
+- Add `shoreline_config` to **`workflow._paths`**, making it `('gradient_file', 'shoreline_config')`.
+  `IsFile` returns an absolute `Path`, and `config.py` warns that an unlisted `Path` reaches
+  the workflow-building subprocess as the literal string `"PosixPath('...')"`. The
+  `eddy_config` and `diffprep_config` entries in `execution._paths` have no effect, but
+  those options store plain strings. This design does not touch them.
+- Rewrite the docstrings of `shoreline_iters`, `shoreline_model` and `hmc_transform` to say
+  they are derived from `--shoreline-config` and are `None` unless `hmc_method` is `shoreline`.
+
+## 2. Consumers and the summary
+
+| Location | Change |
+|---|---|
+| `workflows/dwi/hmc_sdc.py:140` | Pass `num_model_iterations=config.workflow.shoreline_iters` to `init_dwi_hmc_wf`. This is the bug fix. |
+| `workflows/dwi/base.py:257-262` | Delete the runtime check that `iters` is at least 1; the loader enforces it. |
+| `workflows/dwi/base.py:~491` | Pass `hmc_transform` to `DiffusionSummary` only when `config.workflow.hmc_transform` is not `None`. |
+| `interfaces/reports.py` | Make `DiffusionSummaryInputSpec.hmc_transform` optional (no longer `mandatory=True`). Render the "HMC Transform" `<li>` only when it is defined. The other lines are unchanged. |
+| `workflows/dwi/hmc.py` (lines 357, 583, 722), `workflows/dwi/derivatives.py:89`, `utils/plan.py` | No change. They read the resolved fields. |
+| `qsiprep/data/tests/config.toml` | Remove `hmc_transform` and `shoreline_iters`. That fixture is an eddy run. |
+
+Tests that assign `config.workflow.hmc_transform` or `shoreline_iters` directly keep working.
+
+## 3. Documentation
+
+- **`docs/usage.rst`:** generated by sphinx-argparse; no edit.
+- **`docs/quickstart.rst`**, "Head motion correction method":
+  - replace the `--shoreline-model` wording with `--shoreline-config` and a short JSON example;
+  - update the parenthetical on `--hmc-model`;
+  - rewrite the `--shoreline-model none` paragraph as `"model": "none"`.
+- **`docs/preprocessing.rst`:**
+  - add a "Configuring SHORELine" subsection (`.. _configure_shoreline:`) modeled on
+    "Configuring `eddy`", with a table of the three keys (allowed values and defaults)
+    and a link to `shoreline_params.json`. It sits in the SHORELine section and is
+    referenced from the quickstart;
+  - reword "If `"none"` is specified as the hmc_model" to refer to the `"model"` key.
+- **`docs/notebooks/grouping_tutorial.md`:** update the `--hmc-method` bullet.
+- **Out of scope:** the `.. workflow::` directives in `preprocessing.rst` that already pass
+  kwargs the current functions don't accept. `docs/changes.md` is not edited; the PR body
+  describes the breaking change.
+
+## 4. Tests
+
+### Unit tests (run locally: `micromamba run -n linc311 pytest ...`)
+
+**`load_shoreline_config`**, in `qsiprep/tests/test_cli.py` next to the DIFFPREP validator tests:
+
+- the shipped `shoreline_params.json` is valid and equals the `None` result;
+- a partial file (`{"model": "tensor"}`) is merged with the defaults;
+- errors are raised for:
+  - a missing file;
+  - a JSON list at the top level;
+  - an unknown key (`{"iter": 3}`);
+  - a bad `model`;
+  - a bad `transform`;
+  - `iters` set to `0`, `true` or `"2"`;
+- `{"model": "none", "iters": 0}` is accepted.
+
+**Parser**, in `qsiprep/tests/test_cli_run.py`:
+
+- **Defaults:** with default eddy, `shoreline_model`, `shoreline_iters` and `hmc_transform`
+  are all `None`.
+- **Shipped defaults:** `--hmc-method shoreline` gives `3dshore`, `2` and `Affine`, with
+  `hmc_model == '3dSHORE'`.
+- **Custom config:** `--hmc-method shoreline --shoreline-config <tensor, 3, Rigid>` resolves
+  to those values, with `hmc_model == 'tensor'`.
+- **Wrong method:** `--shoreline-config` with eddy or tortoise gives `SystemExit` and
+  "requires --hmc-method shoreline".
+- **Bad file:** an invalid `--shoreline-config` gives `SystemExit` with the loader's message.
+- **Legacy merge:** `--hmc-model tensor --shoreline-config {"iters": 3}` resolves to tensor
+  with 3 iterations and warns about the deprecation.
+- **Legacy conflict:** `--hmc-model tensor --shoreline-config {"model": "3dshore"}` gives
+  `SystemExit`.
+- **Removed flags:** each of `--shoreline-model`, `--shoreline-iters` and `--hmc-transform`
+  gives `SystemExit` with "unrecognized arguments".
+- Replace `test_shoreline_model_requires_shoreline_method`. Update `test_method_axis_defaults`
+  and `test_hmc_model_alias_maps_and_warns` so they don't depend on the removed flags.
+
+**Config round-trip:** after parsing with `--shoreline-config`, `config.from_dict` followed by
+`config.to_filename` and `config.load` leaves `config.workflow.shoreline_config` as a real
+path, and the TOML contains no `PosixPath(`.
+
+**QSIPlan conformance** (`qsiprep/tests/test_plan_cli_spec.py`):
+
+- both conformance tests exempt `--shoreline-model` through a named constant, commented
+  with the QSIPlan follow-up issue;
+- a new test parses `--hmc-method shoreline --shoreline-config {"model": "tensor"}`.
+  `cli_spec.selection_from_namespace` must return a SHORELine selection with
+  `shoreline_model == 'tensor'`.
+
+**Iteration wiring**, in `qsiprep/tests/test_workflows_gradwarp.py`, reusing
+`_cfg_for_shoreline`, `_shoreline_wf` and `_rpe_unit`. These already build
+`init_qsiprep_hmcsdc_wf`, the function that had the bug. Build the workflow with
+`config.workflow.shoreline_iters` set to `3`, then `2`, and check the leaf names from
+`wf.list_node_names()`:
+
+- with `3`, some names start with `dwi_hmc_wf.dwi_model_hmc_wf.shoreline_iteration002.`;
+- with `2`, names start with `...shoreline_iteration001.` but none with
+  `...shoreline_iteration002.`.
+
+This is the regression test for the bug fix: on the current code both builds contain only
+`shoreline_iteration001`.
+
+**Summary:** `DiffusionSummary` rendered without `hmc_transform` has no "HMC Transform"
+line; with `hmc_transform='Rigid'` it shows "HMC Transform: Rigid".
+
+### Integration tests (`qsiprep/tests/test_cli.py`; Docker/CI only, not run locally)
+
+New files under `qsiprep/tests/data/`, loaded with `get_test_data_path()` the way
+`eddy_config.json` is:
+
+| File | Contents | Replaces |
+|---|---|---|
+| `shoreline_none_config.json` | `{"model": "none", "iters": 1}` | `--shoreline-model=none --shoreline-iters=1` (drbuddi_shoreline_epi); also `--shoreline-model=none` in the second SHORELine run (around line 645) |
+| `shoreline_tensor_config.json` | `{"model": "tensor", "iters": 1}` | `--shoreline-model=tensor --shoreline-iters=1` (drbuddi_tensorline_epi) |
+| `shoreline_rigid_config.json` | `{"transform": "Rigid", "iters": 1}` | `--hmc-transform=Rigid --shoreline-iters=1` (dscsdsi) |
+
+With the iteration fix, `iters: 1` now really does make these runs cheaper, so expected
+outputs stay the same apart from anything that depends on the iteration count. The
+`hmcOptimization` file is written only for `3dSHORE` with `iters > 1`, which these
+configurations don't trigger. If a run's `*_outputs.txt` changes, it is updated in the PR.
+
+## 5. QSIPlan follow-up (outside this PR)
+
+Draft an issue for PennLINC/QSIPlan and file it only after the user approves:
+
+- remove `--shoreline-model` from `cli_spec.PLAN_OPTIONS`, or mark it as a flag qsiprep
+  doesn't expose;
+- make `MethodSelection.cli_phrase()` and the explorer suggest
+  `--shoreline-config` with a `"model"` key instead of `--shoreline-model`;
+- update QSIPlan's tests (`test_cli_spec.py`, `test_explorer.py`, `test_serve.py`).
+
+Once that is released and qsiprep's `qsiplan` pin is bumped, remove the conformance
+exemption.
+
+## Out of scope
+
+- Removing SHORELine (#1086).
+- Fixing the stale `.. workflow::` directives in `docs/preprocessing.rst`.
+- Cleaning up the ineffective `eddy_config` and `diffprep_config` entries in `execution._paths`.

--- a/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
+++ b/docs/superpowers/specs/2026-09-11-shoreline-config-design.md
@@ -16,7 +16,7 @@ Replace `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` with a si
 | Retiring the old flags | Remove all three outright. `--shoreline-model` was never released. `--shoreline-iters` and `--hmc-transform` shipped in 26.0.0 but are removed without a deprecation cycle. SHORELine itself is proposed for removal in 27.0.0 (#1086). |
 | JSON schema | Short keys `model`, `iters`, `transform`, all optional. Validation is strict: unknown keys and bad values are errors. |
 | Non-SHORELine runs | `--shoreline-config` without `--hmc-method shoreline` is a parse error. SHORELine settings are resolved only for SHORELine runs. The HTML summary drops the "HMC Transform" line for eddy and TORTOISE. |
-| QSIPlan coupling | Change qsiprep only. Exempt `--shoreline-model` in the plan-CLI conformance tests and open a follow-up issue in QSIPlan. |
+| QSIPlan coupling | This PR changes qsiprep only: `--shoreline-model` is exempted in the plan-CLI conformance tests and a QSIPlan issue is opened. **Release gate:** the QSIPlan fix must be released, and qsiprep's `qsiplan` pin bumped, before the next qsiprep release (section 5). |
 
 ## Background
 
@@ -30,6 +30,11 @@ Replace `--shoreline-model`, `--shoreline-iters` and `--hmc-transform` with a si
   `selection_from_namespace` read the `shoreline_model` dest.
 - `config.load` skips keys a config class doesn't have, so old `config.toml` files stay
   loadable either way.
+- `parse_args` loads `--config-file` after parsing, then overlays the parsed namespace with
+  `config.from_dict(vars(opts))` (`cli/parser.py` around lines 1147 and 1175).
+  `_Config.load` skips `None` values (`config.py:226`). Values the parser resolves already
+  win over a loaded file: `hmc_method` always resolves to a non-`None` value, so a config
+  file never restores it.
 - **Existing bug:** `--shoreline-iters` never reaches the workflow.
   `workflows/dwi/hmc_sdc.py` calls `init_dwi_hmc_wf(source_file=source_file)`, so
   `num_model_iterations` is always its default of 2. This was already true in 26.0.0.
@@ -124,20 +129,61 @@ The existing SHORELine removal notice printed to stderr is unchanged.
 - Add `shoreline_config` to **`workflow._paths`**, making it `('gradient_file', 'shoreline_config')`.
   `IsFile` returns an absolute `Path`, and `config.py` warns that an unlisted `Path` reaches
   the workflow-building subprocess as the literal string `"PosixPath('...')"`. The
-  `eddy_config` and `diffprep_config` entries in `execution._paths` have no effect, but
-  those options store plain strings. This design does not touch them.
+  existing `eddy_config` and `diffprep_config` entries in `execution._paths` do take
+  effect: `_Config.load` checks `_paths` before `hasattr`, so loading them creates
+  path-valued attributes on `execution` that duplicate the `workflow` fields. That
+  duplication is not needed for `shoreline_config`, and this design does not touch the
+  existing entries.
 - Rewrite the docstrings of `shoreline_iters`, `shoreline_model` and `hmc_transform` to say
   they are derived from `--shoreline-config` and are `None` unless `hmc_method` is `shoreline`.
+
+### Interaction with `--config-file`
+
+Relying on `config.from_dict(vars(opts))` alone would leave the SHORELine block
+inconsistent after a `--config-file` reload:
+
+- a loaded file's `shoreline_config` would survive when the command line gives none,
+  because `None` is skipped, while the parser's resolved defaults overwrite the file's
+  `shoreline_model`, `shoreline_iters` and `hmc_transform`;
+- an old eddy `config.toml` would keep its stale `hmc_transform = "Affine"` and
+  `shoreline_iters = 2`.
+
+So the command line is authoritative for the SHORELine block, as it already is for
+`hmc_method`. Right after `config.from_dict(vars(opts), ...)`, `parse_args` assigns
+`config.workflow.shoreline_config`, `shoreline_model`, `shoreline_iters` and
+`hmc_transform` directly from `opts`, including `None` values. A reloaded run that wants
+custom SHORELine settings passes `--shoreline-config` again, just as it must pass
+`--hmc-method shoreline` again.
+
+Resolving after the merge instead would mean moving the method-axis normalization and the
+`hmc_model` derivation out of `parse_known_args`. The parser tests and QSIPlan's
+`selection_from_namespace` rely on that normalization happening during parsing. It would
+also give the SHORELine settings different reload behavior from `hmc_method`.
 
 ## 2. Consumers and the summary
 
 | Location | Change |
 |---|---|
-| `workflows/dwi/hmc_sdc.py:140` | Pass `num_model_iterations=config.workflow.shoreline_iters` to `init_dwi_hmc_wf`. This is the bug fix. |
+| `workflows/dwi/hmc_sdc.py:140` | Pass `num_model_iterations=config.workflow.shoreline_iters` to `init_dwi_hmc_wf`. This is the bug fix; see "Effects of the iteration fix" below. |
 | `workflows/dwi/base.py:257-262` | Delete the runtime check that `iters` is at least 1; the loader enforces it. |
-| `workflows/dwi/base.py:~491` | Pass `hmc_transform` to `DiffusionSummary` only when `config.workflow.hmc_transform` is not `None`. |
+| `workflows/dwi/base.py:~491` | Pass `hmc_transform` to `DiffusionSummary` only when `config.workflow.hmc_method == 'shoreline'`. Gating on the method rather than on the value means a stale value could never reach an eddy or TORTOISE summary. |
 | `interfaces/reports.py` | Make `DiffusionSummaryInputSpec.hmc_transform` optional (no longer `mandatory=True`). Render the "HMC Transform" `<li>` only when it is defined. The other lines are unchanged. |
-| `workflows/dwi/hmc.py` (lines 357, 583, 722), `workflows/dwi/derivatives.py:89`, `utils/plan.py` | No change. They read the resolved fields. |
+| `workflows/dwi/hmc.py:~389` (`init_b0_hmc_wf`, iterative branch) | The methods text says "iterations of `{config.workflow.hmc_model}` registrations"; change it to the local `transform` (Affine or Rigid), which is what actually selects the ANTs settings (`hmc.py:~271`). The `first` branch already does this. It also corrects the anatomical merge and intramodal template text, which pass their own `transform`. |
+| `workflows/dwi/hmc.py:~717-722` (`init_dwi_model_hmc_wf`) | The methods text always says "reconstructing the others using 3dSHORE [@merlet3dshore]". Name the model from `config.workflow.shoreline_model`: "3dSHORE [@merlet3dshore]" for `3dshore` and "a tensor model" for `tensor`. `none` never reaches this function, because `init_dwi_hmc_wf` returns early (`hmc.py:~162`). |
+| `workflows/dwi/hmc.py` (lines 357, 583), `workflows/dwi/derivatives.py:89`, `utils/plan.py` | No change. They read the resolved fields. |
+
+### Effects of the iteration fix
+
+This is an observable processing change for anyone whose `iters` isn't 2:
+
+- **`iters: 1`:** one model iteration instead of two. `summarize_iterations`, the
+  `desc-shorelineiters` figure and `optimization_data` are no longer produced
+  (`hmc.py:~823`). `hmcOptimization.csv` was already suppressed for `iters <= 1` by
+  `derivatives.py:89`.
+- **`iters: 3` or more:** extra registration passes, so different transforms and corrected
+  images, a different optimization CSV, and a different iteration count in the methods text.
+
+The PR body states this.
 | `qsiprep/data/tests/config.toml` | Remove `hmc_transform` and `shoreline_iters`. That fixture is an eddy run. |
 
 Tests that assign `config.workflow.hmc_transform` or `shoreline_iters` directly keep working.
@@ -201,29 +247,55 @@ Tests that assign `config.workflow.hmc_transform` or `shoreline_iters` directly 
 `config.to_filename` and `config.load` leaves `config.workflow.shoreline_config` as a real
 path, and the TOML contains no `PosixPath(`.
 
+**`--config-file` reloads**, through `qsiprep.cli.parser.parse_args` so the real
+load-then-overlay order is exercised:
+
+- an old eddy TOML with `hmc_transform = "Affine"` and `shoreline_iters = 2`, reloaded
+  with the default eddy method, leaves all four SHORELine fields `None`;
+- a TOML with `shoreline_config` set and `shoreline_model = "tensor"`, reloaded with
+  `--hmc-method shoreline` and no `--shoreline-config`, gives `shoreline_config is None` and
+  the shipped defaults (`3dshore`, `2`, `Affine`);
+- the same TOML reloaded with `--shoreline-config <rigid.json>` gives that path and its
+  values.
+
 **QSIPlan conformance** (`qsiprep/tests/test_plan_cli_spec.py`):
 
 - both conformance tests exempt `--shoreline-model` through a named constant, commented
   with the QSIPlan follow-up issue;
-- a new test parses `--hmc-method shoreline --shoreline-config {"model": "tensor"}`.
-  `cli_spec.selection_from_namespace` must return a SHORELine selection with
-  `shoreline_model == 'tensor'`.
+- a new test, parametrized over `3dshore`, `tensor` and `none`, parses
+  `--hmc-method shoreline --shoreline-config {"model": <model>}`.
+  `cli_spec.selection_from_namespace` must return a SHORELine selection with that
+  `shoreline_model`. With `--hmc-method eddy`, the namespace has `shoreline_model is None`
+  and the selection resolves to eddy.
 
 **Iteration wiring**, in `qsiprep/tests/test_workflows_gradwarp.py`, reusing
 `_cfg_for_shoreline`, `_shoreline_wf` and `_rpe_unit`. These already build
 `init_qsiprep_hmcsdc_wf`, the function that had the bug. Build the workflow with
-`config.workflow.shoreline_iters` set to `3`, then `2`, and check the leaf names from
-`wf.list_node_names()`:
+`config.workflow.shoreline_iters` set to `3`, then `1`, and check the leaf names from
+`wf.list_node_names()` under `dwi_hmc_wf.dwi_model_hmc_wf.`:
 
-- with `3`, some names start with `dwi_hmc_wf.dwi_model_hmc_wf.shoreline_iteration002.`;
-- with `2`, names start with `...shoreline_iteration001.` but none with
-  `...shoreline_iteration002.`.
+- with `3`: names under `shoreline_iteration002.` exist, `summarize_iterations` exists,
+  and the `dwi_model_hmc_wf` methods text says "A total of 3 iterations";
+- with `1`: nothing under `shoreline_iteration001.`, no `summarize_iterations`, and the
+  text says "A total of 1 iterations".
 
-This is the regression test for the bug fix: on the current code both builds contain only
-`shoreline_iteration001`.
+This is the regression test for the bug fix. On the current code both builds contain
+`shoreline_iteration001` and `summarize_iterations`, and say 2 iterations.
 
-**Summary:** `DiffusionSummary` rendered without `hmc_transform` has no "HMC Transform"
-line; with `hmc_transform='Rigid'` it shows "HMC Transform: Rigid".
+**Methods text:**
+
+- building `init_dwi_model_hmc_wf` with `shoreline_model = 'tensor'` and
+  `hmc_transform = 'Rigid'` gives a `__desc__` that mentions a tensor model and a Rigid
+  transform, and does not contain "3dSHORE";
+- with `3dshore`, it contains "3dSHORE [@merlet3dshore]";
+- `init_b0_hmc_wf(align_to='iterative', transform='Rigid')` describes "Rigid registrations".
+
+**Summary:**
+
+- `DiffusionSummary` rendered without `hmc_transform` has no "HMC Transform" line; with
+  `hmc_transform='Rigid'` it shows "HMC Transform: Rigid";
+- at the workflow level, the `summary` node built for an eddy run leaves `hmc_transform`
+  undefined even when `config.workflow.hmc_transform` has been set to a stale `'Affine'`.
 
 ### Integration tests (`qsiprep/tests/test_cli.py`; Docker/CI only, not run locally)
 
@@ -236,12 +308,30 @@ New files under `qsiprep/tests/data/`, loaded with `get_test_data_path()` the wa
 | `shoreline_tensor_config.json` | `{"model": "tensor", "iters": 1}` | `--shoreline-model=tensor --shoreline-iters=1` (drbuddi_tensorline_epi) |
 | `shoreline_rigid_config.json` | `{"transform": "Rigid", "iters": 1}` | `--hmc-transform=Rigid --shoreline-iters=1` (dscsdsi) |
 
-With the iteration fix, `iters: 1` now really does make these runs cheaper, so expected
-outputs stay the same apart from anything that depends on the iteration count. The
-`hmcOptimization` file is written only for `3dSHORE` with `iters > 1`, which these
-configurations don't trigger. If a run's `*_outputs.txt` changes, it is updated in the PR.
+With the iteration fix, these `iters: 1` runs now do one model iteration instead of two. No
+expected-output list should change: none of their `*_outputs.txt` files lists a
+`desc-shorelineiters` figure or `hmcOptimization.csv`. The only list containing
+`hmcOptimization.csv`, `maternal_brain_project_outputs.txt`, comes from a run that uses the
+default `iters` of 2. If a list does change, it is updated in the PR.
 
-## 5. QSIPlan follow-up (outside this PR)
+## 5. QSIPlan follow-up (outside this PR; gates the next qsiprep release)
+
+### Why it matters
+
+qsiprep shows QSIPlan's `MethodSelection.cli_phrase()` to users in two places:
+
+- the workflow log, through `describe_processing` (`workflows/base.py:~379`, whose title
+  QSIPlan builds in `qsiplan/report.py:~241`);
+- the grouping report embedded at the top of every subject report
+  (`workflows/base.py:~387-393`), whose plan panel renders it (`qsiplan/interactive.py:~765`).
+
+For SHORELine runs with a `tensor` or `none` model, that phrase is
+`--hmc-method shoreline --shoreline-model <model> --sdc-method drbuddi`, a flag this change
+removes. `3dshore` runs are unaffected because `cli_phrase()` omits the default model.
+Until QSIPlan is fixed, `main` shows that stale phrase for deprecated tensor and none runs.
+No release may ship it.
+
+### Issue
 
 Draft an issue for PennLINC/QSIPlan and file it only after the user approves:
 
@@ -251,11 +341,46 @@ Draft an issue for PennLINC/QSIPlan and file it only after the user approves:
   `--shoreline-config` with a `"model"` key instead of `--shoreline-model`;
 - update QSIPlan's tests (`test_cli_spec.py`, `test_explorer.py`, `test_serve.py`).
 
-Once that is released and qsiprep's `qsiplan` pin is bumped, remove the conformance
-exemption.
+### Release gate
+
+Before the next qsiprep release:
+
+1. the QSIPlan fix is released;
+2. qsiprep's `qsiplan` pin in `pyproject.toml` is bumped to that release;
+3. the `--shoreline-model` conformance exemption is removed.
+
+The PR body records this gate and links the QSIPlan issue, and the exemption constant's
+comment points to that issue.
 
 ## Out of scope
 
 - Removing SHORELine (#1086).
 - Fixing the stale `.. workflow::` directives in `docs/preprocessing.rst`.
-- Cleaning up the ineffective `eddy_config` and `diffprep_config` entries in `execution._paths`.
+- Cleaning up the duplicate `eddy_config` and `diffprep_config` entries in `execution._paths`.
+
+## Review log
+
+A Codex adversarial review of the first draft (task `task-mtx37zjc-sadktc`) raised these points.
+
+**Accepted:**
+
+- **`--config-file` ordering (high):** fixed by making the command line authoritative for
+  the SHORELine block (section 1, "Interaction with `--config-file`") and by gating the
+  summary on `hmc_method`. Tests added.
+- **QSIPlan's `cli_phrase()` appears in qsiprep's own workflow log and embedded grouping
+  report (high):** handled in section 5.
+- **The iteration fix has observable effects beyond node count (medium):** documented in
+  "Effects of the iteration fix", and the tests check `summarize_iterations` and the
+  methods text.
+- **The SHORELine methods text misreports the model and transform (medium):** both
+  `hmc.py` strings are fixed and tested.
+- **The `execution._paths` rationale was wrong (low):** corrected.
+
+**Declined:**
+
+- **Moving all resolution after the `--config-file` merge:** it would restructure the
+  method-axis normalization for no benefit over the command-line-authoritative rule, and it
+  would diverge from how `hmc_method` reloads.
+- **Numerical integration expectations, tests of every model and transform combination,
+  and a `--sloppy` matrix:** the resolved values feed existing code paths unchanged, apart
+  from the fixes above, which have targeted tests.

--- a/qsiprep/cli/parser.py
+++ b/qsiprep/cli/parser.py
@@ -28,7 +28,7 @@ import sys
 
 from .. import config
 from ..utils.gpu import GPU_ALIASES, GPU_TASKS
-from ..utils.misc import parse_denoise_method
+from ..utils.misc import load_shoreline_config, parse_denoise_method
 
 B0_TO_ANAT_TRANSFORM_DEFAULT = 'Rigid'
 """Default for ``--b0-to-anat-transform``.
@@ -73,7 +73,7 @@ def _build_parser(**kwargs):
         ),
         '--hmc-model': (
             '27.0.0',
-            'Use `--hmc-method` instead (with `--shoreline-model` for the '
+            'Use `--hmc-method` instead (with a `--shoreline-config` "model" for the '
             'SHORELine signal model).',
         ),
         '--pepolar-method': (
@@ -190,21 +190,30 @@ def _build_parser(**kwargs):
             if hasattr(namespace, '_legacy_pepolar_method'):
                 del namespace._legacy_pepolar_method
 
+            legacy_shoreline_model = None
             if legacy_hmc is not None:
-                if namespace.shoreline_model is not None:
-                    self.error(
-                        '--shoreline-model requires --hmc-method shoreline '
-                        '(not the deprecated --hmc-model)'
-                    )
                 namespace.hmc_method = hmc_model_to_method[legacy_hmc]
-                namespace.shoreline_model = hmc_model_to_shoreline_model.get(legacy_hmc)
+                legacy_shoreline_model = hmc_model_to_shoreline_model.get(legacy_hmc)
             if namespace.hmc_method is None:
                 namespace.hmc_method = 'eddy'
-            if namespace.shoreline_model is not None and namespace.hmc_method != 'shoreline':
-                self.error('--shoreline-model requires --hmc-method shoreline')
+            if namespace.shoreline_config is not None and namespace.hmc_method != 'shoreline':
+                self.error('--shoreline-config requires --hmc-method shoreline')
+            # SHORELine settings come from --shoreline-config (or the shipped
+            # defaults). Config and the workflow builders read only these resolved
+            # values, which stay None for the other methods.
+            namespace.shoreline_model = None
+            namespace.shoreline_iters = None
+            namespace.hmc_transform = None
             if namespace.hmc_method == 'shoreline':
-                if namespace.shoreline_model is None:
-                    namespace.shoreline_model = '3dshore'
+                try:
+                    shoreline = load_shoreline_config(
+                        namespace.shoreline_config, model=legacy_shoreline_model
+                    )
+                except ValueError as err:
+                    self.error(str(err))
+                namespace.shoreline_model = shoreline['model']
+                namespace.shoreline_iters = shoreline['iters']
+                namespace.hmc_transform = shoreline['transform']
                 print(
                     'SHORELine (--hmc-method shoreline) is scheduled for removal '
                     'in a future major release; eddy and tortoise are the '
@@ -862,13 +871,6 @@ How to combine the corrected results of an output's correction units.
         'of all b0 images to their midpoint image. '
         'Later versions will always use "iterative".',
     )
-    g_moco.add_argument(
-        '--hmc-transform',
-        action='store',
-        default='Affine',
-        choices=['Affine', 'Rigid'],
-        help='transformation to be optimized during head motion correction (default: affine)',
-    )
     g_hmc_method = g_moco.add_mutually_exclusive_group()
     g_hmc_method.add_argument(
         '--hmc-method',
@@ -878,7 +880,7 @@ How to combine the corrected results of an output's correction units.
         help='which software corrects head motion and eddy currents: '
         '"eddy" (FSL; requires a shelled sampling scheme; the default), '
         '"shoreline" (SHORELine; model-based, works on arbitrary q-space '
-        'sampling; see --shoreline-model and --shoreline-iters; scheduled '
+        'sampling; configured with --shoreline-config; scheduled '
         'for removal in a future major release), or '
         '"tortoise" (TORTOISE DIFFPREP; rigid head motion and 24-parameter '
         'quadratic eddy-current correction, arbitrary sampling; see '
@@ -896,20 +898,25 @@ How to combine the corrected results of an output's correction units.
             'tensor',
             'tortoise',
         ],
-        help='DEPRECATED: use --hmc-method (and --shoreline-model) instead. '
+        help='DEPRECATED: use --hmc-method (and --shoreline-config) instead. '
         '"eddy" means `--hmc-method eddy`; "tortoise" means `--hmc-method '
         'tortoise`; "3dSHORE", "tensor" and "none" mean `--hmc-method '
-        'shoreline` with the matching --shoreline-model.',
+        'shoreline` with the matching --shoreline-config "model".',
     )
     g_moco.add_argument(
-        '--shoreline-model',
+        '--shoreline-config',
         action='store',
+        type=IsFile,
         default=None,
-        choices=['3dshore', 'tensor', 'none'],
-        help='signal model SHORELine uses to predict motion-correction target '
-        'images: "3dshore" (the default), "tensor", or "none" (each non-b=0 '
-        'image is warped using the same transform as its nearest b=0 image). '
-        'Only valid with --hmc-method shoreline.',
+        help='path to a JSON file with settings for SHORELine (only valid with '
+        '--hmc-method shoreline). Every key is optional: "model" is the signal model '
+        'used to predict motion-correction targets ("3dshore", the default; "tensor"; '
+        'or "none", which warps each non-b=0 image with the transform of its nearest '
+        'b=0 image), "iters" is the number of SHORELine iterations (default: 2), and '
+        '"transform" is the transformation optimized during head motion correction '
+        '("Affine", the default, or "Rigid"). Unknown keys are an error. The current '
+        'default can be found here: '
+        'https://github.com/PennLINC/qsiprep/blob/main/qsiprep/data/shoreline_params.json',
     )
     g_moco.add_argument(
         '--eddy-config',
@@ -948,14 +955,6 @@ How to combine the corrected results of an output's correction units.
             'Requires the patched TORTOISE. Unset leaves TORTOISE at its default of 15.'
         ),
     )
-    g_moco.add_argument(
-        '--shoreline-iters',
-        action='store',
-        type=int,
-        default=2,
-        help='number of SHORELine iterations. (default: 2)',
-    )
-
     # Fieldmap options
     g_fmap = parser.add_argument_group('Specific options for handling fieldmaps')
     g_fmap.add_argument(
@@ -1173,6 +1172,11 @@ def parse_args(args=None, namespace=None):
 
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts), init=['nipype'])
+    # The command line is authoritative for SHORELine settings, as it already is
+    # for hmc_method. from_dict skips None values, so without this a --config-file
+    # could leave a stale shoreline_config, hmc_transform or shoreline_iters behind.
+    for key in ('shoreline_config', 'shoreline_model', 'shoreline_iters', 'hmc_transform'):
+        setattr(config.workflow, key, getattr(opts, key))
 
     if not config.execution.notrack:
         import importlib.util

--- a/qsiprep/config.py
+++ b/qsiprep/config.py
@@ -610,7 +610,9 @@ class workflow(_Config):
     vocabulary equivalent of ``hmc_method`` + ``shoreline_model``, kept while
     workflow builders still read it."""
     hmc_transform = None
-    """Transformation to be used in SHORELine."""
+    """Transformation SHORELine optimizes during head motion correction: Affine or
+    Rigid. Derived from ``--shoreline-config``; None unless ``hmc_method`` is
+    shoreline."""
     ignore = None
     """Ignore particular steps for *QSIPrep*."""
     infant = False
@@ -642,11 +644,15 @@ class workflow(_Config):
     topup, drbuddi or topup+drbuddi (the parser resolves ``auto``)."""
     separate_all_dwis = False
     """Process all dwis separately - do not attempt concatenation."""
+    shoreline_config = None
+    """Configuration JSON for SHORELine (``--shoreline-config``)."""
     shoreline_iters = None
-    """How many iterations to run SHORELine."""
+    """How many iterations to run SHORELine. Derived from ``--shoreline-config``;
+    None unless ``hmc_method`` is shoreline."""
     shoreline_model = None
     """Signal model SHORELine uses to predict motion-correction targets:
-    3dshore, tensor or none. Only set when ``hmc_method`` is shoreline."""
+    3dshore, tensor or none. Derived from ``--shoreline-config``; None unless
+    ``hmc_method`` is shoreline."""
     tortoise_gpu_cpu_ratio = None
     """Volumes the GPU takes per DIFFPREP pass; None leaves TORTOISE's default."""
     unringing_method = None
@@ -705,7 +711,7 @@ class workflow(_Config):
     # what ``_paths`` names, and toml writes anything else as its repr, so an
     # unlisted Path reaches the workflow-building subprocess as the literal
     # string "PosixPath('/path')".
-    _paths = ('gradient_file',)
+    _paths = ('gradient_file', 'shoreline_config')
 
 
 class loggers:

--- a/qsiprep/data/shoreline_params.json
+++ b/qsiprep/data/shoreline_params.json
@@ -1,0 +1,5 @@
+{
+  "model": "3dshore",
+  "iters": 2,
+  "transform": "Affine"
+}

--- a/qsiprep/data/tests/config.toml
+++ b/qsiprep/data/tests/config.toml
@@ -44,7 +44,6 @@ distortion_group_merge = "none"
 dwi_denoise_window = "auto"
 force_syn = false
 hmc_model = "eddy"
-hmc_transform = "Affine"
 ignore = []
 infant = false
 intramodal_template_iters = 0
@@ -54,7 +53,6 @@ no_b0_harmonization = false
 output_resolution = 5.0
 pepolar_method = "TOPUP"
 separate_all_dwis = false
-shoreline_iters = 2
 use_syn_sdc = false
 spaces = "MNI152NLin2009cAsym"
 

--- a/qsiprep/interfaces/reports.py
+++ b/qsiprep/interfaces/reports.py
@@ -60,8 +60,7 @@ DIFFUSION_TEMPLATE = """\t\t<h3 class="elem-title">Summary</h3>
 \t\t\t<li>Coregistration Transform: {coregistration}</li>
 \t\t\t<li>Denoising Method: {denoise_method}</li>
 \t\t\t<li>Denoising Window: {denoise_window}</li>
-\t\t\t<li>HMC Transform: {hmc_transform}</li>
-\t\t\t<li>HMC Model: {hmc_model}</li>
+{hmc_transform_line}\t\t\t<li>HMC Model: {hmc_model}</li>
 \t\t\t<li>Gradient correction: {gradient_correction}</li>
 \t\t\t<li>DWI series resampled to spaces: ACPC</li>
 \t\t\t<li>Confounds collected: {confounds}</li>
@@ -224,7 +223,7 @@ class DiffusionSummaryInputSpec(BaseInterfaceInputSpec):
     )
     distortion_correction = traits.Str(mandatory=True, desc='Method used for SDC')
     impute_slice_threshold = traits.CFloat(desc='threshold for imputing a slice')
-    hmc_transform = traits.Str(mandatory=True, desc='transform used during HMC')
+    hmc_transform = traits.Str(desc='transform optimized during HMC (SHORELine runs only)')
     hmc_model = traits.Str(desc='model used for hmc')
     b0_to_anat_transform = traits.Enum('Rigid', 'Affine', desc='Transform type for coregistration')
     denoise_method = traits.Str(desc='method used for image denoising')
@@ -261,11 +260,15 @@ class DiffusionSummary(SummaryInterface):
                     validation_summaries.extend(summary_f.readlines())
         validation_summary = '\n'.join(validation_summaries)
 
+        hmc_transform_line = ''
+        if isdefined(self.inputs.hmc_transform):
+            hmc_transform_line = f'\t\t\t<li>HMC Transform: {self.inputs.hmc_transform}</li>\n'
+
         return DIFFUSION_TEMPLATE.format(
             pedir=pedir,
             sdc=self.inputs.distortion_correction,
             coregistration=self.inputs.b0_to_anat_transform,
-            hmc_transform=self.inputs.hmc_transform,
+            hmc_transform_line=hmc_transform_line,
             hmc_model=self.inputs.hmc_model,
             denoise_method=self.inputs.denoise_method,
             denoise_window=self.inputs.dwi_denoise_window,

--- a/qsiprep/tests/data/shoreline_none_config.json
+++ b/qsiprep/tests/data/shoreline_none_config.json
@@ -1,0 +1,4 @@
+{
+  "model": "none",
+  "iters": 1
+}

--- a/qsiprep/tests/data/shoreline_rigid_config.json
+++ b/qsiprep/tests/data/shoreline_rigid_config.json
@@ -1,0 +1,4 @@
+{
+  "transform": "Rigid",
+  "iters": 1
+}

--- a/qsiprep/tests/data/shoreline_tensor_config.json
+++ b/qsiprep/tests/data/shoreline_tensor_config.json
@@ -1,0 +1,4 @@
+{
+  "model": "tensor",
+  "iters": 1
+}

--- a/qsiprep/tests/test_cli.py
+++ b/qsiprep/tests/test_cli.py
@@ -222,6 +222,7 @@ def test_drbuddi_shoreline_epi(data_dir, output_dir, working_dir):
     dataset_dir = os.path.join(dataset_dir, 'tinytensor_epi')
     out_dir = os.path.join(output_dir, TEST_NAME)
     work_dir = os.path.join(working_dir, TEST_NAME)
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_none_config.json')
 
     parameters = [
         dataset_dir,
@@ -234,10 +235,9 @@ def test_drbuddi_shoreline_epi(data_dir, output_dir, working_dir):
         '--b0-motion-corr-to=first',
         '--b1-biascorrect-stage=none',
         '--hmc-method=shoreline',
-        '--shoreline-model=none',
+        f'--shoreline-config={shoreline_config}',
         '--sdc-method=drbuddi',
         '--output-resolution=2',
-        '--shoreline-iters=1',
     ]
 
     _run_and_generate(TEST_NAME, parameters, test_main=False)
@@ -260,6 +260,7 @@ def test_drbuddi_tensorline_epi(data_dir, output_dir, working_dir):
     dataset_dir = os.path.join(dataset_dir, 'DSDTI')
     out_dir = os.path.join(output_dir, TEST_NAME)
     work_dir = os.path.join(working_dir, TEST_NAME)
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_tensor_config.json')
 
     parameters = [
         dataset_dir,
@@ -272,10 +273,9 @@ def test_drbuddi_tensorline_epi(data_dir, output_dir, working_dir):
         '--b0-motion-corr-to=first',
         '--b1-biascorrect-stage=none',
         '--hmc-method=shoreline',
-        '--shoreline-model=tensor',
+        f'--shoreline-config={shoreline_config}',
         '--sdc-method=drbuddi',
         '--output-resolution=5',
-        '--shoreline-iters=1',
     ]
 
     _run_and_generate(TEST_NAME, parameters, test_main=False)
@@ -307,6 +307,7 @@ def test_dscsdsi(data_dir, output_dir, working_dir):
     dataset_dir = os.path.join(dataset_dir, 'DSCSDSI_nofmap')
     out_dir = os.path.join(output_dir, TEST_NAME)
     work_dir = os.path.join(working_dir, TEST_NAME)
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_rigid_config.json')
 
     parameters = [
         dataset_dir,
@@ -318,9 +319,8 @@ def test_dscsdsi(data_dir, output_dir, working_dir):
         '--sdc-anat-reference=invt1w',
         '--b1-biascorrect-stage=none',
         '--hmc-method=shoreline',
-        '--hmc-transform=Rigid',
+        f'--shoreline-config={shoreline_config}',
         '--output-resolution=5',
-        '--shoreline-iters=1',
     ]
 
     _run_and_generate(TEST_NAME, parameters, test_main=False)
@@ -633,6 +633,7 @@ def test_intramodal_template(data_dir, output_dir, working_dir):
     dataset_dir = os.path.join(dataset_dir, 'twoses')
     out_dir = os.path.join(output_dir, TEST_NAME)
     work_dir = os.path.join(working_dir, TEST_NAME)
+    shoreline_config = os.path.join(get_test_data_path(), 'shoreline_none_config.json')
 
     parameters = [
         dataset_dir,
@@ -642,7 +643,7 @@ def test_intramodal_template(data_dir, output_dir, working_dir):
         '--sloppy',
         '--b1-biascorrect-stage=none',
         '--hmc-method=shoreline',
-        '--shoreline-model=none',
+        f'--shoreline-config={shoreline_config}',
         '--b0-motion-corr-to=first',
         '--output-resolution=5',
         '--intramodal-template-transform=BSplineSyN',

--- a/qsiprep/tests/test_cli.py
+++ b/qsiprep/tests/test_cli.py
@@ -1044,6 +1044,24 @@ def test_load_shoreline_config_rejects_bad_files(tmp_path, contents, match):
         load_shoreline_config(str(cfg))
 
 
+def test_load_shoreline_config_names_the_file_on_decode_errors(tmp_path):
+    """A file that is not UTF-8 must still produce an error naming the file."""
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'latin1.json'
+    cfg.write_bytes(b'{"model": "\xff"}')
+    with pytest.raises(ValueError, match=r'SHORELine configuration file .* is not valid JSON'):
+        load_shoreline_config(str(cfg))
+
+
+def test_load_shoreline_config_names_the_file_on_read_errors(tmp_path):
+    """An unreadable path (here a directory) must raise ValueError, not a bare OSError."""
+    from qsiprep.utils.misc import load_shoreline_config
+
+    with pytest.raises(ValueError, match=r'SHORELine configuration file .* could not be read'):
+        load_shoreline_config(str(tmp_path))
+
+
 def test_load_shoreline_config_model_none_ignores_iters(tmp_path):
     import json
 

--- a/qsiprep/tests/test_cli.py
+++ b/qsiprep/tests/test_cli.py
@@ -986,6 +986,98 @@ def test_validate_diffprep_config_accepts_each_correction_mode(tmp_path):
         validate_diffprep_config(str(cfg))
 
 
+_SHORELINE_DEFAULTS = {'model': '3dshore', 'iters': 2, 'transform': 'Affine'}
+
+
+def test_load_shoreline_config_defaults_match_the_shipped_file():
+    import json
+
+    from qsiprep.data import load as load_data
+    from qsiprep.utils.misc import load_shoreline_config
+
+    shipped = load_data('shoreline_params.json')
+    assert json.loads(shipped.read_text()) == _SHORELINE_DEFAULTS
+    assert load_shoreline_config(None) == _SHORELINE_DEFAULTS
+    assert load_shoreline_config(str(shipped)) == _SHORELINE_DEFAULTS
+
+
+def test_load_shoreline_config_merges_a_partial_file(tmp_path):
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'tensor.json'
+    cfg.write_text(json.dumps({'model': 'tensor'}))
+    assert load_shoreline_config(str(cfg)) == {**_SHORELINE_DEFAULTS, 'model': 'tensor'}
+
+
+def test_load_shoreline_config_missing(tmp_path):
+    from qsiprep.utils.misc import load_shoreline_config
+
+    with pytest.raises(ValueError, match='does not exist'):
+        load_shoreline_config(str(tmp_path / 'nope.json'))
+
+
+@pytest.mark.parametrize(
+    ('contents', 'match'),
+    [
+        ('[1, 2]', 'must contain a JSON object'),
+        ('{"model": ', 'not valid JSON'),
+        # A typo must fail loudly rather than silently fall back to a default.
+        ('{"iter": 3}', 'unknown key'),
+        # Values are case-sensitive: the legacy --hmc-model spelling is not accepted.
+        ('{"model": "3dSHORE"}', 'model='),
+        ('{"transform": "affine"}', 'transform='),
+        ('{"iters": 0}', 'iters='),
+        ('{"iters": true}', 'iters='),
+        ('{"iters": "2"}', 'iters='),
+        ('{"iters": 1.5}', 'iters='),
+    ],
+)
+def test_load_shoreline_config_rejects_bad_files(tmp_path, contents, match):
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'bad.json'
+    cfg.write_text(contents)
+    with pytest.raises(ValueError, match=match):
+        load_shoreline_config(str(cfg))
+
+
+def test_load_shoreline_config_model_none_ignores_iters(tmp_path):
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    cfg = tmp_path / 'none.json'
+    cfg.write_text(json.dumps({'model': 'none', 'iters': 0}))
+    assert load_shoreline_config(str(cfg)) == {**_SHORELINE_DEFAULTS, 'model': 'none', 'iters': 0}
+
+
+def test_load_shoreline_config_legacy_model_override(tmp_path):
+    """The deprecated --hmc-model alias supplies the model; the file may still set the rest."""
+    import json
+
+    from qsiprep.utils.misc import load_shoreline_config
+
+    assert load_shoreline_config(None, model='tensor') == {
+        **_SHORELINE_DEFAULTS,
+        'model': 'tensor',
+    }
+
+    iters_only = tmp_path / 'iters.json'
+    iters_only.write_text(json.dumps({'iters': 3}))
+    assert load_shoreline_config(str(iters_only), model='none') == {
+        **_SHORELINE_DEFAULTS,
+        'model': 'none',
+        'iters': 3,
+    }
+
+    with_model = tmp_path / 'with_model.json'
+    with_model.write_text(json.dumps({'model': '3dshore'}))
+    with pytest.raises(ValueError, match='conflicts'):
+        load_shoreline_config(str(with_model), model='tensor')
+
+
 def test_validate_gradient_flags_force_and_ignore_conflict(tmp_path):
     from qsiprep.tests.gradient_fixtures import write_siemens_grad
     from qsiprep.utils.misc import validate_gradient_flags

--- a/qsiprep/tests/test_cli_run.py
+++ b/qsiprep/tests/test_cli_run.py
@@ -607,7 +607,7 @@ def test_hmc_model_alias_conflicts_with_shoreline_config_model(minimal_args, tmp
     cfg = _shoreline_json(tmp_path, model='3dshore')
     with pytest.raises(SystemExit):
         _parse(minimal_args, '--hmc-model', 'tensor', '--shoreline-config', cfg)
-    assert 'conflicts' in capsys.readouterr().err
+    assert '--hmc-model conflicts' in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/qsiprep/tests/test_cli_run.py
+++ b/qsiprep/tests/test_cli_run.py
@@ -470,6 +470,9 @@ def test_method_axis_defaults(minimal_args, capsys):
     assert capsys.readouterr().err == ''
     assert opts.hmc_method == 'eddy'
     assert opts.shoreline_model is None
+    assert opts.shoreline_config is None
+    assert opts.shoreline_iters is None
+    assert opts.hmc_transform is None
     assert opts.sdc_method == 'topup'
     # Legacy vocabulary is back-filled for unconverted readers.
     assert opts.hmc_model == 'eddy'
@@ -479,6 +482,8 @@ def test_method_axis_defaults(minimal_args, capsys):
 def test_hmc_method_shoreline_gets_model_and_drbuddi(minimal_args):
     opts = _parse(minimal_args, '--hmc-method', 'shoreline')
     assert opts.shoreline_model == '3dshore'
+    assert opts.shoreline_iters == 2
+    assert opts.hmc_transform == 'Affine'
     assert opts.sdc_method == 'drbuddi'
     assert opts.hmc_model == '3dSHORE'
     # The deprecated spelling remains a truthful view of the resolved method.
@@ -551,18 +556,183 @@ def test_legacy_topup_with_tortoise_is_an_error(minimal_args, capsys):
     assert 'requires --hmc-method eddy' in capsys.readouterr().err
 
 
-def test_shoreline_model_requires_shoreline_method(minimal_args, capsys):
-    with pytest.raises(SystemExit):
-        _parse(minimal_args, '--shoreline-model', 'tensor')
-    assert 'requires --hmc-method shoreline' in capsys.readouterr().err
+def _shoreline_json(tmp_path, name='shoreline.json', **settings):
+    import json
 
-    with pytest.raises(SystemExit):
-        _parse(minimal_args, '--hmc-model', '3dSHORE', '--shoreline-model', 'tensor')
-    assert 'requires --hmc-method shoreline' in capsys.readouterr().err
+    path = tmp_path / name
+    path.write_text(json.dumps(settings))
+    return str(path)
 
-    opts = _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-model', 'tensor')
+
+def test_shoreline_config_values_reach_the_namespace(minimal_args, tmp_path):
+    from pathlib import Path
+
+    cfg = _shoreline_json(tmp_path, model='tensor', iters=3, transform='Rigid')
+    opts = _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    assert opts.shoreline_config == Path(cfg).absolute()
     assert opts.shoreline_model == 'tensor'
+    assert opts.shoreline_iters == 3
+    assert opts.hmc_transform == 'Rigid'
     assert opts.hmc_model == 'tensor'
+
+
+@pytest.mark.parametrize(
+    'method_args', [[], ['--hmc-method', 'eddy'], ['--hmc-method', 'tortoise']]
+)
+def test_shoreline_config_requires_shoreline_method(minimal_args, tmp_path, capsys, method_args):
+    cfg = _shoreline_json(tmp_path, model='tensor')
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, *method_args, '--shoreline-config', cfg)
+    assert '--shoreline-config requires --hmc-method shoreline' in capsys.readouterr().err
+
+
+def test_invalid_shoreline_config_is_a_parse_error(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, iter=3)
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    assert 'unknown key' in capsys.readouterr().err
+
+
+def test_hmc_model_alias_merges_with_shoreline_config(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, iters=3)
+    opts = _parse(minimal_args, '--hmc-model', 'tensor', '--shoreline-config', cfg)
+    assert 'deprecated' in capsys.readouterr().err
+    assert opts.hmc_method == 'shoreline'
+    assert opts.shoreline_model == 'tensor'
+    assert opts.shoreline_iters == 3
+    assert opts.hmc_model == 'tensor'
+
+
+def test_hmc_model_alias_conflicts_with_shoreline_config_model(minimal_args, tmp_path, capsys):
+    cfg = _shoreline_json(tmp_path, model='3dshore')
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-model', 'tensor', '--shoreline-config', cfg)
+    assert 'conflicts' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ('flag', 'value'),
+    [('--shoreline-model', 'tensor'), ('--shoreline-iters', '3'), ('--hmc-transform', 'Rigid')],
+)
+def test_removed_shoreline_flags_are_rejected(minimal_args, capsys, flag, value):
+    with pytest.raises(SystemExit):
+        _parse(minimal_args, '--hmc-method', 'shoreline', flag, value)
+    assert 'unrecognized arguments' in capsys.readouterr().err
+
+
+_SHORELINE_KEYS = ('shoreline_config', 'shoreline_model', 'shoreline_iters', 'hmc_transform')
+
+
+@pytest.fixture
+def restore_shoreline_config():
+    """Yield qsiprep.config, restoring the SHORELine block that parse_args writes."""
+    from qsiprep import config
+
+    saved = {key: getattr(config.workflow, key) for key in _SHORELINE_KEYS}
+    yield config
+    for key, value in saved.items():
+        setattr(config.workflow, key, value)
+
+
+def test_shoreline_config_survives_a_config_round_trip(
+    minimal_args, tmp_path, restore_shoreline_config
+):
+    """A Path must be written as a path string, not the literal "PosixPath('...')"."""
+    from pathlib import Path
+
+    import toml
+
+    config = restore_shoreline_config
+    cfg = _shoreline_json(tmp_path, model='tensor')
+    opts = _parse(minimal_args, '--hmc-method', 'shoreline', '--shoreline-config', cfg)
+    config.workflow.load({'shoreline_config': opts.shoreline_config}, init=False)
+    dumped = toml.dumps({'workflow': config.workflow.get()})
+    assert 'PosixPath(' not in dumped
+    config.workflow.shoreline_config = None
+    config.workflow.load(toml.loads(dumped)['workflow'], init=False)
+    assert config.workflow.shoreline_config == Path(cfg).absolute()
+
+
+def _parse_with_config_file(tmp_path, toml_text, *extra):
+    """Run the real parse_args, loading ``toml_text`` as a --config-file."""
+    from qsiprep import config
+    from qsiprep.cli.parser import parse_args
+
+    bids_dir = tmp_path / 'bids'
+    generate_bids_skeleton(str(bids_dir), long)
+    work_dir = tmp_path / 'work'
+    config_file = tmp_path / 'previous.toml'
+    config_file.write_text(toml_text)
+    config.from_dict({'bids_dir': str(bids_dir), 'work_dir': str(work_dir)}, init=True)
+    parse_args(
+        [
+            str(bids_dir),
+            str(tmp_path / 'out'),
+            'participant',
+            '--participant-label',
+            '01',
+            '--output-resolution',
+            '2',
+            '--work-dir',
+            str(work_dir),
+            '--skip-bids-validation',
+            '--config-file',
+            str(config_file),
+            *extra,
+        ]
+    )
+    return config
+
+
+def test_config_file_reload_drops_stale_shoreline_settings(tmp_path, restore_shoreline_config):
+    """An old eddy config.toml carried hmc_transform/shoreline_iters; they must not survive."""
+    config = _parse_with_config_file(
+        tmp_path,
+        '[workflow]\nhmc_model = "eddy"\nhmc_transform = "Affine"\nshoreline_iters = 2\n',
+    )
+    for key in _SHORELINE_KEYS:
+        assert getattr(config.workflow, key) is None, key
+
+
+def _previous_shoreline_toml(tmp_path):
+    old_json = _shoreline_json(tmp_path, name='old.json', model='tensor', iters=5)
+    return (
+        '[workflow]\n'
+        f'shoreline_config = "{old_json}"\n'
+        'shoreline_model = "tensor"\n'
+        'shoreline_iters = 5\n'
+        'hmc_transform = "Rigid"\n'
+    )
+
+
+def test_config_file_reload_uses_command_line_shoreline_defaults(
+    tmp_path, restore_shoreline_config
+):
+    config = _parse_with_config_file(
+        tmp_path, _previous_shoreline_toml(tmp_path), '--hmc-method', 'shoreline'
+    )
+    assert config.workflow.shoreline_config is None
+    assert config.workflow.shoreline_model == '3dshore'
+    assert config.workflow.shoreline_iters == 2
+    assert config.workflow.hmc_transform == 'Affine'
+
+
+def test_config_file_reload_uses_command_line_shoreline_config(tmp_path, restore_shoreline_config):
+    from pathlib import Path
+
+    new_json = _shoreline_json(tmp_path, name='new.json', iters=3, transform='Rigid')
+    config = _parse_with_config_file(
+        tmp_path,
+        _previous_shoreline_toml(tmp_path),
+        '--hmc-method',
+        'shoreline',
+        '--shoreline-config',
+        new_json,
+    )
+    assert config.workflow.shoreline_config == Path(new_json).absolute()
+    assert config.workflow.shoreline_model == '3dshore'
+    assert config.workflow.shoreline_iters == 3
+    assert config.workflow.hmc_transform == 'Rigid'
 
 
 def test_sdc_anat_reference_parses(minimal_args):

--- a/qsiprep/tests/test_plan_cli_spec.py
+++ b/qsiprep/tests/test_plan_cli_spec.py
@@ -9,10 +9,19 @@ as the config-to-selection bridge already did (see the regression test below).
 """
 
 import argparse
+import json
 
+import pytest
 from qsiplan import cli_spec
 
 from qsiprep.cli.parser import _build_parser
+
+# QSIPlan still lists --shoreline-model as a qsiprep flag, but qsiprep takes the
+# SHORELine model from --shoreline-config (a JSON "model" key) and fills the same
+# ``shoreline_model`` dest that selection_from_namespace reads. Remove this, and
+# bump the qsiplan pin, once QSIPlan stops listing the flag (QSIPlan issue:
+# "Replace --shoreline-model with qsiprep's --shoreline-config").
+_NOT_A_QSIPREP_FLAG = frozenset({'--shoreline-model'})
 
 
 def _actions():
@@ -23,7 +32,7 @@ def _actions():
 def test_parser_realizes_every_implemented_plan_option():
     actions = _actions()
     for option in cli_spec.PLAN_OPTIONS:
-        if option.planned:
+        if option.planned or option.flag in _NOT_A_QSIPREP_FLAG:
             continue
         action = actions.get(option.flag)
         assert action is not None, f'qsiprep parser is missing {option.flag}'
@@ -33,9 +42,15 @@ def test_parser_realizes_every_implemented_plan_option():
 
 def test_planned_options_are_the_only_gaps():
     actions = _actions()
-    absent = sorted(o.flag for o in cli_spec.PLAN_OPTIONS if o.flag not in actions)
+    absent = sorted(
+        o.flag
+        for o in cli_spec.PLAN_OPTIONS
+        if o.flag not in actions and o.flag not in _NOT_A_QSIPREP_FLAG
+    )
     planned = sorted(o.flag for o in cli_spec.PLAN_OPTIONS if o.planned)
     assert absent == planned  # today: []
+    # The exemption must not outlive the flag in QSIPlan's spec.
+    assert _NOT_A_QSIPREP_FLAG <= {o.flag for o in cli_spec.PLAN_OPTIONS}
 
 
 def _parse_minimal(tmp_path, *extra):
@@ -181,3 +196,21 @@ def test_complex_dwi_reaches_the_plan_as_a_magnitude_companion(tmp_path):
     series = (*unit.dwi_files, *unit.plus_files, *unit.minus_files)
     assert not [path for path in series if 'part-phase' in path]
     assert not [path for path in unit.sidecar_overrides() if 'part-phase' in path]
+
+
+@pytest.mark.parametrize('model', ['3dshore', 'tensor', 'none'])
+def test_shoreline_config_model_reaches_the_method_selection(tmp_path, model):
+    cfg = tmp_path / 'shoreline.json'
+    cfg.write_text(json.dumps({'model': model}))
+    namespace = _parse_minimal(
+        tmp_path, '--hmc-method', 'shoreline', '--shoreline-config', str(cfg)
+    )
+    selection = cli_spec.selection_from_namespace(namespace)
+    assert selection.hmc.value == 'shoreline'
+    assert selection.shoreline_model == model
+
+
+def test_eddy_namespace_has_no_shoreline_model(tmp_path):
+    namespace = _parse_minimal(tmp_path, '--hmc-method', 'eddy')
+    assert namespace.shoreline_model is None
+    assert cli_spec.selection_from_namespace(namespace).hmc.value == 'eddy'

--- a/qsiprep/tests/test_reports.py
+++ b/qsiprep/tests/test_reports.py
@@ -465,3 +465,30 @@ def test_diffusion_summary_renders_gradient_correction():
         gradient_correction='through-plane only (ImageType: DIS2D)',
     )
     assert 'through-plane only' in summary._generate_segment()
+
+
+def _diffusion_summary(**overrides):
+    from qsiprep.interfaces.reports import DiffusionSummary
+
+    inputs = {
+        'distortion_correction': 'TOPUP',
+        'pe_direction': 'j',
+        'hmc_model': 'eddy',
+        'b0_to_anat_transform': 'Rigid',
+        'denoise_method': 'dwidenoise',
+        'dwi_denoise_window': 5,
+    }
+    inputs.update(overrides)
+    return DiffusionSummary(**inputs)
+
+
+def test_diffusion_summary_omits_hmc_transform_when_undefined():
+    segment = _diffusion_summary()._generate_segment()
+    assert 'HMC Transform' not in segment
+    assert 'HMC Model: eddy' in segment
+
+
+def test_diffusion_summary_shows_hmc_transform_when_given():
+    segment = _diffusion_summary(hmc_model='3dSHORE', hmc_transform='Rigid')._generate_segment()
+    assert '<li>HMC Transform: Rigid</li>' in segment
+    assert 'HMC Model: 3dSHORE' in segment

--- a/qsiprep/tests/test_template_registration_settings.py
+++ b/qsiprep/tests/test_template_registration_settings.py
@@ -206,3 +206,13 @@ def test_init_b0_hmc_wf_has_no_spatial_bias_correct():
     from qsiprep.workflows.dwi.hmc import init_b0_hmc_wf
 
     assert 'spatial_bias_correct' not in inspect.signature(init_b0_hmc_wf).parameters
+
+
+def test_iterative_b0_description_names_the_transform(tmp_path):
+    """The methods text named hmc_model ("tortoise registrations") instead of the transform."""
+    from qsiprep.workflows.dwi.hmc import init_b0_hmc_wf
+
+    _config().execution.output_dir = str(tmp_path)
+    wf = init_b0_hmc_wf(align_to='iterative', transform='Rigid')
+    assert 'iterations of Rigid registrations' in wf.__desc__
+    assert 'tortoise' not in wf.__desc__

--- a/qsiprep/tests/test_workflows_gradwarp.py
+++ b/qsiprep/tests/test_workflows_gradwarp.py
@@ -1483,3 +1483,57 @@ def test_dwi_finalize_wf_does_not_warn_when_graddev_is_written(tmp_path, caplog)
         _finalize_wf_with_gradients(tmp_path, write_derivatives=True)
 
     assert 'graddev' not in caplog.text
+
+
+def test_shoreline_iters_sets_the_model_iteration_count(tmp_path):
+    """Regression: --shoreline-iters never reached init_dwi_hmc_wf (always 2)."""
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.shoreline_iters = 3
+    wf = _shoreline_wf(tmp_path, _rpe_unit(tmp_path))
+    model_wf = wf.get_node('dwi_hmc_wf.dwi_model_hmc_wf')
+    assert model_wf.get_node('shoreline_iteration002') is not None
+    assert model_wf.get_node('shoreline_iteration003') is None
+    assert model_wf.get_node('summarize_iterations') is not None
+    assert 'A total of 3 iterations' in model_wf.__desc__
+
+
+def test_single_shoreline_iteration_skips_the_iteration_summary(tmp_path):
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.shoreline_iters = 1
+    wf = _shoreline_wf(tmp_path, _rpe_unit(tmp_path))
+    model_wf = wf.get_node('dwi_hmc_wf.dwi_model_hmc_wf')
+    assert model_wf.get_node('initial_model_iteration') is not None
+    assert model_wf.get_node('shoreline_iteration001') is None
+    assert model_wf.get_node('summarize_iterations') is None
+    assert 'A total of 1 iterations' in model_wf.__desc__
+
+
+@pytest.mark.parametrize(
+    ('hmc_model', 'expected', 'unexpected'),
+    [
+        ('tensor', 'using a tensor model', '3dSHORE'),
+        ('3dSHORE', 'using 3dSHORE [@merlet3dshore]', 'tensor model'),
+    ],
+)
+def test_shoreline_methods_text_names_the_model_and_transform(
+    tmp_path, hmc_model, expected, unexpected
+):
+    from qsiprep.workflows.dwi.hmc import init_dwi_model_hmc_wf
+
+    _cfg_for_shoreline(tmp_path)
+    config.workflow.hmc_model = hmc_model
+    config.workflow.hmc_transform = 'Rigid'
+    wf = init_dwi_model_hmc_wf(num_iters=2)
+    assert expected in wf.__desc__
+    assert unexpected not in wf.__desc__
+    assert 'using a Rigid transform' in wf.__desc__
+
+
+def test_eddy_summary_leaves_hmc_transform_undefined(tmp_path):
+    """A stale hmc_transform (e.g. from a reloaded config) must not reach an eddy summary."""
+    from nipype.interfaces.base import isdefined
+
+    wf = _preproc_wf(tmp_path)
+    # _dwi_preproc_cfg sets this, standing in for a stale value.
+    assert config.workflow.hmc_transform == 'Affine'
+    assert not isdefined(wf.get_node('summary').inputs.hmc_transform)

--- a/qsiprep/tests/test_workflows_gradwarp.py
+++ b/qsiprep/tests/test_workflows_gradwarp.py
@@ -1494,7 +1494,7 @@ def test_shoreline_iters_sets_the_model_iteration_count(tmp_path):
     assert model_wf.get_node('shoreline_iteration002') is not None
     assert model_wf.get_node('shoreline_iteration003') is None
     assert model_wf.get_node('summarize_iterations') is not None
-    assert 'A total of 3 iterations' in model_wf.__desc__
+    assert 'A total of 3 iterations were run' in model_wf.__desc__
 
 
 def test_single_shoreline_iteration_skips_the_iteration_summary(tmp_path):
@@ -1505,7 +1505,7 @@ def test_single_shoreline_iteration_skips_the_iteration_summary(tmp_path):
     assert model_wf.get_node('initial_model_iteration') is not None
     assert model_wf.get_node('shoreline_iteration001') is None
     assert model_wf.get_node('summarize_iterations') is None
-    assert 'A total of 1 iterations' in model_wf.__desc__
+    assert 'A total of 1 iteration was run' in model_wf.__desc__
 
 
 @pytest.mark.parametrize(
@@ -1526,7 +1526,7 @@ def test_shoreline_methods_text_names_the_model_and_transform(
     wf = init_dwi_model_hmc_wf(num_iters=2)
     assert expected in wf.__desc__
     assert unexpected not in wf.__desc__
-    assert 'using a Rigid transform' in wf.__desc__
+    assert 'using the Rigid transform' in wf.__desc__
 
 
 def test_eddy_summary_leaves_hmc_transform_undefined(tmp_path):

--- a/qsiprep/tests/test_workflows_native.py
+++ b/qsiprep/tests/test_workflows_native.py
@@ -474,7 +474,7 @@ def test_legacy_method_keys_read_only_at_allowlisted_sites():
         # Display strings and the SHORELine model vocabulary.
         'workflows/dwi/base.py': {'hmc_model': 1},
         'workflows/dwi/derivatives.py': {'hmc_model': 3},
-        'workflows/dwi/hmc.py': {'hmc_model': 3},
+        'workflows/dwi/hmc.py': {'hmc_model': 4},
         # The backend-dependent gradwarp resampling sentence: also display
         # vocabulary, and safe only because 'eddy' and 'tortoise' are spelled
         # the same in the legacy key and in HmcMethod. See the Notes section of

--- a/qsiprep/utils/misc.py
+++ b/qsiprep/utils/misc.py
@@ -472,11 +472,13 @@ def load_shoreline_config(path=None, model=None):
         source = f'SHORELine configuration file {path}'
         if not os.path.exists(path):
             raise ValueError(f'{source} does not exist.')
-        with open(path) as f:
-            try:
+        try:
+            with open(path, encoding='utf-8') as f:
                 user_cfg = json.load(f)
-            except json.JSONDecodeError as err:
-                raise ValueError(f'{source} is not valid JSON: {err}') from err
+        except OSError as err:
+            raise ValueError(f'{source} could not be read: {err}') from err
+        except (json.JSONDecodeError, UnicodeDecodeError) as err:
+            raise ValueError(f'{source} is not valid JSON: {err}') from err
         if not isinstance(user_cfg, dict):
             raise ValueError(f'{source} must contain a JSON object.')
         # Unknown keys are errors so a typo cannot silently fall back to a default.

--- a/qsiprep/utils/misc.py
+++ b/qsiprep/utils/misc.py
@@ -430,6 +430,91 @@ def validate_diffprep_config(diffprep_config):
     return
 
 
+SHORELINE_MODELS = ('3dshore', 'tensor', 'none')
+"""Signal models SHORELine can use to predict motion-correction targets."""
+
+SHORELINE_TRANSFORMS = ('Affine', 'Rigid')
+"""Transformations SHORELine can optimize during head motion correction."""
+
+
+def load_shoreline_config(path=None, model=None):
+    """Load a ``--shoreline-config`` JSON file, merged over the shipped defaults.
+
+    Parameters
+    ----------
+    path : str, os.PathLike or None
+        The SHORELine configuration JSON file. ``None`` uses the defaults in
+        ``qsiprep/data/shoreline_params.json``.
+    model : str or None
+        A SHORELine model from the deprecated ``--hmc-model`` alias (``3dshore``,
+        ``tensor`` or ``none``). It replaces the default model, and conflicts with
+        a ``model`` key in the file.
+
+    Returns
+    -------
+    dict
+        Exactly the keys ``model``, ``iters`` and ``transform``.
+
+    Raises
+    ------
+    ValueError
+        If the file does not exist, is not a JSON object, has an unknown key or an
+        invalid value, or sets ``model`` while ``model`` is also given.
+    """
+    import json
+    import os
+
+    from ..data import load as load_data
+
+    cfg = json.loads(load_data('shoreline_params.json').read_text())
+    source = 'The default SHORELine configuration'
+    if path is not None:
+        source = f'SHORELine configuration file {path}'
+        if not os.path.exists(path):
+            raise ValueError(f'{source} does not exist.')
+        with open(path) as f:
+            try:
+                user_cfg = json.load(f)
+            except json.JSONDecodeError as err:
+                raise ValueError(f'{source} is not valid JSON: {err}') from err
+        if not isinstance(user_cfg, dict):
+            raise ValueError(f'{source} must contain a JSON object.')
+        # Unknown keys are errors so a typo cannot silently fall back to a default.
+        unknown = sorted(set(user_cfg) - set(cfg))
+        if unknown:
+            raise ValueError(
+                f'{source} has unknown key(s) {", ".join(unknown)}; '
+                f'valid keys are {", ".join(sorted(cfg))}.'
+            )
+        if model is not None and 'model' in user_cfg:
+            raise ValueError(f'--hmc-model conflicts with "model" in --shoreline-config {path}.')
+        cfg.update(user_cfg)
+    if model is not None:
+        cfg['model'] = model
+
+    if cfg['model'] not in SHORELINE_MODELS:
+        raise ValueError(
+            f'{source} sets model={cfg["model"]!r}; must be one of {", ".join(SHORELINE_MODELS)}.'
+        )
+    if cfg['transform'] not in SHORELINE_TRANSFORMS:
+        raise ValueError(
+            f'{source} sets transform={cfg["transform"]!r}; must be one of '
+            f'{", ".join(SHORELINE_TRANSFORMS)}.'
+        )
+    iters = cfg['iters']
+    # bool is a subclass of int, so "iters": true has to be rejected explicitly.
+    if (
+        isinstance(iters, bool)
+        or not isinstance(iters, int)
+        or (iters < 1 and cfg['model'] != 'none')
+    ):
+        raise ValueError(
+            f'{source} sets iters={iters!r}; must be an integer >= 1 '
+            '(any integer when model is "none").'
+        )
+    return cfg
+
+
 def validate_gradient_flags(gradient_file, force, ignore):
     """Validate the ``--gradient-file``/``--force``/``--ignore`` combination.
 

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -255,11 +255,6 @@ def init_dwi_preproc_wf(
     test_pre_hmc_connect = pe.Node(TestInput(), name='test_pre_hmc_connect')
     hmc_tool = unit.run.hmc_stage.tool
     if hmc_tool == 'shoreline':
-        if config.workflow.shoreline_model != 'none' and config.workflow.shoreline_iters < 1:
-            raise Exception(
-                '--shoreline-iters must be > 0 when --shoreline-model is '
-                f'{config.workflow.shoreline_model}'
-            )
         hmc_wf = init_qsiprep_hmcsdc_wf(
             unit=unit,
             source_file=source_file,
@@ -488,7 +483,6 @@ def init_dwi_preproc_wf(
             pe_direction=unit.pe_dir or None,
             hmc_model=config.workflow.hmc_model,
             b0_to_anat_transform=config.workflow.b0_to_anat_transform,
-            hmc_transform=config.workflow.hmc_transform,
             denoise_method=config.workflow.denoise_method,
             dwi_denoise_window=config.workflow.dwi_denoise_window,
             gradient_correction=describe_gradient_correction(
@@ -499,6 +493,11 @@ def init_dwi_preproc_wf(
         mem_gb=DEFAULT_MEMORY_MIN_GB,
         run_without_submitting=True,
     )
+    if hmc_tool == 'shoreline':
+        # Only SHORELine optimizes a selectable transform. Gating on the resolved
+        # method, not the value, keeps a stale hmc_transform out of eddy and
+        # TORTOISE summaries.
+        summary.inputs.hmc_transform = config.workflow.hmc_transform
 
     workflow.connect([
         (inputnode, b0_coreg_wf, [

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -29,6 +29,13 @@ from .util import init_dwi_reference_wf
 
 DEFAULT_MEMORY_MIN_GB = 0.01
 
+# Methods-text names for the SHORELine signal models, keyed by the hmc_model value
+# SignalPrediction reads. "none" never builds the model-based workflow.
+_SHORELINE_MODEL_DESCRIPTIONS = {
+    '3dSHORE': '3dSHORE [@merlet3dshore]',
+    'tensor': 'a tensor model',
+}
+
 
 def init_dwi_hmc_wf(
     source_file,
@@ -386,7 +393,7 @@ def init_b0_hmc_wf(
     if align_to == 'iterative':
         desc += (
             f'An unbiased b=0 template was constructed over {num_iters} iterations '
-            f'of {config.workflow.hmc_model} registrations. '
+            f'of {transform} registrations. '
         )
         initial_template = pe.Node(
             ants.AverageImages(normalize=True, dimension=3),
@@ -714,10 +721,13 @@ def init_dwi_model_hmc_wf(
         ),
         name='outputnode',
     )
+    model_description = _SHORELINE_MODEL_DESCRIPTIONS.get(
+        config.workflow.hmc_model, config.workflow.hmc_model
+    )
     workflow.__desc__ = (
         'The SHORELine method was used to estimate head motion in b>0 '
         'images. This entails leaving out each b>0 image and reconstructing '
-        'the others using 3dSHORE [@merlet3dshore]. The signal for the left-'
+        f'the others using {model_description}. The signal for the left-'
         f'out image serves as the registration target. A total of {num_iters} '
         f'iterations were run using a {config.workflow.hmc_transform} transform. '
     )

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -60,8 +60,8 @@ def init_dwi_hmc_wf(
         name: str
             Name of the workflow. Default: 'dwi_hmc_wf'.
 
-        The transform and signal model come from ``config.workflow.hmc_transform`` and
-        ``config.workflow.hmc_model``, set by ``--shoreline-config``.
+        The transform and signal model come from the ``hmc_transform`` and ``hmc_model``
+        workflow settings, set by ``--shoreline-config``.
 
     **Inputs**
 

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -719,12 +719,13 @@ def init_dwi_model_hmc_wf(
     model_description = _SHORELINE_MODEL_DESCRIPTIONS.get(
         config.workflow.hmc_model, config.workflow.hmc_model
     )
+    iterations_run = 'iteration was' if num_iters == 1 else 'iterations were'
     workflow.__desc__ = (
         'The SHORELine method was used to estimate head motion in b>0 '
         'images. This entails leaving out each b>0 image and reconstructing '
         f'the others using {model_description}. The signal for the left-'
         f'out image serves as the registration target. A total of {num_iters} '
-        f'iterations were run using a {config.workflow.hmc_transform} transform. '
+        f'{iterations_run} run using the {config.workflow.hmc_transform} transform. '
     )
 
     # Merge b0s into a single volume, put the non-b0 dwis into a list

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -50,23 +50,18 @@ def init_dwi_hmc_wf(
 
     **Parameters**
 
-        hmc_transform: 'Rigid' or 'Affine'
-            How many degrees of freedom to incorporate into motion correction
-        hmc_model: '3dSHORE', 'none' , 'tensor' or 'SH'
-            Which model to use for generating signal predictions for hmc. '3dSHORE' requires
-            multiple b-values, 'none' will only use b0 images for motion correction, 'tensor'
-            uses a tensor model for signal predictions for hmc, and 'SH' uses spherical harmonics
-            (not implemented yet).
-        hmc_align_to: 'first' or 'iterative'
-            Which volume should be used to determine the motion-corrected space?
         source_file: str
             Path to one of the original dwi files (used for reportlets)
-        rpe_b0: str
-            Path to a reverse phase encoding image to be used for 3dQWarp's TOPUP-style
-            correction
         num_model_iterations: int
-            If ``hmc_model`` is ``'3dSHORE'`` or ``'SH'`` determines the number of times the
-            model is updated and motion correction is estimated. Default: 2.
+            Number of SHORELine model-based iterations, used when the model is '3dSHORE' or
+            'tensor' (ignored for 'none'). Default: 2.
+        mem_gb: float
+            Estimated memory usage. Default: 3.
+        name: str
+            Name of the workflow. Default: 'dwi_hmc_wf'.
+
+        The transform and signal model come from ``config.workflow.hmc_transform`` and
+        ``config.workflow.hmc_model``, set by ``--shoreline-config``.
 
     **Inputs**
 

--- a/qsiprep/workflows/dwi/hmc_sdc.py
+++ b/qsiprep/workflows/dwi/hmc_sdc.py
@@ -137,7 +137,10 @@ def init_qsiprep_hmcsdc_wf(
     )
 
     # Motion correct the data
-    dwi_hmc_wf = init_dwi_hmc_wf(source_file=source_file)
+    dwi_hmc_wf = init_dwi_hmc_wf(
+        source_file=source_file,
+        num_model_iterations=config.workflow.shoreline_iters,
+    )
 
     # Impute slice data if requested
     slice_qc = pe.Node(SliceQC(), name='slice_qc')


### PR DESCRIPTION
Closes #1132.

## Changes proposed in this pull request

- Remove `--shoreline-iters`, `--shoreline-model`, and `--hmc-transform` parameters.
- Add `--shoreline-config`.